### PR TITLE
Upgrade intercom-ios swift package

### DIFF
--- a/apple/Omnivore.xcodeproj/project.pbxproj
+++ b/apple/Omnivore.xcodeproj/project.pbxproj
@@ -1961,7 +1961,7 @@
 			repositoryURL = "https://github.com/intercom/intercom-ios";
 			requirement = {
 				kind = exactVersion;
-				version = 10.3.2;
+				version = 11.1.2;
 			};
 		};
 		042184EB273AD426002357B0 /* XCRemoteSwiftPackageReference "PSPDFKit-SP" */ = {

--- a/apple/Omnivore.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/apple/Omnivore.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -96,8 +96,8 @@
         "repositoryURL": "https://github.com/intercom/intercom-ios",
         "state": {
           "branch": null,
-          "revision": "c782c99bf164cc38210dc98a926b67b8b61d8195",
-          "version": "10.3.2"
+          "revision": "3345d9e7599141d7c844981423a7e5409f2bfb81",
+          "version": "11.1.2"
         }
       },
       {


### PR DESCRIPTION
The previous intercom version in our spec could no longer be found so it was breaking our build.