### PR TITLE
Simplify startup of the puppeteer service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,7 +57,7 @@ services:
       - SSO_JWT_SECRET=some_sso_secret
       - CLIENT_URL=http://localhost:3000
       - GATEWAY_URL=http://localhost:8080/api
-      - PUPPETEER_TASK_HANDLER_URL=http://localhost:9090/
+      - PUPPETEER_TASK_HANDLER_URL=http://host.docker.internal:9090/
       - REMINDER_TASK_HANDLER_URL=/svc/reminders/trigger
     depends_on:
       migrate:

--- a/packages/puppeteer-parse/index.js
+++ b/packages/puppeteer-parse/index.js
@@ -25,8 +25,8 @@ const { pdfHandler } = require('./pdf-handler');
 const { mediumHandler } = require('./medium-handler');
 
 const storage = new Storage();
-const previewBucket = storage.bucket(process.env.PREVIEW_IMAGE_BUCKET);
-const ALLOWED_ORIGINS = process.env.ALLOWED_ORIGINS.split(',');
+const ALLOWED_ORIGINS = process.env.ALLOWED_ORIGINS ? process.env.ALLOWED_ORIGINS.split(',') : [];
+const previewBucket = process.env.PREVIEW_IMAGE_BUCKET ? storage.bucket(process.env.PREVIEW_IMAGE_BUCKET) : undefined;
 
 Sentry.GCPFunction.init({
   dsn: process.env.SENTRY_DSN,
@@ -401,6 +401,11 @@ exports.preview = Sentry.GCPFunction.wrapHttpFunction(async (req, res) => {
       execution_id: execution_id,
     },
   });
+
+  if (!process.env.PREVIEW_IMAGE_BUCKET) {
+    logger.error(`PREVIEW_IMAGE_BUCKET not set`)
+    return res.sendStatus(500);
+  }
 
   const url = getUrl(req);
   console.log('preview request url', url);

--- a/packages/puppeteer-parse/package.json
+++ b/packages/puppeteer-parse/package.json
@@ -20,7 +20,7 @@
     "@google-cloud/functions-framework": "^1.7.1"
   },
   "scripts": {
-    "start": "npx functions-framework --target=puppeteer",
+    "start": "npx functions-framework --port=9090 --target=puppeteer",
     "start_preview": "npx functions-framework --target=preview",
     "test": "yarn mocha"
   }


### PR DESCRIPTION
- Run on port 9090 so we don't conflict with other services
- Route the docker-compose requests to the host network
- Dont require preview bucket information on startup
