### PR TITLE
Fixes for dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,8 @@
 version: 2
 updates:
-  - package-ecosystem: "yarn"
-    directory: "/**"
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
     allow:
       - dependency-type: "production"


### PR DESCRIPTION
This requires a schedule interval and should use `npm` instead
of yarn.
