### PR TITLE
Move requirements to the top of the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,13 @@ Read more about Omnivore on our blog. <https://blog.omnivore.app/p/getting-start
 
 The easiest way to get started with local development is to use `docker-compose up`. This will start a postgres container, our web frontend, an API server, and our content fetching microservice.
 
+### Requirements for development
+
+Omnivore is written in TypeScript and JavaScript.
+
+* [Node](https://nodejs.org/) -- currently we are using nodejs v14.18
+* [Chromium](https://www.chromium.org/chromium-projects/) -- see below for installation info
+
 ###  Running the web and API services
 
 ### 1. Start docker-compose
@@ -66,14 +73,6 @@ cd packages/web
 cp .env.local .env
 yarn dev
 ```
-
-### Requirements for development
-
-Omnivore is written in TypeScript and JavaScript.
-
-* [Node](https://nodejs.org/) -- currently we are using nodejs v14.18
-* [Chromium](https://www.chromium.org/chromium-projects/) -- see below for installation info
-
 
 ### Running the puppeteer-parse service outside of Docker
 


### PR DESCRIPTION
This makes it easier for people to find the correct node.js version.