### PR TITLE
Use pull_request_target instead of pull_request for tests

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -5,7 +5,7 @@ on:
       - main
     paths-ignore:
       - 'apple/**'
-  pull_request:
+  pull_request_target:
     branches:
       - main
     paths-ignore:


### PR DESCRIPTION
This should allow downstream forks to execute the graphql tests.
