### PR TITLE
Remove root pkg dependencies from db docker image

### DIFF
--- a/packages/db/Dockerfile
+++ b/packages/db/Dockerfile
@@ -2,8 +2,6 @@ FROM node:14.18-alpine
 
 WORKDIR /app
 
-COPY package.json .
-COPY yarn.lock .
 COPY tsconfig.json .
 
 COPY /packages/db/package.json ./packages/db/package.json


### PR DESCRIPTION
Because this is just used to execute the migrations we can
use the non-locked versions here and don't need to pull in all
of the root workspace packages.
