### PR TITLE
Reader view bar behavior

### DIFF
--- a/apple/OmnivoreKit/Sources/Views/LinkedItemDetail/LinkItemDetailView.swift
+++ b/apple/OmnivoreKit/Sources/Views/LinkedItemDetail/LinkItemDetailView.swift
@@ -54,8 +54,29 @@ public struct LinkItemDetailView: View {
     innerBody
     #if os(iOS)
       .navigationBarTitleDisplayMode(.inline)
+      .introspectNavigationController {
+        navigationController = $0
+        navigationController?.hidesBarsOnSwipe = UIDevice.isIPhone
+      }
+      .introspectTabBarController {
+        tabBarController = $0
+        tabBarController?.tabBar.isHidden = UIDevice.isIPhone
+      }
+      .onDisappear {
+        navigationController?.hidesBarsOnSwipe = true
+        tabBarController?.tabBar.isHidden = false
+      }
+      .onAppear {
+        navigationController?.hidesBarsOnSwipe = UIDevice.isIPhone
+        tabBarController?.tabBar.isHidden = UIDevice.isIPhone
+      }
+      //      .ignoresSafeArea(, edges: <#T##Edge.Set#>)
+      .ignoresSafeArea(., edges: .vertical)
     #endif
   }
+
+  @State var navigationController: UINavigationController?
+  @State var tabBarController: UITabBarController?
 
   @ViewBuilder private var innerBody: some View {
     if let pdfURL = viewModel.item.pdfURL {
@@ -91,6 +112,7 @@ public struct LinkItemDetailView: View {
             #endif
           }
         }
+
     } else {
       HStack(alignment: .center) {
         Spacer()

--- a/apple/OmnivoreKit/Sources/Views/LinkedItemDetail/LinkItemDetailView.swift
+++ b/apple/OmnivoreKit/Sources/Views/LinkedItemDetail/LinkItemDetailView.swift
@@ -70,8 +70,7 @@ public struct LinkItemDetailView: View {
         navigationController?.hidesBarsOnSwipe = UIDevice.isIPhone
         tabBarController?.tabBar.isHidden = UIDevice.isIPhone
       }
-      //      .ignoresSafeArea(, edges: <#T##Edge.Set#>)
-      .ignoresSafeArea(., edges: .vertical)
+      .ignoresSafeArea(.all, edges: .vertical)
     #endif
   }
 

--- a/apple/OmnivoreKit/Sources/Views/PrimaryContainerViews/HomeFeedView.swift
+++ b/apple/OmnivoreKit/Sources/Views/PrimaryContainerViews/HomeFeedView.swift
@@ -56,6 +56,8 @@ public struct HomeFeedView: View {
   @State private var confirmationShown = false
   @State private var snoozePresented = false
   @State private var itemToSnooze: FeedItem?
+  @State var navigationController: UINavigationController?
+  @State var tabBarController: UITabBarController?
 
   public init(viewModel: HomeFeedViewModel) {
     self.viewModel = viewModel
@@ -376,6 +378,23 @@ public struct HomeFeedView: View {
       if UIDevice.isIPhone {
         NavigationView {
           conditionalInnerBody
+            .introspectNavigationController {
+              navigationController = $0
+              navigationController?.hidesBarsOnSwipe = false
+            }
+            .introspectTabBarController {
+              tabBarController = $0
+              tabBarController?.tabBar.isHidden = false
+              navigationController?.navigationBar.isHidden = false
+            }
+            .onDisappear {
+              tabBarController?.tabBar.isHidden = true
+              navigationController?.hidesBarsOnSwipe = true
+            }
+            .onAppear {
+              navigationController?.hidesBarsOnSwipe = false
+              tabBarController?.tabBar.isHidden = false
+            }
         }
       } else {
         conditionalInnerBody


### PR DESCRIPTION
To give readers more space to read on screen (and remove visual distractions):

- Use the Safari style nav behavior (nav bar hides when swiped, shows agin when swiped other way)
- Hide the tab bar when the view is pushed

https://user-images.githubusercontent.com/836745/154000482-d7e5d4ab-46bb-4f5e-a77e-9f12d1935c08.mp4


