### PR TITLE
Remove unneeded installs from API docker file

### DIFF
--- a/packages/api/Dockerfile
+++ b/packages/api/Dockerfile
@@ -5,8 +5,6 @@ WORKDIR /app
 ENV NODE_ENV production
 ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD true
 
-RUN apk add udev ttf-freefont
-
 COPY package.json .
 COPY yarn.lock .
 COPY tsconfig.json .


### PR DESCRIPTION
These were needed when Chromium was installed on this image.
