### PR TITLE
iOS Reader transparent nav bar

### DIFF
--- a/apple/OmnivoreKit/Sources/Views/LinkedItemDetail/LinkItemDetailView.swift
+++ b/apple/OmnivoreKit/Sources/Views/LinkedItemDetail/LinkItemDetailView.swift
@@ -54,8 +54,29 @@ public struct LinkItemDetailView: View {
     innerBody
     #if os(iOS)
       .navigationBarTitleDisplayMode(.inline)
+      .introspectNavigationController {
+        navigationController = $0
+        navigationController?.hidesBarsOnSwipe = UIDevice.isIPhone
+      }
+      .introspectTabBarController {
+        tabBarController = $0
+        tabBarController?.tabBar.isHidden = UIDevice.isIPhone
+      }
+      .onDisappear {
+        navigationController?.hidesBarsOnSwipe = true
+        tabBarController?.tabBar.isHidden = false
+      }
+      .onAppear {
+        navigationController?.hidesBarsOnSwipe = UIDevice.isIPhone
+        tabBarController?.tabBar.isHidden = UIDevice.isIPhone
+      }
+      //      .ignoresSafeArea(, edges: <#T##Edge.Set#>)
+      .ignoresSafeArea(., edges: .vertical)
     #endif
   }
+
+  @State var navigationController: UINavigationController?
+  @State var tabBarController: UITabBarController?
 
   @ViewBuilder private var innerBody: some View {
     if let pdfURL = viewModel.item.pdfURL {
@@ -91,6 +112,7 @@ public struct LinkItemDetailView: View {
             #endif
           }
         }
+
     } else {
       HStack(alignment: .center) {
         Spacer()

--- a/apple/OmnivoreKit/Sources/Views/LinkedItemDetail/LinkItemDetailView.swift
+++ b/apple/OmnivoreKit/Sources/Views/LinkedItemDetail/LinkItemDetailView.swift
@@ -56,21 +56,34 @@ public struct LinkItemDetailView: View {
       .navigationBarTitleDisplayMode(.inline)
       .introspectNavigationController {
         navigationController = $0
-        navigationController?.hidesBarsOnSwipe = UIDevice.isIPhone
+        if UIDevice.isIPhone {
+          navigationController?.navigationBar.setBackgroundImage(UIImage(), for: .default)
+          navigationController?.navigationBar.shadowImage = UIImage()
+          navigationController?.navigationBar.isTranslucent = true
+        }
       }
       .introspectTabBarController {
         tabBarController = $0
         tabBarController?.tabBar.isHidden = UIDevice.isIPhone
       }
       .onDisappear {
-        navigationController?.hidesBarsOnSwipe = true
         tabBarController?.tabBar.isHidden = false
+        if UIDevice.isIPhone {
+          navigationController?.navigationBar.setBackgroundImage(nil, for: .default)
+          navigationController?.navigationBar.shadowImage = nil
+          navigationController?.navigationBar.isTranslucent = false
+        }
       }
       .onAppear {
-        navigationController?.hidesBarsOnSwipe = UIDevice.isIPhone
+        if UIDevice.isIPhone {
+          navigationController?.navigationBar.setBackgroundImage(UIImage(), for: .default)
+          navigationController?.navigationBar.shadowImage = UIImage()
+          navigationController?.navigationBar.isTranslucent = true
+        }
         tabBarController?.tabBar.isHidden = UIDevice.isIPhone
       }
       .ignoresSafeArea(.all, edges: .vertical)
+      .statusBar(hidden: true)
     #endif
   }
 

--- a/apple/OmnivoreKit/Sources/Views/LinkedItemDetail/LinkItemDetailView.swift
+++ b/apple/OmnivoreKit/Sources/Views/LinkedItemDetail/LinkItemDetailView.swift
@@ -70,8 +70,7 @@ public struct LinkItemDetailView: View {
         navigationController?.hidesBarsOnSwipe = UIDevice.isIPhone
         tabBarController?.tabBar.isHidden = UIDevice.isIPhone
       }
-      //      .ignoresSafeArea(, edges: <#T##Edge.Set#>)
-      .ignoresSafeArea(., edges: .vertical)
+      .ignoresSafeArea(.all, edges: .vertical)
     #endif
   }
 

--- a/apple/OmnivoreKit/Sources/Views/PrimaryContainerViews/HomeFeedView.swift
+++ b/apple/OmnivoreKit/Sources/Views/PrimaryContainerViews/HomeFeedView.swift
@@ -380,7 +380,6 @@ public struct HomeFeedView: View {
           conditionalInnerBody
             .introspectNavigationController {
               navigationController = $0
-              navigationController?.hidesBarsOnSwipe = false
             }
             .introspectTabBarController {
               tabBarController = $0
@@ -389,11 +388,15 @@ public struct HomeFeedView: View {
             }
             .onDisappear {
               tabBarController?.tabBar.isHidden = true
-              navigationController?.hidesBarsOnSwipe = true
+              navigationController?.navigationBar.setBackgroundImage(UIImage(), for: .default)
+              navigationController?.navigationBar.shadowImage = UIImage()
+              navigationController?.navigationBar.isTranslucent = true
             }
             .onAppear {
-              navigationController?.hidesBarsOnSwipe = false
               tabBarController?.tabBar.isHidden = false
+              navigationController?.navigationBar.setBackgroundImage(nil, for: .default)
+              navigationController?.navigationBar.shadowImage = nil
+              navigationController?.navigationBar.isTranslucent = false
             }
         }
       } else {

--- a/apple/OmnivoreKit/Sources/Views/PrimaryContainerViews/HomeFeedView.swift
+++ b/apple/OmnivoreKit/Sources/Views/PrimaryContainerViews/HomeFeedView.swift
@@ -56,6 +56,8 @@ public struct HomeFeedView: View {
   @State private var confirmationShown = false
   @State private var snoozePresented = false
   @State private var itemToSnooze: FeedItem?
+  @State var navigationController: UINavigationController?
+  @State var tabBarController: UITabBarController?
 
   public init(viewModel: HomeFeedViewModel) {
     self.viewModel = viewModel
@@ -376,6 +378,23 @@ public struct HomeFeedView: View {
       if UIDevice.isIPhone {
         NavigationView {
           conditionalInnerBody
+            .introspectNavigationController {
+              navigationController = $0
+              navigationController?.hidesBarsOnSwipe = false
+            }
+            .introspectTabBarController {
+              tabBarController = $0
+              tabBarController?.tabBar.isHidden = false
+              navigationController?.navigationBar.isHidden = false
+            }
+            .onDisappear {
+              tabBarController?.tabBar.isHidden = true
+              navigationController?.hidesBarsOnSwipe = true
+            }
+            .onAppear {
+              navigationController?.hidesBarsOnSwipe = false
+              tabBarController?.tabBar.isHidden = false
+            }
         }
       } else {
         conditionalInnerBody


### PR DESCRIPTION
Alternative to the `hidesBarOnSwipe` way.

Still has text going into the status bar area when scrolled up. 

(Also the color when going back to the home feed is off...just focusing on the detail view for now)

<img width="350" src="https://user-images.githubusercontent.com/836745/154114595-0ddff068-0fa7-4edb-b58b-3742b0b52e57.png" />

