### PR TITLE
Compact Navbar for PDF Viewer [iOS]

### DIFF
--- a/apple/OmnivoreKit/Sources/Views/LinkedItemDetail/LinkItemDetailView.swift
+++ b/apple/OmnivoreKit/Sources/Views/LinkedItemDetail/LinkItemDetailView.swift
@@ -157,6 +157,7 @@ public struct LinkItemDetailView: View {
     if let pdfURL = viewModel.item.pdfURL {
       #if os(iOS)
         PDFProvider.pdfViewerProvider?(pdfURL, viewModel.item)
+          .navigationBarTitleDisplayMode(.inline)
       #elseif os(macOS)
         PDFWrapperView(pdfURL: pdfURL)
       #endif

--- a/apple/Sources/PDFReaderView.swift
+++ b/apple/Sources/PDFReaderView.swift
@@ -21,7 +21,7 @@ import WebKit
 
       let nav = UINavigationController(rootViewController: readerViewcontroller)
 
-      // Using an emoty image creates a transparent navigation bar
+      // Using an empty image creates a transparent navigation bar
       nav.navigationBar.setBackgroundImage(UIImage(), for: .default)
       nav.navigationBar.shadowImage = UIImage()
       nav.navigationBar.isTranslucent = true


### PR DESCRIPTION
The nav bar was configured for large titles so we had extra padding on the PDF reader view.
