### PR TITLE
Tweak the line height for reader text and titles

### DIFF
--- a/packages/web/components/elements/StyledText.tsx
+++ b/packages/web/components/elements/StyledText.tsx
@@ -130,7 +130,7 @@ const textVariants = {
 export const StyledText = styled('p', {
   fontFamily: 'Inter',
   fontWeight: 'normal',
-  lineHeight: '1.35',
+  lineHeight: '120%',
   color: '$grayTextContrast',
   variants: textVariants,
   defaultVariants: {

--- a/packages/web/components/templates/article/ArticleContainer.tsx
+++ b/packages/web/components/templates/article/ArticleContainer.tsx
@@ -126,7 +126,7 @@ export function ArticleContainer(props: ArticleContainerProps): JSX.Element {
           maxWidth: '94%',
           '--text-font-family': styles.fontFamily,
           '--text-font-size': `${styles.fontSize}px`,
-          '--line-height': `1.61em`,
+          '--line-height': `150%`,
           '--blockquote-padding': '0.5em 1em',
           '--blockquote-icon-font-size': '1.3rem',
           '--figure-margin': '1.6rem auto',


### PR DESCRIPTION
We still aren't using the degular font, so I kept the font sizes
the same as they are now. We will need to update if we change
the font.
