### PR TITLE
Handle non-number size attributes in images

### DIFF
--- a/packages/readabilityjs/Readability.js
+++ b/packages/readabilityjs/Readability.js
@@ -512,15 +512,15 @@ Readability.prototype = {
 
         if (src) {
           const absoluteSrc = this.toAbsoluteURI(src);
-          const parseNumber = (str) => {
+          const attToNumber = (str) => {
             if (!str) { return 0; }
-            const res = parseNumber(str);
+            const res = parseInt(str);
             if (isNaN(res)) { return 0; }
             return res
           }
 
-          const width = parseInt(image.getAttribute('width') || image.style.width);
-          const height = parseInt(image.getAttribute('height') || image.style.height);
+          const width = attToNumber(image.getAttribute('width') || image.style.width);
+          const height = attToNumber(image.getAttribute('height') || image.style.height);
 
           const proxySrc = this.createImageProxyUrl(absoluteSrc, width, height);
           image.setAttribute('src', proxySrc);

--- a/packages/readabilityjs/Readability.js
+++ b/packages/readabilityjs/Readability.js
@@ -519,8 +519,8 @@ Readability.prototype = {
             return res
           }
 
-          const width = parseNumber(image.getAttribute('width') || image.style.width);
-          const height = parseNumber(image.getAttribute('height') || image.style.height);
+          const width = parseInt(image.getAttribute('width') || image.style.width);
+          const height = parseInt(image.getAttribute('height') || image.style.height);
 
           const proxySrc = this.createImageProxyUrl(absoluteSrc, width, height);
           image.setAttribute('src', proxySrc);

--- a/packages/readabilityjs/Readability.js
+++ b/packages/readabilityjs/Readability.js
@@ -516,6 +516,7 @@ Readability.prototype = {
             if (!str) { return 0; }
             const res = parseInt(str);
             if (isNaN(res)) { return 0; }
+            if (String(res) !== str) { return 0; }
             return res
           }
 

--- a/packages/readabilityjs/Readability.js
+++ b/packages/readabilityjs/Readability.js
@@ -512,11 +512,17 @@ Readability.prototype = {
 
         if (src) {
           const absoluteSrc = this.toAbsoluteURI(src);
+          const parseNumber = (str) => {
+            if (!str) { return 0; }
+            const res = parseNumber(str);
+            if (isNaN(res)) { return 0; }
+            return res
+          }
 
-          const width = image.getAttribute('width') || image.style.width;
-          const height = image.getAttribute('height') || image.style.height;
+          const width = parseNumber(image.getAttribute('width') || image.style.width);
+          const height = parseNumber(image.getAttribute('height') || image.style.height);
 
-          const proxySrc = this.createImageProxyUrl(absoluteSrc, width || 0, height || 0);
+          const proxySrc = this.createImageProxyUrl(absoluteSrc, width, height);
           image.setAttribute('src', proxySrc);
         }
       });


### PR DESCRIPTION
The previous code assumed we would always have number size values
for width and height, but attributes like 100% are valid. In
cases where we don't have a numeric value we can just fallback
and let the item be sized by the reader CSS.
