### PR TITLE
Use null instead of undefined when unarchiving links

### DIFF
--- a/packages/api/src/services/save_email.ts
+++ b/packages/api/src/services/save_email.ts
@@ -79,7 +79,7 @@ export const saveEmail = async (
 
     result = await ctx.models.userArticle.update(matchedUserArticleRecord.id, {
       savedAt: new Date(),
-      archivedAt: undefined,
+      archivedAt: null,
     })
   } else {
     await ctx.pubsub.pageCreated(saverId, url, input.originalContent)

--- a/packages/api/src/services/save_file.ts
+++ b/packages/api/src/services/save_file.ts
@@ -92,7 +92,7 @@ export const saveFile = async (
         matchedUserArticleRecord.id,
         {
           savedAt: new Date(),
-          archivedAt: undefined,
+          archivedAt: null,
         },
         tx
       )

--- a/packages/api/src/services/save_page.ts
+++ b/packages/api/src/services/save_page.ts
@@ -125,7 +125,7 @@ export const savePage = async (
         matchedUserArticleRecord.id,
         {
           savedAt: new Date(),
-          archivedAt: undefined,
+          archivedAt: null,
         },
         tx
       )

--- a/packages/api/test/resolvers/article.test.ts
+++ b/packages/api/test/resolvers/article.test.ts
@@ -4,31 +4,116 @@ import {
   createTestUser,
   deleteTestUser,
 } from '../db'
-import { graphqlRequest, request } from '../util'
+import { generateFakeUuid, graphqlRequest, request } from '../util'
 import { expect } from 'chai'
 import { Page } from '../../src/entity/page'
 import 'mocha'
+import { User } from '../../src/entity/user'
+import * as chai from 'chai'
+import chaiString from 'chai-string'
+
+chai.use(chaiString)
+
+const archiveLink = async (authToken: string, linkId: string) => {
+  const query = `
+  mutation {
+    setLinkArchived(
+      input: {
+        linkId: "${linkId}",
+        archived: ${true}
+      }
+    ) {
+      ... on ArchiveLinkSuccess {
+        linkId
+      }
+      ... on ArchiveLinkError {
+        errorCodes
+      }
+    }
+  }
+  `
+ return await graphqlRequest(query, authToken).expect(200)
+}
+
+const articlesQuery = (after = '', order = 'ASCENDING') => {
+  return `
+  query {
+    articles(
+      sharedOnly: ${false}
+      sort: {
+        order: ${order}
+        by: UPDATED_TIME
+      }
+      after: "${after}"
+      first: 5
+      query: "") {
+      ... on ArticlesSuccess {
+        edges {
+          cursor
+          node {
+            id
+            url
+          }
+        }
+        pageInfo {
+          hasNextPage
+          hasPreviousPage
+          startCursor
+          endCursor
+          totalCount
+        }
+      }
+      ... on ArticlesError {
+        errorCodes
+      }
+    }
+  }
+  `
+}
+
+const savePageQuery = (url: string, title: string, originalContent: string) => {
+  return `
+    mutation {
+      savePage(
+        input: {
+          url: "${url}",
+          source: "test",
+          clientRequestId: "${generateFakeUuid()}",
+          title: "${title}",
+          originalContent: "${originalContent}"
+        }
+      ) {
+        ... on SaveSuccess {
+          url
+        }
+        ... on SaveError {
+          errorCodes
+        }
+      }
+    }
+    `
+}
 
 describe('Article API', () => {
   const username = 'fakeUser'
-
   let authToken: string
+  let user: User
   let links: Page[] = []
 
   before(async () => {
     // create test user and login
-    const user = await createTestUser(username)
+    user = await createTestUser(username)
     const res = await request
       .post('/local/debug/fake-user-login')
       .send({ fakeEmail: user.email })
 
-    authToken = res.body.authToken
-
+    // Create some test links
     for (let i = 0; i < 15; i++) {
       const page = await createTestPage()
       await createTestLink(user, page)
       links.push(page)
     }
+    authToken = res.body.authToken
   })
 
   after(async () => {
@@ -40,39 +125,8 @@ describe('Article API', () => {
     let query = ''
     let after = ''
 
-    beforeEach(() => {
-      query = `
-      query {
-        articles(
-          sharedOnly: ${false}
-          sort: {
-            order: ASCENDING
-            by: UPDATED_TIME
-          }
-          after: "${after}"
-          first: 5
-          query: "") {
-          ... on ArticlesSuccess {
-            edges {
-              cursor
-              node {
-                id
-              }
-            }
-            pageInfo {
-              hasNextPage
-              hasPreviousPage
-              startCursor
-              endCursor
-              totalCount
-            }
-          }
-          ... on ArticlesError {
-            errorCodes
-          }
-        }
-      }
-      `
+    beforeEach(async () => {
+      query = articlesQuery(after)
     })
 
     context('when we fetch the first page', () => {
@@ -137,6 +191,45 @@ describe('Article API', () => {
         ).to.eql(true)
         // We don't implement hasPreviousPage in the API and should probably remove it
         // expect(res.body.data.articles.pageInfo.hasPreviousPage).to.eql(true)
+      })
+    })
+  })
+
+  describe('SavePage', () => {
+    let query = ''
+    let title = 'Example Title'
+    let url = 'https://example.com'
+    let originalContent = '<div>Example Content</div>'
+
+    beforeEach(() => {
+      query = savePageQuery(url, title, originalContent)
+    })
+
+    context('when we save a new page', () => {
+      it('should return a slugged url', async () => {
+        const res = await graphqlRequest(query, authToken).expect(200)
+        expect(res.body.data.savePage.url).to.startsWith("http://localhost:3000/fakeUser/example-title-")
+      })
+    })
+
+    context('when we save a page that is already archived', () => {
+      it('it should return that page in the GetArticles Query', async () => {
+        url = 'https://example.com/new-url'
+        await graphqlRequest(savePageQuery(url, title, originalContent), authToken).expect(200)
+
+        // Save a link, then archive it
+        let allLinks = await graphqlRequest(articlesQuery('', 'DESCENDING'), authToken).expect(200)
+        const justSavedId = allLinks.body.data.articles.edges[0].node.id
+        await archiveLink(authToken, justSavedId)
+
+        // test the negative case, ensuring the archive link wasn't returned
+        allLinks = await graphqlRequest(articlesQuery('', 'DESCENDING'), authToken).expect(200)
+        expect(allLinks.body.data.articles.edges[0].node.url).to.not.eq(url)
+
+        // Now save the link again, and ensure it is returned
+        const resaved = await graphqlRequest(savePageQuery(url, title, originalContent), authToken).expect(200)
+        allLinks = await graphqlRequest(articlesQuery('', 'DESCENDING'), authToken).expect(200)
+        expect(allLinks.body.data.articles.edges[0].node.url).to.eq(url)
       })
     })
   })


### PR DESCRIPTION
This fixes unarchiving content by re-saving it via the Save*
API methods.

Setting to undefined is not the same as null in this case, and
will result in archived_at being non-null and the link then
being excluded from the GetArticles query.
