### PR TITLE
Use @StateObject when appropriate

### DIFF
--- a/apple/OmnivoreKit/Sources/App/AppExtensions/Share/ShareExtensionScene.swift
+++ b/apple/OmnivoreKit/Sources/App/AppExtensions/Share/ShareExtensionScene.swift
@@ -95,10 +95,10 @@ final class ShareExtensionViewModel: ObservableObject {
 }
 
 struct ShareExtensionView: View {
-  @ObservedObject private var viewModel: ShareExtensionViewModel
+  @StateObject private var viewModel: ShareExtensionViewModel
 
   init(extensionContext: NSExtensionContext?) {
-    self.viewModel = ShareExtensionViewModel(extensionContext: extensionContext)
+    self._viewModel = StateObject(wrappedValue: ShareExtensionViewModel(extensionContext: extensionContext))
   }
 
   var body: some View {

--- a/apple/OmnivoreKit/Sources/App/Views/CreateProfileContainerView.swift
+++ b/apple/OmnivoreKit/Sources/App/Views/CreateProfileContainerView.swift
@@ -101,13 +101,15 @@ final class CreateProfileViewModel: ObservableObject {
 struct CreateProfileContainerView: View {
   @EnvironmentObject var authenticator: Authenticator
   @EnvironmentObject var dataService: DataService
-  @ObservedObject private var viewModel: CreateProfileViewModel
+  @StateObject private var viewModel: CreateProfileViewModel
 
   @State private var name: String
   @State private var bio = ""
 
   init(userProfile: UserProfile, dataService: DataService) {
-    self.viewModel = CreateProfileViewModel(initialUserProfile: userProfile, dataService: dataService)
+    self._viewModel = StateObject(
+      wrappedValue: CreateProfileViewModel(initialUserProfile: userProfile, dataService: dataService)
+    )
     self._name = State(initialValue: userProfile.name)
   }
 

--- a/apple/OmnivoreKit/Sources/App/Views/HomeFeedView.swift
+++ b/apple/OmnivoreKit/Sources/App/Views/HomeFeedView.swift
@@ -179,7 +179,7 @@ final class HomeFeedViewModel: ObservableObject {
 struct HomeFeedView: View {
   @EnvironmentObject var dataService: DataService
 
-  @ObservedObject private var viewModel = HomeFeedViewModel()
+  @StateObject private var viewModel = HomeFeedViewModel()
   @State private var selectedLinkItem: FeedItem?
   @State private var searchQuery = ""
   @State private var itemToRemove: FeedItem?

--- a/apple/OmnivoreKit/Sources/App/Views/NewAppleSignupView.swift
+++ b/apple/OmnivoreKit/Sources/App/Views/NewAppleSignupView.swift
@@ -30,12 +30,12 @@ final class NewAppleSignupViewModel: ObservableObject {
 
 struct NewAppleSignupView: View {
   @EnvironmentObject var authenticator: Authenticator
-  @ObservedObject private var viewModel: NewAppleSignupViewModel
+  @StateObject private var viewModel: NewAppleSignupViewModel
   let showProfileEditView: () -> Void
 
   init(userProfile: UserProfile, showProfileEditView: @escaping () -> Void) {
     self.showProfileEditView = showProfileEditView
-    self.viewModel = NewAppleSignupViewModel(userProfile: userProfile)
+    self._viewModel = StateObject(wrappedValue: NewAppleSignupViewModel(userProfile: userProfile))
   }
 
   var body: some View {

--- a/apple/OmnivoreKit/Sources/App/Views/Profile/NewsletterEmailsView.swift
+++ b/apple/OmnivoreKit/Sources/App/Views/Profile/NewsletterEmailsView.swift
@@ -43,7 +43,7 @@ final class NewsletterEmailsViewModel: ObservableObject {
 
 struct NewsletterEmailsView: View {
   @EnvironmentObject var dataService: DataService
-  @ObservedObject var viewModel = NewsletterEmailsViewModel()
+  @StateObject var viewModel = NewsletterEmailsViewModel()
   let footerText = "Add PDFs to your library, or subscribe to emails using an Omnivore email address."
 
   var body: some View {

--- a/apple/OmnivoreKit/Sources/App/Views/Profile/ProfileView.swift
+++ b/apple/OmnivoreKit/Sources/App/Views/Profile/ProfileView.swift
@@ -30,7 +30,7 @@ struct ProfileView: View {
   @EnvironmentObject var authenticator: Authenticator
   @EnvironmentObject var dataService: DataService
 
-  @ObservedObject private var viewModel = ProfileContainerViewModel()
+  @StateObject private var viewModel = ProfileContainerViewModel()
 
   @State private var showLogoutConfirmation = false
 

--- a/apple/OmnivoreKit/Sources/App/Views/RegistrationView.swift
+++ b/apple/OmnivoreKit/Sources/App/Views/RegistrationView.swift
@@ -88,7 +88,7 @@ struct RegistrationView: View {
   @EnvironmentObject var authenticator: Authenticator
   @EnvironmentObject var dataService: DataService
   @Environment(\.horizontalSizeClass) var horizontalSizeClass
-  @ObservedObject private var viewModel = RegistrationViewModel()
+  @StateObject private var viewModel = RegistrationViewModel()
 
   var authenticationView: some View {
     VStack(spacing: 0) {

--- a/apple/OmnivoreKit/Sources/Views/AsyncImage.swift
+++ b/apple/OmnivoreKit/Sources/Views/AsyncImage.swift
@@ -5,31 +5,43 @@ import Utils
 
 struct AsyncImage: View {
   let isResizable: Bool
-  @ObservedObject private var imageLoader = ImageLoader()
+  let url: URL?
+  @State private var isLoaded = false
+  @StateObject private var imageLoader = ImageLoader()
 
   init(url: URL?, isResizable: Bool = true) {
     self.isResizable = isResizable
-    if let url = url {
+    self.url = url
+  }
+
+  func load() {
+    if let url = url, !isLoaded {
       imageLoader.load(fromUrl: url)
+      isLoaded = true
     }
   }
 
   var body: some View {
-    #if os(iOS)
-      if isResizable {
-        Image(uiImage: imageLoader.image ?? imageLoader.placeholder)
-          .resizable()
-      } else {
-        Image(uiImage: imageLoader.image ?? imageLoader.placeholder)
-      }
-    #elseif os(macOS)
-      if isResizable {
-        Image(nsImage: imageLoader.image ?? imageLoader.placeholder)
-          .resizable()
-      } else {
-        Image(nsImage: imageLoader.image ?? imageLoader.placeholder)
-      }
-    #endif
+    Group {
+      #if os(iOS)
+        if isResizable {
+          Image(uiImage: imageLoader.image ?? imageLoader.placeholder)
+            .resizable()
+        } else {
+          Image(uiImage: imageLoader.image ?? imageLoader.placeholder)
+        }
+      #elseif os(macOS)
+        if isResizable {
+          Image(nsImage: imageLoader.image ?? imageLoader.placeholder)
+            .resizable()
+        } else {
+          Image(nsImage: imageLoader.image ?? imageLoader.placeholder)
+        }
+      #endif
+    }
+    .onAppear {
+      load()
+    }
   }
 }
 


### PR DESCRIPTION
Was just looking into the new Swift async stuff and read a bit about SwiftUI's `@StateObject`. Most of the time we should be marking our view models as `@StateObject` rather than `@ObservedObject`.

The rule is that if a view owns the observed object then it should be marked as `@StateObject`. If it's passed in then we mark it as `@ObservedObject`. That way a view will hold onto the object when it owns it. 

I think this will fix that bug where user profile was cleared out when the app was backgrounded.