### PR TITLE
Remove block formatting on code

### DIFF
--- a/packages/web/styles/articleInnerStyling.css
+++ b/packages/web/styles/articleInnerStyling.css
@@ -293,8 +293,6 @@ on smaller screens we display the note icon
 
 .article-inner-css pre,
 .article-inner-css code {
-  display: block;
-  font-size: 0.87em;
   word-wrap: initial;
   font-family: 'SF Mono', monospace !important;
   white-space: pre;


### PR DESCRIPTION
This fixes line breaks being added on inline code elements for
example lines like:

call the <code>sprintf</code> function
