### PR TITLE
Import highlightjs types

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -43,6 +43,7 @@
     "@types/cookie-parser": "^1.4.2",
     "@types/dompurify": "^2.0.4",
     "@types/express": "^4.17.7",
+    "@types/highlightjs": "^9.12.2",
     "@types/intercom-client": "^2.11.8",
     "@types/jsdom": "^16.2.3",
     "@types/jsonwebtoken": "^8.5.0",


### PR DESCRIPTION
We still need these dev packages because of the way our docker
builds are setup.
