### PR TITLE
Remove inline-block styling on code blocks

### DIFF
--- a/packages/web/styles/articleInnerStyling.css
+++ b/packages/web/styles/articleInnerStyling.css
@@ -293,7 +293,6 @@ on smaller screens we display the note icon
 
 .article-inner-css pre,
 .article-inner-css code {
-  display: inline-block;
   vertical-align: bottom;
   word-wrap: initial;
   font-family: 'SF Mono', monospace !important;


### PR DESCRIPTION
This will let code blocks go full width without inline code
statements creating a new line break.
