### PR TITLE
Header button fixes

### DIFF
--- a/packages/web/components/elements/Button.tsx
+++ b/packages/web/components/elements/Button.tsx
@@ -50,9 +50,6 @@ export const Button = styled('button', {
         '@md': {
           bg: 'rgb(125, 125, 125, 0.1)',
         },
-        '@xsmDown': {
-          visibility: 'collapse',
-        },
         '.ctaButtonIcon': {
           visibility: 'hidden',
         }

--- a/packages/web/components/patterns/PrimaryHeader.tsx
+++ b/packages/web/components/patterns/PrimaryHeader.tsx
@@ -188,20 +188,21 @@ function NavHeader(props: NavHeaderProps): JSX.Element {
             alignment="center"
             css={{ display: 'flex', alignItems: 'center' }}
           >
-            <a href="https://github.com/omnivore-app/omnivore" target='_blank' rel="noreferrer">
-              <Button style="ctaLightGray" css={{ background: 'unset', mr: '32px' }}>
-                <HStack css={{ height: '100%' }}>
-                  <svg version="1.1" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true">
-                    <path fill={theme.colors.grayTextContrast.toString()} fillRule="evenodd" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"></path>
-                  </svg>
-                  <SpanBox css={{ pl: '8px', color: '$grayTextContrast' }}>Follow us on GitHub</SpanBox>
-                  <Box className='ctaButtonIcon' css={{ ml: '4px' }}>
-                    <ArrowSquareOut size={16} />
-                  </Box>
-
-                </HStack>
-              </Button>
-            </a>
+            <Box css={{ '@xsmDown': { visibility: 'collapse' } }}>
+              <a href="https://github.com/omnivore-app/omnivore" target='_blank' rel="noreferrer">
+                <Button style="ctaLightGray" css={{ background: 'unset', mr: '32px' }}>
+                  <HStack css={{ height: '100%' }}>
+                    <svg version="1.1" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true">
+                      <path fill={theme.colors.grayTextContrast.toString()} fillRule="evenodd" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"></path>
+                    </svg>
+                    <SpanBox css={{ pl: '8px', color: '$grayTextContrast' }}>Follow us on GitHub</SpanBox>
+                    <Box className='ctaButtonIcon' css={{ ml: '4px' }}>
+                      <ArrowSquareOut size={16} />
+                    </Box>
+                  </HStack>
+                </Button>
+              </a>
+            </Box>
             <DropdownMenu
               username={props.username}
               triggerElement={

--- a/packages/web/components/templates/LoginLayout.tsx
+++ b/packages/web/components/templates/LoginLayout.tsx
@@ -32,7 +32,7 @@ export function LoginLayout(props: LoginFormProps): JSX.Element {
           width: '100%',
         }}
       >
-        <OmnivoreNameLogo color={theme.colors.omnivoreGray.toString()} />
+        <OmnivoreNameLogo color={theme.colors.omnivoreGray.toString()} href='/login' />
         <Box css={{
           marginLeft: 'auto',
           fontSize: '15px',
@@ -43,18 +43,20 @@ export function LoginLayout(props: LoginFormProps): JSX.Element {
           lineHeight: '100%',
           textDecoration: 'none',
         }}>
-          <a href="https://github.com/omnivore-app/omnivore" target='_blank' rel="noreferrer">
-            <Button style="ctaLightGray">
-              <HStack css={{ height: '100%' }}>
-                <SpanBox css={{ pt: '5px', pr: '6px' }}>Follow on GitHub</SpanBox>
-                <SpanBox css={{ alpha: '0.1' }}>
-                <svg version="1.1" width="24" height="24" viewBox="0 0 16 16" aria-hidden="true">
-                  <path fillRule="evenodd" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"></path>
-                </svg>
-                </SpanBox>
-              </HStack>
-            </Button>
-          </a>
+          <Box css={{ '@xsmDown': { visibility: 'collapse' } }}>
+            <a href="https://github.com/omnivore-app/omnivore" target='_blank' rel="noreferrer">
+              <Button style="ctaLightGray">
+                <HStack css={{ height: '100%' }}>
+                  <SpanBox css={{ pt: '5px', pr: '6px' }}>Follow on GitHub</SpanBox>
+                  <SpanBox css={{ alpha: '0.1' }}>
+                  <svg version="1.1" width="24" height="24" viewBox="0 0 16 16" aria-hidden="true">
+                    <path fillRule="evenodd" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"></path>
+                  </svg>
+                  </SpanBox>
+                </HStack>
+              </Button>
+            </a>
+          </Box>
         </Box>
       </Box>
     </>


### PR DESCRIPTION
- Completely disable the GitHub button when collapsed in header
- Point the name logo button to /login on the login page
