### PR TITLE
In /app use the window to scroll to initial read position

### DIFF
--- a/packages/web/components/templates/article/Article.tsx
+++ b/packages/web/components/templates/article/Article.tsx
@@ -151,7 +151,11 @@ export function Article(props: ArticleProps): JSX.Element {
         return 0
       }
 
-      props.scrollElementRef.current?.scroll(0, calculateOffset(anchorElement))
+      if (props.scrollElementRef.current) {
+        props.scrollElementRef.current?.scroll(0, calculateOffset(anchorElement))
+      } else {
+        window.document.documentElement.scroll(0, calculateOffset(anchorElement))
+      }
     }
   }, [
     props.initialAnchorIndex,


### PR DESCRIPTION
There isn't a scrollElementRef in `/app` because there is no
fixed header, so this will scroll the entire document instead.
