### PR TITLE
Add ELASTIC_URL env var to docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -83,6 +83,7 @@ services:
       - PG_DB=omnivore
       - PG_PORT=5432
       - PG_POOL_MAX=20
+      - ELASTIC_URL=http://elastic:9200
       - IMAGE_PROXY_URL=http://localhost:9999
       - IMAGE_PROXY_SECRET=some-secret
       - JWT_SECRET=some_secret


### PR DESCRIPTION
This should fix startup of the API server in docker-compose.
