### PR TITLE
Fix postgres error when merging highlights

### DIFF
--- a/packages/api/src/resolvers/highlight/index.ts
+++ b/packages/api/src/resolvers/highlight/index.ts
@@ -131,6 +131,7 @@ export const mergeHighlightResolver = authorized<
       await models.highlight.deleteMany(overlapHighlightIdList, tx)
       return await models.highlight.create({
         ...newHighlightInput,
+        articleId: undefined,
         annotation: mergedAnnotation ? mergedAnnotation.join('\n') : null,
         userId: claims.uid,
         elasticPageId: newHighlightInput.articleId,


### PR DESCRIPTION
fix article_id type mismatch (uuid => varchar) when saving highlight in postgres by setting `article_id` to be `undefined`
@jacksonh 