### PR TITLE
return empty content instead of null in search result

### DIFF
--- a/packages/api/src/elastic/index.ts
+++ b/packages/api/src/elastic/index.ts
@@ -474,6 +474,7 @@ export const searchPages = async (
     return [
       response.body.hits.hits.map((hit: { _source: Page; _id: string }) => ({
         ...hit._source,
+        content: '',
         id: hit._id,
       })),
       response.body.hits.total.value,


### PR DESCRIPTION
Fix: GraphQLError: Cannot return null for non-nullable field Article.content.
Sentry: https://sentry.io/organizations/omnivore/issues/3103869186/?project=5591542&referrer=regression-activity-email

