### PR TITLE
Add a /install/apple redirect for the store

### DIFF
--- a/packages/web/next.config.js
+++ b/packages/web/next.config.js
@@ -133,6 +133,12 @@ const moduleExports = {
           'https://apps.apple.com/us/app/omnivore-read-highlight-share/id1564031042',
         permanent: true,
       },
+      {
+        source: '/install/apple',
+        destination:
+          'https://apps.apple.com/us/app/omnivore-read-highlight-share/id1564031042',
+        permanent: true,
+      },
     ]
   },
 }


### PR DESCRIPTION
This is the same as ios, safari, mac just a more generic name
for our installs page
