### PR TITLE
add a maximum length of password in signup form

### DIFF
--- a/packages/web/pages/email-registration.tsx
+++ b/packages/web/pages/email-registration.tsx
@@ -32,7 +32,7 @@ export default function EmailRegistration(): JSX.Element {
         </div>
         <div>
           <label>Password</label>
-          <input type="password" name={'password'} required />
+          <input type="password" name={'password'} required maxLength={40} />
         </div>
         <div>
           <label>Full Name</label>


### PR DESCRIPTION
fix: https://sentry.io/organizations/omnivore/issues/3145394128/?project=5466498

Specified password should not be longer than 40 characters