### PR TITLE
Fix searching for multiple labels

### DIFF
--- a/packages/api/src/elastic/pages.ts
+++ b/packages/api/src/elastic/pages.ts
@@ -128,21 +128,17 @@ const appendIncludeLabelFilter = (
   body: SearchBody,
   filters: LabelFilter[]
 ): void => {
-  body.query.bool.filter.push({
-    nested: {
-      path: 'labels',
-      query: {
-        bool: {
-          filter: filters.map((filter) => {
-            return {
-              terms: {
-                'labels.name': filter.labels,
-              },
-            }
-          }),
+  filters.forEach((filter) => {
+    body.query.bool.filter.push({
+      nested: {
+        path: 'labels',
+        query: {
+          terms: {
+            'labels.name': filter.labels,
+          },
         },
       },
-    },
+    })
   })
 }
 

--- a/packages/api/src/elastic/types.ts
+++ b/packages/api/src/elastic/types.ts
@@ -32,12 +32,8 @@ export interface SearchBody {
             nested: {
               path: 'labels'
               query: {
-                bool: {
-                  filter: {
-                    terms: {
-                      'labels.name': string[]
-                    }
-                  }[]
+                terms: {
+                  'labels.name': string[]
                 }
               }
             }


### PR DESCRIPTION
Fixed a search query syntax error for multiple labels:
```        
{
          "nested": {
            "path": "labels",
            "query": {
              "terms": {
                "labels.name": [
                  "test"
                ]
              }
            }
          }
        },
        {
          "nested": {
            "path": "labels",
            "query": {
              "terms": {
                "labels.name": [
                  "test1"
                ]
              }
            }
          }
        }
```