### PR TITLE
Fix parsing newsletter url from substack by fixing a typo in the method name

### DIFF
--- a/packages/inbound-email-handler/src/substack-handler.ts
+++ b/packages/inbound-email-handler/src/substack-handler.ts
@@ -7,7 +7,7 @@ export class SubstackHandler extends NewsletterHandler {
     this.defaultUrl = 'https://www.substack.com'
   }
 
-  getNewsletterUrl(postHeader: string, _html: string): string | undefined {
+  parseNewsletterUrl(postHeader: string, _html: string): string | undefined {
     // raw SubStack newsletter url is like <https://hongbo130.substack.com/p/tldr>
     // we need to get the real url from the raw url
     return addressparser(postHeader).length > 0

--- a/packages/inbound-email-handler/test/newsletter.test.ts
+++ b/packages/inbound-email-handler/test/newsletter.test.ts
@@ -83,7 +83,7 @@ describe('Newsletter email test', () => {
     it('returns url when email is from SubStack', () => {
       const rawUrl = '<https://hongbo130.substack.com/p/tldr>'
 
-      expect(new SubstackHandler().getNewsletterUrl(rawUrl, '')).to.equal(
+      expect(new SubstackHandler().parseNewsletterUrl(rawUrl, '')).to.equal(
         'https://hongbo130.substack.com/p/tldr'
       )
     })


### PR DESCRIPTION
Fix a typo in the method name