### PR TITLE
Increase the rate limit

### DIFF
--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -92,7 +92,7 @@ export const createApp = (): {
   if (!env.dev.isLocal) {
     const apiLimiter = rateLimit({
       windowMs: 60 * 1000, // 1 minute
-      max: 10, // Limit each IP to 10 requests per `window` (here, per minute)
+      max: 50, // Limit each IP to 10 requests per `window` (here, per minute)
       standardHeaders: true, // Return rate limit info in the `RateLimit-*` headers
       legacyHeaders: false, // Disable the `X-RateLimit-*` headers
     })


### PR DESCRIPTION
Turns out 10 is very low because we make CORs requests from the
browser and SWR will make background requests for some objects
like viewer. I was hitting the limit while testing search.
