### PR TITLE
Remove the client side highlight.js code

### DIFF
--- a/packages/web/pages/_document.tsx
+++ b/packages/web/pages/_document.tsx
@@ -53,7 +53,6 @@ export default class Document extends NextDocument {
           <link rel="manifest" href="/manifest.webmanifest" />
           <script async src="/static/scripts/intercom.js" />
           <script async src="/static/scripts/inject-sw.js" />
-          <script async src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/11.4.0/highlight.min.js"></script>
         </Head>
         <body>
           <Main />


### PR DESCRIPTION
We perform highlighting on the backend when content is saved, so
this include isn't needed.
