### PR TITLE
Keep iOS NavBar hidden

### DIFF
--- a/apple/OmnivoreKit/Sources/App/Views/Home/Components/FeedCardNavigationLink.swift
+++ b/apple/OmnivoreKit/Sources/App/Views/Home/Components/FeedCardNavigationLink.swift
@@ -11,9 +11,16 @@ struct FeedCardNavigationLink: View {
   @ObservedObject var viewModel: HomeFeedViewModel
 
   var body: some View {
-    ZStack {
+    let destination = LinkItemDetailView(viewModel: LinkItemDetailViewModel(item: item, homeFeedViewModel: viewModel))
+    #if os(iOS)
+      let modifiedDestination = destination.navigationBarHidden(true)
+    #else
+      let modifiedDestination = destination
+    #endif
+
+    return ZStack {
       NavigationLink(
-        destination: LinkItemDetailView(viewModel: LinkItemDetailViewModel(item: item, homeFeedViewModel: viewModel)),
+        destination: modifiedDestination,
         tag: item,
         selection: $viewModel.selectedLinkItem
       ) {
@@ -42,9 +49,16 @@ struct GridCardNavigationLink: View {
   @ObservedObject var viewModel: HomeFeedViewModel
 
   var body: some View {
-    ZStack {
+    let destination = LinkItemDetailView(viewModel: LinkItemDetailViewModel(item: item, homeFeedViewModel: viewModel))
+    #if os(iOS)
+      let modifiedDestination = destination.navigationBarHidden(true)
+    #else
+      let modifiedDestination = destination
+    #endif
+
+    return ZStack {
       NavigationLink(
-        destination: LinkItemDetailView(viewModel: LinkItemDetailViewModel(item: item, homeFeedViewModel: viewModel)),
+        destination: modifiedDestination,
         tag: item,
         selection: $viewModel.selectedLinkItem
       ) {

--- a/apple/OmnivoreKit/Sources/App/Views/LinkItemDetailView.swift
+++ b/apple/OmnivoreKit/Sources/App/Views/LinkItemDetailView.swift
@@ -248,9 +248,7 @@ struct LinkItemDetailView: View {
             navBar
             Spacer()
           }
-          .navigationBarHidden(true)
         }
-
       } else {
         VStack(spacing: 0) {
           navBar
@@ -262,7 +260,6 @@ struct LinkItemDetailView: View {
             rawAuthCookie: authenticator.omnivoreAuthCookieString
           )
         }
-        .navigationBarHidden(true)
       }
     }
   #endif

--- a/apple/OmnivoreKit/Sources/App/Views/LinkItemDetailView.swift
+++ b/apple/OmnivoreKit/Sources/App/Views/LinkItemDetailView.swift
@@ -140,10 +140,8 @@ struct LinkItemDetailView: View {
     #if os(iOS)
       if viewModel.item.isPDF {
         fixedNavBarReader
-      } else if FeatureFlag.useLocalWebView {
-        WebReaderContainerView(item: viewModel.item, homeFeedViewModel: viewModel.homeFeedViewModel)
       } else {
-        hidingNavBarReader
+        WebReaderContainerView(item: viewModel.item, homeFeedViewModel: viewModel.homeFeedViewModel)
       }
     #else
       fixedNavBarReader

--- a/apple/OmnivoreKit/Sources/App/Views/Profile/NewsletterEmailsView.swift
+++ b/apple/OmnivoreKit/Sources/App/Views/Profile/NewsletterEmailsView.swift
@@ -91,7 +91,7 @@ struct NewsletterEmailsView: View {
                 #if os(macOS)
                   let pasteBoard = NSPasteboard.general
                   pasteBoard.clearContents()
-                  pasteBoard.writeObjects([newsletterEmail.email as NSString])
+                  pasteBoard.writeObjects([newsletterEmail.unwrappedEmail as NSString])
                 #endif
 
                 Snackbar.show(message: "Email copied")

--- a/apple/OmnivoreKit/Sources/App/Views/Profile/ProfileView.swift
+++ b/apple/OmnivoreKit/Sources/App/Views/Profile/ProfileView.swift
@@ -72,10 +72,8 @@ struct ProfileView: View {
       }
 
       Section {
-        if FeatureFlag.enableLabels {
-          NavigationLink(destination: LabelsView()) {
-            Text("Labels")
-          }
+        NavigationLink(destination: LabelsView()) {
+          Text("Labels")
         }
 
         NavigationLink(destination: NewsletterEmailsView()) {

--- a/apple/OmnivoreKit/Sources/App/Views/WebReader/WebReaderContainer.swift
+++ b/apple/OmnivoreKit/Sources/App/Views/WebReader/WebReaderContainer.swift
@@ -222,13 +222,10 @@ import WebKit
           navBar
           Spacer()
         }
-        .navigationBarHidden(true)
-
       }.onDisappear {
         // Clear the shared webview content when exiting
         WebViewManager.shared().loadHTMLString("<html></html>", baseURL: nil)
       }
-      .navigationBarHidden(true)
     }
   }
 #endif

--- a/apple/OmnivoreKit/Sources/Models/DataModels/NewsletterEmail.swift
+++ b/apple/OmnivoreKit/Sources/Models/DataModels/NewsletterEmail.swift
@@ -1,11 +1,23 @@
+import CoreData
 import Foundation
 
 public extension NewsletterEmail {
-  var unwrappedEmailId: String {
-    emailId ?? ""
-  }
+  var unwrappedEmailId: String { emailId ?? "" }
 
-  var unwrappedEmail: String {
-    email ?? ""
+  var unwrappedEmail: String { email ?? "" }
+
+  static func lookup(byID emailID: String, inContext context: NSManagedObjectContext) -> NewsletterEmail? {
+    let fetchRequest: NSFetchRequest<Models.NewsletterEmail> = NewsletterEmail.fetchRequest()
+    fetchRequest.predicate = NSPredicate(
+      format: "%K == %@", #keyPath(NewsletterEmail.emailId), emailID
+    )
+
+    var email: NewsletterEmail?
+
+    context.performAndWait {
+      email = (try? context.fetch(fetchRequest))?.first
+    }
+
+    return email
   }
 }

--- a/apple/OmnivoreKit/Sources/Services/DataService/Mutations/CreateNewsletterEmailMutation.swift
+++ b/apple/OmnivoreKit/Sources/Services/DataService/Mutations/CreateNewsletterEmailMutation.swift
@@ -5,7 +5,7 @@ import Models
 import SwiftGraphQL
 
 public extension DataService {
-  func createNewsletterEmailPublisher() -> AnyPublisher<NSManagedObjectID, BasicError> {
+  func createNewsletter() async throws -> NSManagedObjectID {
     enum MutationResult {
       case saved(newsletterEmail: InternalNewsletterEmail)
       case error(errorCode: Enums.CreateNewsletterEmailErrorCode)
@@ -34,32 +34,24 @@ public extension DataService {
     let path = appEnvironment.graphqlPath
     let headers = networker.defaultHeaders
 
-    return Deferred {
-      Future { promise in
-        send(mutation, to: path, headers: headers) { result in
-          switch result {
-          case let .success(payload):
-            if let graphqlError = payload.errors {
-              promise(.failure(.message(messageText: "graphql error: \(graphqlError)")))
-            }
+    return try await withCheckedThrowingContinuation { continuation in
+      send(mutation, to: path, headers: headers) { [weak self] queryResult in
+        guard let payload = try? queryResult.get(), let self = self else {
+          continuation.resume(throwing: BasicError.message(messageText: "network error"))
+          return
+        }
 
-            switch payload.data {
-            case let .saved(newsletterEmail: newsletterEmail):
-              if let newsletterEmailObjectID = newsletterEmail.persist(context: self.backgroundContext) {
-                promise(.success(newsletterEmailObjectID))
-              } else {
-                promise(.failure(.message(messageText: "coredata error")))
-              }
-            case let .error(errorCode: errorCode):
-              promise(.failure(.message(messageText: errorCode.rawValue)))
-            }
-          case .failure:
-            promise(.failure(.message(messageText: "graphql error")))
+        switch payload.data {
+        case let .saved(newsletterEmail: newsletterEmail):
+          if let newsletterEmailObjectID = newsletterEmail.persist(context: self.backgroundContext) {
+            continuation.resume(returning: newsletterEmailObjectID)
+          } else {
+            continuation.resume(throwing: BasicError.message(messageText: "CoreData error"))
           }
+        case let .error(errorCode: errorCode):
+          continuation.resume(throwing: BasicError.message(messageText: errorCode.rawValue))
         }
       }
     }
-    .receive(on: DispatchQueue.main)
-    .eraseToAnyPublisher()
   }
 }

--- a/apple/OmnivoreKit/Sources/Services/DataService/Queries/NewsletterEmailsQuery.swift
+++ b/apple/OmnivoreKit/Sources/Services/DataService/Queries/NewsletterEmailsQuery.swift
@@ -1,11 +1,10 @@
-import Combine
 import CoreData
 import Foundation
 import Models
 import SwiftGraphQL
 
 public extension DataService {
-  func newsletterEmailsPublisher() -> AnyPublisher<[NSManagedObjectID], ServerError> {
+  func newsletterEmails() async throws -> [NSManagedObjectID] {
     enum QueryResult {
       case success(result: [InternalNewsletterEmail])
       case error(error: String)
@@ -36,29 +35,26 @@ public extension DataService {
 
     let path = appEnvironment.graphqlPath
     let headers = networker.defaultHeaders
+    let context = backgroundContext
 
-    return Deferred {
-      Future { promise in
-        send(query, to: path, headers: headers) { result in
-          switch result {
-          case let .success(payload):
-            switch payload.data {
-            case let .success(result: result):
-              if let newsletterEmailObjectIDs = result.persist(context: self.backgroundContext) {
-                promise(.success(newsletterEmailObjectIDs))
-              } else {
-                promise(.failure(.unknown))
-              }
-            case .error:
-              promise(.failure(.unknown))
-            }
-          case .failure:
-            promise(.failure(.unknown))
+    return try await withCheckedThrowingContinuation { continuation in
+      send(query, to: path, headers: headers) { queryResult in
+        guard let payload = try? queryResult.get() else {
+          continuation.resume(throwing: BasicError.message(messageText: "network request failed"))
+          return
+        }
+
+        switch payload.data {
+        case let .success(result: result):
+          if let newsletterEmailObjectIDs = result.persist(context: context) {
+            continuation.resume(returning: newsletterEmailObjectIDs)
+          } else {
+            continuation.resume(throwing: BasicError.message(messageText: "CoreData error"))
           }
+        case .error:
+          continuation.resume(throwing: BasicError.message(messageText: "Newsletter Email fetch error"))
         }
       }
     }
-    .receive(on: DispatchQueue.main)
-    .eraseToAnyPublisher()
   }
 }

--- a/apple/OmnivoreKit/Sources/Services/InternalModels/InternalNewsletterEmail.swift
+++ b/apple/OmnivoreKit/Sources/Services/InternalModels/InternalNewsletterEmail.swift
@@ -56,20 +56,3 @@ extension Sequence where Element == InternalNewsletterEmail {
     return result
   }
 }
-
-extension NewsletterEmail {
-  static func lookup(byID emailID: String, inContext context: NSManagedObjectContext) -> NewsletterEmail? {
-    let fetchRequest: NSFetchRequest<Models.NewsletterEmail> = NewsletterEmail.fetchRequest()
-    fetchRequest.predicate = NSPredicate(
-      format: "%K == %@", #keyPath(NewsletterEmail.emailId), emailID
-    )
-
-    var email: NewsletterEmail?
-
-    context.performAndWait {
-      email = (try? context.fetch(fetchRequest))?.first
-    }
-
-    return email
-  }
-}

--- a/apple/OmnivoreKit/Sources/Utils/FeatureFlags.swift
+++ b/apple/OmnivoreKit/Sources/Utils/FeatureFlags.swift
@@ -14,6 +14,4 @@ public enum FeatureFlag {
   public static let enablePushNotifications = false
   public static let enableShareButton = false
   public static let enableSnooze = false
-  public static let enableLabels = true
-  public static let useLocalWebView = true
 }

--- a/apple/OmnivoreKit/Sources/Views/FeedItem/GridCard.swift
+++ b/apple/OmnivoreKit/Sources/Views/FeedItem/GridCard.swift
@@ -149,20 +149,16 @@ public struct GridCard: View {
         .onTapGesture { tapHandler() }
 
         // Category Labels
-        if FeatureFlag.enableLabels {
-          ScrollView(.horizontal, showsIndicators: false) {
-            HStack {
-              ForEach(item.labels.asArray(of: LinkedItemLabel.self), id: \.self) {
-                TextChip(feedItemLabel: $0)
-              }
-              Spacer()
+        ScrollView(.horizontal, showsIndicators: false) {
+          HStack {
+            ForEach(item.labels.asArray(of: LinkedItemLabel.self), id: \.self) {
+              TextChip(feedItemLabel: $0)
             }
-            .frame(height: 30)
-            .padding(.horizontal)
-            .padding(.bottom, 8)
+            Spacer()
           }
-        } else {
-          Spacer(minLength: 8)
+          .frame(height: 30)
+          .padding(.horizontal)
+          .padding(.bottom, 8)
         }
       }
       .background(


### PR DESCRIPTION
Moved the modifier onto NavLink to make sure it's always applied. It can get lost of we apply it further down the tree (according to other comments I found online). Seems to fix it. Haven't reproduced the bug again.

Also fixed the mac app and converted some combine funds to async.