### PR TITLE
Move the analytics event for link_read out of the container, supply userId

### DIFF
--- a/packages/web/components/templates/article/ArticleContainer.tsx
+++ b/packages/web/components/templates/article/ArticleContainer.tsx
@@ -79,14 +79,6 @@ export function ArticleContainer(props: ArticleContainerProps): JSX.Element {
     }
   })
 
-  useEffect(() => {
-    window.analytics?.track('link_read', {
-      link: props.article.id,
-      slug: props.article.slug,
-      url: props.article.originalArticleUrl,
-    })
-  }, [props.article])
-
   const styles = {
     fontSize,
     margin: props.margin ?? 360,

--- a/packages/web/pages/[username]/[slug]/index.tsx
+++ b/packages/web/pages/[username]/[slug]/index.tsx
@@ -107,6 +107,17 @@ export default function Home(): JSX.Element {
     })
   )
 
+  useEffect(() => {
+    if (article && viewerData?.me) {
+      window.analytics?.track('link_read', {
+        link: article.id,
+        slug: article.slug,
+        url: article.originalArticleUrl,
+        userId: viewerData.me.id
+      })
+    }
+  }, [article, viewerData])
+
   return (
     <PrimaryLayout
       pageTestId="home-page-tag"


### PR DESCRIPTION
This prevents events from being sent when there is no user id yet
due to race conditions in analytics setup.
