### PR TITLE
Allow looking up articles by ID

### DIFF
--- a/packages/api/src/resolvers/article/index.ts
+++ b/packages/api/src/resolvers/article/index.ts
@@ -426,7 +426,9 @@ export const getArticleResolver: ResolverFn<
     })
     await createIntercomEvent('get-article', claims.uid)
 
-    const page = await getPageByParam({ userId: claims.uid, slug })
+    // We allow the backend to use the ID instead of a slug to fetch the article
+    const page = await getPageByParam({ userId: claims.uid, slug }) || await getPageByParam({ userId: claims.uid, _id: slug })
+
     if (!page) {
       return { errorCodes: [ArticleErrorCode.NotFound] }
     }

--- a/packages/api/src/resolvers/article/index.ts
+++ b/packages/api/src/resolvers/article/index.ts
@@ -427,7 +427,9 @@ export const getArticleResolver: ResolverFn<
     await createIntercomEvent('get-article', claims.uid)
 
     // We allow the backend to use the ID instead of a slug to fetch the article
-    const page = await getPageByParam({ userId: claims.uid, slug }) || await getPageByParam({ userId: claims.uid, _id: slug })
+    const page =
+      (await getPageByParam({ userId: claims.uid, slug })) ||
+      (await getPageByParam({ userId: claims.uid, _id: slug }))
 
     if (!page) {
       return { errorCodes: [ArticleErrorCode.NotFound] }


### PR DESCRIPTION
iOS needs to be able to lookup an article by its ID not its
slug, because the slug can change once saved.
