### PR TITLE
Pending item support - iOS/macOS

### DIFF
--- a/apple/Omnivore.xcodeproj/project.pbxproj
+++ b/apple/Omnivore.xcodeproj/project.pbxproj
@@ -1261,7 +1261,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 12.0;
-				MARKETING_VERSION = 1.5.0;
+				MARKETING_VERSION = 1.6.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "app.omnivore.app.ShareExtension-Mac";
@@ -1292,7 +1292,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 12.0;
-				MARKETING_VERSION = 1.5.0;
+				MARKETING_VERSION = 1.6.0;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "app.omnivore.app.ShareExtension-Mac";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1374,7 +1374,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 12.0;
-				MARKETING_VERSION = 1.5.0;
+				MARKETING_VERSION = 1.6.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = app.omnivore.app;
@@ -1408,7 +1408,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 12.0;
-				MARKETING_VERSION = 1.5.0;
+				MARKETING_VERSION = 1.6.0;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = app.omnivore.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1463,7 +1463,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.5.0;
+				MARKETING_VERSION = 1.6.0;
 				PRODUCT_BUNDLE_IDENTIFIER = app.omnivore.app;
 				PRODUCT_NAME = Omnivore;
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1495,7 +1495,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.5.0;
+				MARKETING_VERSION = 1.6.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				OTHER_LDFLAGS = (
@@ -1534,7 +1534,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.5.0;
+				MARKETING_VERSION = 1.6.0;
 				MTL_FAST_MATH = YES;
 				OTHER_LDFLAGS = (
 					"-framework",
@@ -1573,7 +1573,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 12.0;
-				MARKETING_VERSION = 1.5.0;
+				MARKETING_VERSION = 1.6.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				OTHER_LDFLAGS = (
@@ -1611,7 +1611,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 12.0;
-				MARKETING_VERSION = 1.5.0;
+				MARKETING_VERSION = 1.6.0;
 				MTL_FAST_MATH = YES;
 				OTHER_LDFLAGS = (
 					"-framework",
@@ -1696,7 +1696,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.5.0;
+				MARKETING_VERSION = 1.6.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "app.omnivore.app.share-extension";
 				PRODUCT_NAME = ShareExtension;
 				SDKROOT = iphoneos;
@@ -1750,7 +1750,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.5.0;
+				MARKETING_VERSION = 1.6.0;
 				PRODUCT_BUNDLE_IDENTIFIER = app.omnivore.app;
 				PRODUCT_NAME = Omnivore;
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1778,7 +1778,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.5.0;
+				MARKETING_VERSION = 1.6.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "app.omnivore.app.share-extension";
 				PRODUCT_NAME = ShareExtension;
 				SDKROOT = iphoneos;

--- a/apple/OmnivoreKit/Sources/App/Views/Home/HomeFeedViewModel.swift
+++ b/apple/OmnivoreKit/Sources/App/Views/Home/HomeFeedViewModel.swift
@@ -80,7 +80,7 @@ import Views
       isLoading = false
       receivedIdx = thisSearchIdx
       cursor = queryResult.cursor
-      await dataService.prefetchPages(itemSlugs: newItems.map(\.unwrappedSlug))
+      await dataService.prefetchPages(itemIDs: newItems.map(\.unwrappedID))
     } else if searchTermIsEmpty {
       await dataService.viewContext.perform {
         let fetchRequest: NSFetchRequest<Models.LinkedItem> = LinkedItem.fetchRequest()

--- a/apple/OmnivoreKit/Sources/App/Views/WebReader/WebReaderContainer.swift
+++ b/apple/OmnivoreKit/Sources/App/Views/WebReader/WebReaderContainer.swift
@@ -190,7 +190,7 @@ import WebKit
           Color.clear
             .contentShape(Rectangle())
             .task {
-              await viewModel.loadContent(dataService: dataService, slug: item.unwrappedSlug)
+              await viewModel.loadContent(dataService: dataService, itemID: item.unwrappedID)
             }
         }
         if showFontSizePopover {

--- a/apple/OmnivoreKit/Sources/App/Views/WebReader/WebReaderContainer.swift
+++ b/apple/OmnivoreKit/Sources/App/Views/WebReader/WebReaderContainer.swift
@@ -187,8 +187,8 @@ import WebKit
             )
           }
         } else {
-          Color.clear
-            .contentShape(Rectangle())
+          Text(viewModel.contentFetchFailed ? "Unable to fetch content." : "Processing...")
+            .padding()
             .task {
               await viewModel.loadContent(dataService: dataService, itemID: item.unwrappedID)
             }

--- a/apple/OmnivoreKit/Sources/App/Views/WebReader/WebReaderViewModel.swift
+++ b/apple/OmnivoreKit/Sources/App/Views/WebReader/WebReaderViewModel.swift
@@ -10,7 +10,7 @@ struct SafariWebLink: Identifiable {
 
 @MainActor final class WebReaderViewModel: ObservableObject {
   @Published var articleContent: ArticleContent?
-  @Published var contentFetchFailed = false // update UI to reflect this
+  @Published var contentFetchFailed = false
 
   func loadContent(dataService: DataService, itemID: String) async {
     contentFetchFailed = false

--- a/apple/OmnivoreKit/Sources/App/Views/WebReader/WebReaderViewModel.swift
+++ b/apple/OmnivoreKit/Sources/App/Views/WebReader/WebReaderViewModel.swift
@@ -10,13 +10,16 @@ struct SafariWebLink: Identifiable {
 
 @MainActor final class WebReaderViewModel: ObservableObject {
   @Published var articleContent: ArticleContent?
+  @Published var contentFetchFailed = false // update UI to reflect this
 
-  var slug: String?
+  func loadContent(dataService: DataService, itemID: String) async {
+    contentFetchFailed = false
 
-  func loadContent(dataService: DataService, slug: String) async {
-    self.slug = slug
-    guard let username = dataService.currentViewer?.username else { return }
-    articleContent = try? await dataService.articleContent(username: username, slug: slug, useCache: true)
+    do {
+      articleContent = try await dataService.fetchArticleContent(itemID: itemID)
+    } catch {
+      contentFetchFailed = true
+    }
   }
 
   func createHighlight(

--- a/apple/OmnivoreKit/Sources/Models/DataModels/ArticleContent.swift
+++ b/apple/OmnivoreKit/Sources/Models/DataModels/ArticleContent.swift
@@ -1,14 +1,24 @@
 import Foundation
 
+public enum ArticleContentStatus {
+  case failed
+  case processing
+  case succeeded
+  case unknown
+}
+
 public struct ArticleContent {
   public let htmlContent: String
   public let highlightsJSONString: String
+  public let contentStatus: ArticleContentStatus
 
   public init(
     htmlContent: String,
-    highlightsJSONString: String
+    highlightsJSONString: String,
+    contentStatus: ArticleContentStatus
   ) {
     self.htmlContent = htmlContent
     self.highlightsJSONString = highlightsJSONString
+    self.contentStatus = contentStatus
   }
 }

--- a/apple/OmnivoreKit/Sources/Services/DataService/Queries/LibraryItemsQuery.swift
+++ b/apple/OmnivoreKit/Sources/Services/DataService/Queries/LibraryItemsQuery.swift
@@ -44,6 +44,7 @@ public extension DataService {
       try $0.articles(
         after: OptionalArgument(cursor),
         first: OptionalArgument(limit),
+        includePending: OptionalArgument(true),
         query: OptionalArgument(searchQuery),
         sharedOnly: .present(false),
         sort: OptionalArgument(


### PR DESCRIPTION
Adds support for retries for link content. If the server returns content with a `.processing` state then we try again after a delay. 

Just adds basic UI to reflect the states. We'll need to implement grid and list cells to reflect the pending state of the content. Also add a loading and error state to the web reader view.