### PR TITLE
Pending content loading

### DIFF
--- a/apple/OmnivoreKit/Sources/App/Views/WebReader/WebReaderContainer.swift
+++ b/apple/OmnivoreKit/Sources/App/Views/WebReader/WebReaderContainer.swift
@@ -15,6 +15,7 @@ import WebKit
     @State private var navBarVisibilityRatio = 1.0
     @State private var showDeleteConfirmation = false
     @State private var showOverlay = true
+    @State private var progressViewOpacity = 0.0
     @State var increaseFontActionID: UUID?
     @State var decreaseFontActionID: UUID?
     @State var annotationSaveTransactionID: UUID?
@@ -186,9 +187,16 @@ import WebKit
               }
             )
           }
+        } else if let errorMessage = viewModel.errorMessage {
+          Text(errorMessage).padding()
         } else {
-          Text(viewModel.contentFetchFailed ? "Unable to fetch content." : "Processing...")
-            .padding()
+          ProgressView()
+            .opacity(progressViewOpacity)
+            .onAppear {
+              DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(1000)) {
+                progressViewOpacity = 1
+              }
+            }
             .task {
               await viewModel.loadContent(dataService: dataService, itemID: item.unwrappedID)
             }

--- a/apple/OmnivoreKit/Sources/App/Views/WebReader/WebReaderContainer.swift
+++ b/apple/OmnivoreKit/Sources/App/Views/WebReader/WebReaderContainer.swift
@@ -14,7 +14,6 @@ import WebKit
     @State var safariWebLink: SafariWebLink?
     @State private var navBarVisibilityRatio = 1.0
     @State private var showDeleteConfirmation = false
-    @State private var showOverlay = true
     @State private var progressViewOpacity = 0.0
     @State var increaseFontActionID: UUID?
     @State var decreaseFontActionID: UUID?
@@ -156,21 +155,6 @@ import WebKit
             decreaseFontActionID: $decreaseFontActionID,
             annotationSaveTransactionID: $annotationSaveTransactionID,
             annotation: $annotation
-          )
-          .overlay(
-            Group {
-              if showOverlay {
-                Color.systemBackground
-                  .transition(.opacity)
-                  .onAppear {
-                    DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(100)) {
-                      withAnimation(.linear(duration: 0.2)) {
-                        showOverlay = false
-                      }
-                    }
-                  }
-              }
-            }
           )
           .sheet(item: $safariWebLink) {
             SafariView(url: $0.url)

--- a/apple/OmnivoreKit/Sources/App/Views/WebReader/WebReaderViewModel.swift
+++ b/apple/OmnivoreKit/Sources/App/Views/WebReader/WebReaderViewModel.swift
@@ -10,15 +10,16 @@ struct SafariWebLink: Identifiable {
 
 @MainActor final class WebReaderViewModel: ObservableObject {
   @Published var articleContent: ArticleContent?
-  @Published var contentFetchFailed = false
+  @Published var errorMessage: String?
 
   func loadContent(dataService: DataService, itemID: String) async {
-    contentFetchFailed = false
+    errorMessage = nil
 
     do {
       articleContent = try await dataService.fetchArticleContent(itemID: itemID)
     } catch {
-      contentFetchFailed = true
+      // TODO: check if this is a network or parsing error
+      errorMessage = "Unable to extract your content."
     }
   }
 

--- a/apple/OmnivoreKit/Sources/App/Views/WebReader/WebReaderViewModel.swift
+++ b/apple/OmnivoreKit/Sources/App/Views/WebReader/WebReaderViewModel.swift
@@ -18,8 +18,16 @@ struct SafariWebLink: Identifiable {
     do {
       articleContent = try await dataService.fetchArticleContent(itemID: itemID)
     } catch {
-      // TODO: check if this is a network or parsing error
-      errorMessage = "Unable to extract your content."
+      if let fetchError = error as? ContentFetchError {
+        switch fetchError {
+        case .network:
+          errorMessage = "We were unable to retrieve your content. Please ccheck network connectivity and try again."
+        default:
+          errorMessage = "We were unable to parse your content."
+        }
+      } else {
+        errorMessage = "We were unable to retrieve your content."
+      }
     }
   }
 

--- a/apple/OmnivoreKit/Sources/Models/ErrorModels/SaveArticleError.swift
+++ b/apple/OmnivoreKit/Sources/Models/ErrorModels/SaveArticleError.swift
@@ -1,5 +1,7 @@
 import Foundation
 
+public typealias ContentFetchError = SaveArticleError
+
 public enum SaveArticleError: Error {
   case unauthorized
   case network


### PR DESCRIPTION
- Show a loading indicator after a delay of one second
- Surface either a parsing error message or network message if article content can't be loaded
- Remove the loading overlay (since the article is usually loaded either instantly or after a few seconds).