### PR TITLE
Support grid style cards on iphone

### DIFF
--- a/apple/OmnivoreKit/Sources/App/Views/Home/HomeFeedViewIOS.swift
+++ b/apple/OmnivoreKit/Sources/App/Views/Home/HomeFeedViewIOS.swift
@@ -8,7 +8,7 @@ import Views
 #if os(iOS)
   struct HomeFeedContainerView: View {
     @EnvironmentObject var dataService: DataService
-    @AppStorage(UserDefaultKey.homeFeedlayoutPreference.rawValue) var prefersListLayout = UIDevice.isIPhone
+    @AppStorage(UserDefaultKey.homeFeedlayoutPreference.rawValue) var prefersListLayout = false
     @ObservedObject var viewModel: HomeFeedViewModel
 
     func loadItems(isRefresh: Bool) {
@@ -48,6 +48,40 @@ import Views
         }
         .sheet(item: $viewModel.itemUnderLabelEdit) { item in
           ApplyLabelsView(mode: .item(item), onSave: nil)
+        }
+        .toolbar {
+          ToolbarItem(placement: .barTrailing) {
+            Button("", action: {})
+              .disabled(true)
+              .overlay {
+                if viewModel.isLoading, !prefersListLayout {
+                  ProgressView()
+                }
+              }
+          }
+          ToolbarItem(placement: UIDevice.isIPhone ? .barLeading : .barTrailing) {
+            Button(
+              action: { prefersListLayout.toggle() },
+              label: {
+                Label("Toggle Feed Layout", systemImage: prefersListLayout ? "square.grid.2x2" : "list.bullet")
+              }
+            )
+          }
+          ToolbarItem(placement: .barTrailing) {
+            if UIDevice.isIPhone {
+              NavigationLink(
+                destination: { ProfileView() },
+                label: {
+                  Image.profile
+                    .resizable()
+                    .frame(width: 26, height: 26)
+                    .padding(.vertical)
+                }
+              )
+            } else {
+              EmptyView()
+            }
+          }
         }
       }
       .navigationTitle("Home")
@@ -119,27 +153,6 @@ import Views
           HomeFeedListView(prefersListLayout: $prefersListLayout, viewModel: viewModel)
         } else {
           HomeFeedGridView(viewModel: viewModel)
-            .toolbar {
-              ToolbarItem {
-                Button("", action: {})
-                  .disabled(true)
-                  .overlay {
-                    if viewModel.isLoading {
-                      ProgressView()
-                    }
-                  }
-              }
-              ToolbarItem {
-                if UIDevice.isIPad {
-                  Button(
-                    action: { prefersListLayout.toggle() },
-                    label: {
-                      Label("Toggle Feed Layout", systemImage: prefersListLayout ? "square.grid.2x2" : "list.bullet")
-                    }
-                  )
-                }
-              }
-            }
         }
       }
     }
@@ -256,18 +269,6 @@ import Views
         }
       }
       .listStyle(PlainListStyle())
-      .toolbar {
-        ToolbarItem {
-          if UIDevice.isIPad {
-            Button(
-              action: { prefersListLayout.toggle() },
-              label: {
-                Label("Toggle Feed Layout", systemImage: prefersListLayout ? "square.grid.2x2" : "list.bullet")
-              }
-            )
-          }
-        }
-      }
     }
   }
 

--- a/apple/OmnivoreKit/Sources/App/Views/Home/HomeView.swift
+++ b/apple/OmnivoreKit/Sources/App/Views/Home/HomeView.swift
@@ -8,19 +8,6 @@ struct HomeView: View {
       if UIDevice.isIPhone {
         NavigationView {
           HomeFeedContainerView(viewModel: viewModel)
-            .toolbar {
-              ToolbarItem {
-                NavigationLink(
-                  destination: { ProfileView() },
-                  label: {
-                    Image.profile
-                      .resizable()
-                      .frame(width: 26, height: 26)
-                      .padding()
-                  }
-                )
-              }
-            }
         }
         .accentColor(.appGrayTextContrast)
       } else {


### PR DESCRIPTION
Added a button on the left side of the nav bar to toggle between layout types. A few more things we could do:

- Rework the grid card layout to display the entire title
- Remove images from the list card style to make it more compact