### PR TITLE
Fix card label display issues [iOS]

### DIFF
--- a/apple/OmnivoreKit/Sources/App/Views/Labels/LabelsViewModel.swift
+++ b/apple/OmnivoreKit/Sources/App/Views/Labels/LabelsViewModel.swift
@@ -22,7 +22,7 @@ import Views
       dataService.viewContext.performAndWait {
         self.labels = labelIDs.compactMap { dataService.viewContext.object(with: $0) as? LinkedItemLabel }
       }
-      let selLabels = initiallySelectedLabels ?? item?.labels.asArray(of: LinkedItemLabel.self) ?? []
+      let selLabels = initiallySelectedLabels ?? item?.sortedLabels ?? []
       for label in labels {
         if selLabels.contains(label) {
           selectedLabels.append(label)

--- a/apple/OmnivoreKit/Sources/Models/DataModels/FeedItem.swift
+++ b/apple/OmnivoreKit/Sources/Models/DataModels/FeedItem.swift
@@ -58,6 +58,12 @@ public extension LinkedItem {
     return URL(string: pageURLString ?? "")
   }
 
+  var sortedLabels: [LinkedItemLabel] {
+    labels.asArray(of: LinkedItemLabel.self).sorted {
+      ($0.name ?? "").lowercased() < ($1.name ?? "").lowercased()
+    }
+  }
+
   var labelsJSONString: String {
     let labels = self.labels.asArray(of: LinkedItemLabel.self).map { label in
       [

--- a/apple/OmnivoreKit/Sources/Views/FeedItem/GridCard.swift
+++ b/apple/OmnivoreKit/Sources/Views/FeedItem/GridCard.swift
@@ -156,7 +156,6 @@ public struct GridCard: View {
             }
             Spacer()
           }
-          .frame(height: 30)
           .padding(.horizontal)
           .padding(.bottom, 8)
         }

--- a/apple/OmnivoreKit/Sources/Views/FeedItem/GridCard.swift
+++ b/apple/OmnivoreKit/Sources/Views/FeedItem/GridCard.swift
@@ -151,7 +151,7 @@ public struct GridCard: View {
         // Category Labels
         ScrollView(.horizontal, showsIndicators: false) {
           HStack {
-            ForEach(item.labels.asArray(of: LinkedItemLabel.self), id: \.self) {
+            ForEach(item.sortedLabels, id: \.self) {
               TextChip(feedItemLabel: $0)
             }
             Spacer()

--- a/apple/OmnivoreKit/Sources/Views/FeedItem/HomeFeedCardView.swift
+++ b/apple/OmnivoreKit/Sources/Views/FeedItem/HomeFeedCardView.swift
@@ -67,7 +67,7 @@ public struct FeedCard: View {
       // Category Labels
       ScrollView(.horizontal, showsIndicators: false) {
         HStack {
-          ForEach(item.labels.asArray(of: LinkedItemLabel.self), id: \.self) {
+          ForEach(item.sortedLabels, id: \.self) {
             TextChip(feedItemLabel: $0)
           }
           Spacer()

--- a/apple/OmnivoreKit/Sources/Views/TextChip.swift
+++ b/apple/OmnivoreKit/Sources/Views/TextChip.swift
@@ -26,8 +26,7 @@ public struct TextChip: View {
       .font(.appFootnote)
       .foregroundColor(color.isDark ? .white : .black)
       .lineLimit(1)
-      .background(color)
-      .cornerRadius(cornerRadius)
+      .background(Capsule().fill(color))
   }
 }
 

--- a/apple/OmnivoreKit/Sources/Views/TextChip.swift
+++ b/apple/OmnivoreKit/Sources/Views/TextChip.swift
@@ -17,7 +17,6 @@ public struct TextChip: View {
 
   let text: String
   let color: Color
-  let cornerRadius = 20.0
 
   public var body: some View {
     Text(text)
@@ -85,7 +84,6 @@ public struct TextChipButton: View {
   let color: Color
   let onTap: () -> Void
   let actionType: ActionType
-  let cornerRadius = 20.0
   let foregroundColor: Color
 
   public var body: some View {
@@ -101,8 +99,7 @@ public struct TextChipButton: View {
         .font(.appFootnote)
         .foregroundColor(foregroundColor)
         .lineLimit(1)
-        .background(color)
-        .cornerRadius(cornerRadius)
+        .background(Capsule().fill(color))
 
         Color.clear.contentShape(Rectangle()).frame(height: 15)
       }


### PR DESCRIPTION
Displays labels in alphabetical order so we render the card in a consistent way. Also fixes a bug where the label chip can become distorted when the context menu is active.