### PR TITLE
Store sqlite file in app group file container [iOS]

### DIFF
--- a/apple/OmnivoreKit/Sources/Models/CoreData/StorageProvider.swift
+++ b/apple/OmnivoreKit/Sources/Models/CoreData/StorageProvider.swift
@@ -12,6 +12,13 @@ public class PersistentContainer: NSPersistentContainer {
     let model = NSManagedObjectModel(contentsOf: modelURL)!
     let container = PersistentContainer(name: "DataModel", managedObjectModel: model)
 
+    // Store the sqlite file in the app group container.
+    // This allows shared access for app and app extensions.
+    let appGroupID = "group.app.omnivoreapp"
+    let appGroupContainer = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: appGroupID)
+    let appGroupContainerURL = appGroupContainer?.appendingPathComponent("store.sqlite")
+    container.persistentStoreDescriptions.first!.url = appGroupContainerURL
+
     container.viewContext.automaticallyMergesChangesFromParent = true
     container.viewContext.name = "viewContext"
     container.viewContext.mergePolicy = NSMergePolicy.mergeByPropertyObjectTrump


### PR DESCRIPTION
This allows us to access the core data container from the share extension. 

If we want to support batch operations then there's more work involved with setting up persistent history tracking and notifications. I think can avoid that for now and revisit when we want to optimize.