### PR TITLE
If parsing fails, attempt adding <html> wrappers to a document

### DIFF
--- a/packages/api/src/utils/parser.ts
+++ b/packages/api/src/utils/parser.ts
@@ -205,7 +205,8 @@ const applyHandlers = async (
 export const parsePreparedContent = async (
   url: string,
   preparedDocument: PreparedDocumentInput,
-  isNewsletter?: boolean
+  isNewsletter?: boolean,
+  allowRetry = true
 ): Promise<ParsedContentPuppeteer> => {
   const logRecord: ArticleParseLogRecord = {
     url: url,
@@ -236,6 +237,10 @@ export const parsePreparedContent = async (
 
   try {
     article = getReadabilityResult(url, document, dom, isNewsletter)
+    if (!article?.textContent && allowRetry) {
+      const newDocument = { ...preparedDocument, document: '<html>' + preparedDocument.document + '</html>' }
+      return parsePreparedContent(url, newDocument, isNewsletter, false)
+    }
 
     // Format code blocks
     // TODO: we probably want to move this type of thing

--- a/packages/api/src/utils/parser.ts
+++ b/packages/api/src/utils/parser.ts
@@ -238,7 +238,10 @@ export const parsePreparedContent = async (
   try {
     article = getReadabilityResult(url, document, dom, isNewsletter)
     if (!article?.textContent && allowRetry) {
-      const newDocument = { ...preparedDocument, document: '<html>' + preparedDocument.document + '</html>' }
+      const newDocument = {
+        ...preparedDocument,
+        document: '<html>' + preparedDocument.document + '</html>',
+      }
       return parsePreparedContent(url, newDocument, isNewsletter, false)
     }
 


### PR DESCRIPTION
LinkedDom seems less forgiving and expects the outerHTML of a
document, however older extension versions still send innerHTML.
