### PR TITLE
iOS background fetch

### DIFF
--- a/apple/InfoPlists/Omnivore.plist
+++ b/apple/InfoPlists/Omnivore.plist
@@ -48,6 +48,10 @@
 	<string>Images from documents and annotations can be saved to the photo library.</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>Images from your photo library can be chosen by you to send as feedback.</string>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>fetch</string>
+	</array>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>

--- a/apple/InfoPlists/Omnivore.plist
+++ b/apple/InfoPlists/Omnivore.plist
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>BGTaskSchedulerPermittedIdentifiers</key>
+	<array>
+		<string>app.omnivore.fetchLinkedItems</string>
+	</array>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>

--- a/apple/OmnivoreKit/Sources/App/Services.swift
+++ b/apple/OmnivoreKit/Sources/App/Services.swift
@@ -1,8 +1,14 @@
+import BackgroundTasks
 import Foundation
 import Models
+import OSLog
 import Services
 
 public final class Services {
+  static let fetchTaskID = "app.omnivore.fetchLinkedItems"
+  static let secondsToWaitBeforeNextBackgroundRefresh: TimeInterval = 3 // 1 hour
+  static let logger = Logger(subsystem: "app.omnivore", category: "services-class")
+
   public let authenticator: Authenticator
   public let dataService: DataService
 
@@ -10,5 +16,54 @@ public final class Services {
     let networker = Networker(appEnvironment: appEnvironment)
     self.authenticator = Authenticator(networker: networker)
     self.dataService = DataService(appEnvironment: appEnvironment, networker: networker)
+  }
+}
+
+// Background fetching functions
+extension Services {
+  public static func registerBackgroundFetch() {
+    BGTaskScheduler.shared.register(forTaskWithIdentifier: fetchTaskID, using: nil) { task in
+      if let task = task as? BGAppRefreshTask {
+        startBackgroundFetch(task: task)
+      }
+    }
+  }
+
+  static func scheduleBackgroundFetch() {
+    let taskRequest = BGProcessingTaskRequest(identifier: fetchTaskID)
+    taskRequest.requiresNetworkConnectivity = true
+    taskRequest.earliestBeginDate = Date(timeIntervalSinceNow: secondsToWaitBeforeNextBackgroundRefresh)
+
+    do {
+      try BGTaskScheduler.shared.submit(taskRequest)
+      logger.debug("\(fetchTaskID) task scheduled")
+    } catch {
+      logger.debug("task scheduling failed: \(fetchTaskID)")
+    }
+  }
+
+  static func startBackgroundFetch(task: BGAppRefreshTask) {
+    scheduleBackgroundFetch()
+    let services = Services()
+
+    task.expirationHandler = {
+      logger.debug("handling background fetch expiration")
+      // cancel tasks if still running
+      // maybe save/cancel pending changes to coredata context?
+    }
+
+    services.peformBackgroundFetch()
+  }
+  
+  func peformBackgroundFetch() {
+    Services.logger.debug("starting background fetch")
+
+    guard authenticator.hasValidAuthToken else {
+      Services.logger.debug("background fetch failed: user does not habe a valid auth token")
+      authenticator.logout()
+      return
+    }
+
+    // TODO: perform tasks using data service
   }
 }

--- a/apple/OmnivoreKit/Sources/App/Services.swift
+++ b/apple/OmnivoreKit/Sources/App/Services.swift
@@ -24,14 +24,15 @@ extension Services {
   public static func registerBackgroundFetch() {
     BGTaskScheduler.shared.register(forTaskWithIdentifier: fetchTaskID, using: nil) { task in
       if let task = task as? BGAppRefreshTask {
+        logger.debug("in background task register closure")
         startBackgroundFetch(task: task)
       }
     }
   }
 
   static func scheduleBackgroundFetch() {
-    let taskRequest = BGProcessingTaskRequest(identifier: fetchTaskID)
-    taskRequest.requiresNetworkConnectivity = true
+    BGTaskScheduler.shared.cancelAllTaskRequests()
+    let taskRequest = BGAppRefreshTaskRequest(identifier: fetchTaskID)
     taskRequest.earliestBeginDate = Date(timeIntervalSinceNow: secondsToWaitBeforeNextBackgroundRefresh)
 
     do {
@@ -53,17 +54,20 @@ extension Services {
     }
 
     services.peformBackgroundFetch()
+    task.setTaskCompleted(success: true)
   }
-  
+
   func peformBackgroundFetch() {
     Services.logger.debug("starting background fetch")
 
     guard authenticator.hasValidAuthToken else {
       Services.logger.debug("background fetch failed: user does not habe a valid auth token")
-      authenticator.logout()
       return
     }
 
+    Services.logger.debug("ayo this is a background task!")
     // TODO: perform tasks using data service
   }
 }
+
+// e -l objc -- (void)[[BGTaskScheduler sharedScheduler] _simulateLaunchForTaskWithIdentifier:@"app.omnivore.fetchLinkedItems"]

--- a/apple/OmnivoreKit/Sources/App/Services.swift
+++ b/apple/OmnivoreKit/Sources/App/Services.swift
@@ -3,10 +3,11 @@ import Foundation
 import Models
 import OSLog
 import Services
+import Utils
 
 public final class Services {
   static let fetchTaskID = "app.omnivore.fetchLinkedItems"
-  static let secondsToWaitBeforeNextBackgroundRefresh: TimeInterval = 3 // 1 hour
+  static let secondsToWaitBeforeNextBackgroundRefresh: TimeInterval = isDebug ? 0 : 3600 // 1 hour
   static let logger = Logger(subsystem: "app.omnivore", category: "services-class")
 
   public let authenticator: Authenticator
@@ -24,6 +25,7 @@ extension Services {
   public static func registerBackgroundFetch() {
     BGTaskScheduler.shared.register(forTaskWithIdentifier: fetchTaskID, using: nil) { task in
       if let task = task as? BGAppRefreshTask {
+        EventTracker.trackForDebugging("executing app.omnivore.fetchLinkedItems bg task")
         logger.debug("in background task register closure")
         startBackgroundFetch(task: task)
       }
@@ -48,12 +50,12 @@ extension Services {
     let services = Services()
 
     task.expirationHandler = {
+      EventTracker.trackForDebugging("background fetch expiration handler called")
       logger.debug("handling background fetch expiration")
-      // cancel tasks if still running
-      // maybe save/cancel pending changes to coredata context?
     }
 
     services.peformBackgroundFetch()
+    EventTracker.trackForDebugging("background fetch task completed successfully")
     task.setTaskCompleted(success: true)
   }
 
@@ -61,6 +63,7 @@ extension Services {
     Services.logger.debug("starting background fetch")
 
     guard authenticator.hasValidAuthToken else {
+      EventTracker.trackForDebugging("background fetch failed: user does not habe a valid auth token")
       Services.logger.debug("background fetch failed: user does not habe a valid auth token")
       return
     }

--- a/apple/OmnivoreKit/Sources/App/Views/Home/HomeFeedViewModel.swift
+++ b/apple/OmnivoreKit/Sources/App/Views/Home/HomeFeedViewModel.swift
@@ -98,7 +98,9 @@ import Views
       isLoading = false
       receivedIdx = thisSearchIdx
       cursor = queryResult.cursor
-      await dataService.prefetchPages(itemIDs: newItems.map(\.unwrappedID))
+      if let username = dataService.currentViewer?.username {
+        await dataService.prefetchPages(itemIDs: newItems.map(\.unwrappedID), username: username)
+      }
     } else {
       updateFetchController(dataService: dataService)
     }

--- a/apple/OmnivoreKit/Sources/App/Views/RootView/RootView.swift
+++ b/apple/OmnivoreKit/Sources/App/Views/RootView/RootView.swift
@@ -5,6 +5,7 @@ import Utils
 import Views
 
 public struct RootView: View {
+  @Environment(\.scenePhase) var scenePhase
   let pdfViewerProvider: ((URL, PDFViewerViewModel) -> AnyView)?
   @StateObject private var viewModel = RootViewModel()
 
@@ -29,6 +30,11 @@ public struct RootView: View {
       .onAppear {
         if let pdfViewerProvider = pdfViewerProvider {
           viewModel.configurePDFProvider(pdfViewerProvider: pdfViewerProvider)
+        }
+      }
+      .onChange(of: scenePhase) { phase in
+        if phase == .background {
+          Services.scheduleBackgroundFetch()
         }
       }
   }

--- a/apple/OmnivoreKit/Sources/Services/DataService/FetchLinkedItemsBackgroundTask.swift
+++ b/apple/OmnivoreKit/Sources/Services/DataService/FetchLinkedItemsBackgroundTask.swift
@@ -1,0 +1,57 @@
+import CoreData
+import Foundation
+import Models
+import SwiftGraphQL
+
+extension DataService {
+  public func fetchLinkedItemsBackgroundTask() async throws {
+    // Query the server for item IDs and compare against CoreData
+    // to see what we're missing
+    let missingItemIds = try await fetchMissingItemIDs()
+    guard !missingItemIds.isEmpty else { return }
+
+    let username: String? = await backgroundContext.perform(schedule: .immediate) {
+      let fetchRequest: NSFetchRequest<Models.Viewer> = Viewer.fetchRequest()
+      fetchRequest.fetchLimit = 1 // we should only have one viewer saved
+      return try? self.backgroundContext.fetch(fetchRequest).first?.username
+    }
+
+    guard let username = username else {
+      throw BasicError.message(messageText: "could not retrieve username from core data")
+    }
+
+    // Fetch the items
+    for itemID in missingItemIds { // TOOD: run these in parallel
+      logger.debug("fetching item with ID: \(itemID)")
+      _ = try await articleContent(username: username, itemID: itemID, useCache: false)
+      logger.debug("done fetching item with ID: \(itemID)")
+    }
+  }
+
+  func fetchMissingItemIDs(previouslyFetchedIDs: [String] = [], cursor: String? = nil) async throws -> [String] {
+    logger.debug("fetching more IDS: \(cursor ?? "no cursor")")
+    let maxItemCount = 30
+    let fetchResult = try await fetchLinkedItemIDs(limit: 10, cursor: cursor)
+    let newItemsToFetch = await itemsNotInStore(from: fetchResult.itemIDs)
+    let itemsToFetch = previouslyFetchedIDs + newItemsToFetch
+
+    if newItemsToFetch.isEmpty || itemsToFetch.count > maxItemCount || fetchResult.cursor == nil {
+      return itemsToFetch
+    } else {
+      return try await fetchMissingItemIDs(previouslyFetchedIDs: itemsToFetch, cursor: fetchResult.cursor)
+    }
+  }
+
+  func itemsNotInStore(from itemIDs: [String]) async -> [String] {
+    let fetchRequest: NSFetchRequest<Models.LinkedItem> = LinkedItem.fetchRequest()
+    fetchRequest.predicate = NSPredicate(format: "id IN %@", itemIDs)
+
+    return await backgroundContext.perform(schedule: .immediate) {
+      if let foundIDs = (try? self.backgroundContext.fetch(fetchRequest).map(\.unwrappedID)) {
+        return itemIDs.filter { !foundIDs.contains($0) }
+      } else {
+        return []
+      }
+    }
+  }
+}

--- a/apple/OmnivoreKit/Sources/Services/DataService/Queries/ArticleContentQuery.swift
+++ b/apple/OmnivoreKit/Sources/Services/DataService/Queries/ArticleContentQuery.swift
@@ -9,9 +9,9 @@ extension DataService {
     let retryCount: Int
   }
 
-  public func prefetchPages(itemIDs: [String]) async {
-    guard let username = currentViewer?.username else { return }
-
+  public func prefetchPages(itemIDs: [String], username: String) async {
+    // TODO: make this concurrent
+    // TODO: make a non-pending page option for BG tasks
     for itemID in itemIDs {
       await prefetchPage(pendingLink: PendingLink(itemID: itemID, retryCount: 1), username: username)
     }
@@ -183,9 +183,8 @@ extension DataService {
       let fetchRequest: NSFetchRequest<Models.LinkedItem> = LinkedItem.fetchRequest()
       fetchRequest.predicate = NSPredicate(format: "id == %@", item.id)
 
-      let linkedItem = try? self.backgroundContext.fetch(fetchRequest).first
-
-      guard let linkedItem = linkedItem else { return }
+      let existingItem = try? self.backgroundContext.fetch(fetchRequest).first
+      let linkedItem = existingItem ?? LinkedItem(entity: LinkedItem.entity(), insertInto: self.backgroundContext)
 
       let highlightObjects = highlights.map {
         $0.asManagedObject(context: self.backgroundContext)

--- a/apple/OmnivoreKit/Sources/Services/DataService/Queries/LinkedItemIDsQuery.swift
+++ b/apple/OmnivoreKit/Sources/Services/DataService/Queries/LinkedItemIDsQuery.swift
@@ -1,0 +1,67 @@
+import Foundation
+import Models
+import SwiftGraphQL
+
+extension DataService {
+  struct LinkedItemIDFetchResult {
+    let itemIDs: [String]
+    let cursor: String?
+  }
+
+  func fetchLinkedItemIDs(limit: Int, cursor: String?) async throws -> LinkedItemIDFetchResult {
+    enum QueryResult {
+      case success(result: LinkedItemIDFetchResult)
+      case error(error: String)
+    }
+
+    let articleIDSelection = Selection.SearchItemEdge {
+      try $0.node(selection: Selection.SearchItem { try $0.id() })
+    }
+
+    let selection = Selection<QueryResult, Unions.SearchResult> {
+      try $0.on(
+        searchError: .init {
+          QueryResult.error(error: try $0.errorCodes().description)
+        },
+        searchSuccess: .init {
+          QueryResult.success(
+            result: LinkedItemIDFetchResult(
+              itemIDs: try $0.edges(selection: articleIDSelection.list),
+              cursor: try $0.pageInfo(selection: Selection.PageInfo {
+                try $0.endCursor()
+              })
+            )
+          )
+        }
+      )
+    }
+
+    let query = Selection.Query {
+      try $0.search(
+        after: OptionalArgument(cursor),
+        first: OptionalArgument(limit),
+        query: OptionalArgument(nil),
+        selection: selection
+      )
+    }
+
+    let path = appEnvironment.graphqlPath
+    let headers = networker.defaultHeaders
+
+    return try await withCheckedThrowingContinuation { continuation in
+      send(query, to: path, headers: headers) { queryResult in
+        guard let payload = try? queryResult.get() else {
+          continuation.resume(throwing: BasicError.message(messageText: "network error"))
+          return
+        }
+
+        switch payload.data {
+        case let .success(result: result):
+          continuation.resume(returning: result)
+        case .error:
+          continuation.resume(throwing: BasicError.message(messageText: "LinkedItem fetch error"))
+        }
+      }
+    }
+  }
+}

--- a/apple/OmnivoreKit/Sources/Services/InternalModels/InternalLinkedItem.swift
+++ b/apple/OmnivoreKit/Sources/Services/InternalModels/InternalLinkedItem.swift
@@ -54,7 +54,6 @@ struct InternalLinkedItem {
 }
 
 extension Sequence where Element == InternalLinkedItem {
-  // TODO: -optimization use batch update?
   func persist(context: NSManagedObjectContext) -> [LinkedItem]? {
     var linkedItems: [LinkedItem]?
     context.performAndWait {

--- a/apple/OmnivoreKit/Sources/Utils/EventTracking/EventTracker.swift
+++ b/apple/OmnivoreKit/Sources/Utils/EventTracking/EventTracker.swift
@@ -7,6 +7,12 @@ public enum EventTracker {
     _ = segment?.version()
   }
 
+  public static func trackForDebugging(_ message: String) {
+    #if DEBUG
+      track(.debugMessage(message: message))
+    #endif
+  }
+
   public static func track(_ event: TrackableEvent) {
     segment?.track(name: event.name, properties: event.properties)
   }

--- a/apple/OmnivoreKit/Sources/Utils/EventTracking/TrackableEvents.swift
+++ b/apple/OmnivoreKit/Sources/Utils/EventTracking/TrackableEvents.swift
@@ -2,6 +2,7 @@ import Foundation
 
 public enum TrackableEvent {
   case linkRead(linkID: String, slug: String, originalArticleURL: String)
+  case debugMessage(message: String)
 }
 
 public extension TrackableEvent {
@@ -9,6 +10,8 @@ public extension TrackableEvent {
     switch self {
     case .linkRead:
       return "link_read"
+    case .debugMessage:
+      return "debug_message"
     }
   }
 
@@ -20,6 +23,8 @@ public extension TrackableEvent {
         "slug": slug,
         "url": originalArticleURL
       ]
+    case let .debugMessage(message: message):
+      return ["message": message]
     }
   }
 }

--- a/apple/Sources/AppDelegate.swift
+++ b/apple/Sources/AppDelegate.swift
@@ -1,11 +1,16 @@
+import OSLog
+
 #if os(macOS)
   import AppKit
 #elseif os(iOS)
+  import App
   import Intercom
   import UIKit
   import Utils
   import Views
 #endif
+
+private let logger = Logger(subsystem: "app.omnivore", category: "app-delegate")
 
 #if os(macOS)
   class AppDelegate: NSObject, NSApplicationDelegate {
@@ -20,11 +25,6 @@
 
 #elseif os(iOS)
   class AppDelegate: NSObject, UIApplicationDelegate {
-//    override init() {
-//      super.init()
-//      UIColor.classInit
-//    }
-
     // swiftlint:disable:next line_length
     func application(_: UIApplication, didFinishLaunchingWithOptions _: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
       #if DEBUG
@@ -45,6 +45,7 @@
         }
       }
 
+      Services.registerBackgroundFetch()
       configurePushNotifications()
       return true
     }


### PR DESCRIPTION
A few things/questions left:
- Adjust timing of BG task scheduling (right now it's set to wait at least an hour)
- Max items should we fetch? (right now it's 30)
- Do we need to fetch IDs 10 at a time as it is now? Or just ask for them all at once?
- Additional event tracking
- Performance optimizations (run requests in parallel. skip content fetches when user opens the app)