### PR TITLE
Reader mode refresh

### DIFF
--- a/apple/OmnivoreKit/Sources/App/Views/Home/HomeFeedViewIOS.swift
+++ b/apple/OmnivoreKit/Sources/App/Views/Home/HomeFeedViewIOS.swift
@@ -94,10 +94,7 @@ private let enableGrid = UIDevice.isIPad || FeatureFlag.enableGridCardsOnPhone
       .navigationTitle("Home")
       .navigationBarTitleDisplayMode(.inline)
       .onReceive(NotificationCenter.default.publisher(for: UIApplication.willEnterForegroundNotification)) { _ in
-        // Don't refresh the list if the user is currently reading an article
-        if viewModel.selectedLinkItem == nil || viewModel.linkRequest == nil {
-          loadItems(isRefresh: true)
-        }
+        loadItems(isRefresh: true)
       }
       .onReceive(NotificationCenter.default.publisher(for: Notification.Name("PushJSONArticle"))) { notification in
         guard let jsonArticle = notification.userInfo?["article"] as? JSONArticle else { return }

--- a/apple/OmnivoreKit/Sources/App/Views/Home/HomeFeedViewIOS.swift
+++ b/apple/OmnivoreKit/Sources/App/Views/Home/HomeFeedViewIOS.swift
@@ -128,7 +128,7 @@ private let enableGrid = UIDevice.isIPad || FeatureFlag.enableGridCardsOnPhone
           }
         }
       }
-      .onAppear { // TODO: use task instead
+      .task {
         if viewModel.items.isEmpty {
           loadItems(isRefresh: true)
         }


### PR DESCRIPTION
Now that it's CoreData driven we can update the library list while in reader mode (since core data uses the objectID as identity rather than the entire struct. So properties can change without causing identity to change).
