### PR TITLE
Save and filter by language

### DIFF
--- a/packages/api/src/elastic/pages.ts
+++ b/packages/api/src/elastic/pages.ts
@@ -17,7 +17,7 @@ import {
   SortBy,
   SortOrder,
   SortParams,
-  SubscriptionFilter,
+  TermFilter,
 } from '../utils/search'
 import { client, INDEX_ALIAS } from './index'
 import { EntityType } from '../datalayer/pubsub'
@@ -158,14 +158,13 @@ const appendDateFilters = (body: SearchBody, filters: DateFilter[]): void => {
   })
 }
 
-const appendSubscriptionFilter = (
-  body: SearchBody,
-  filter: SubscriptionFilter
-): void => {
-  body.query.bool.filter.push({
-    term: {
-      subscription: filter.name,
-    },
+const appendTermFilters = (body: SearchBody, filters: TermFilter[]): void => {
+  filters.forEach((filter) => {
+    body.query.bool.filter.push({
+      term: {
+        [filter.field]: filter.value,
+      },
+    })
   })
 }
 
@@ -338,7 +337,7 @@ export const searchPages = async (
     labelFilters: LabelFilter[]
     hasFilters: HasFilter[]
     dateFilters: DateFilter[]
-    subscriptionFilter?: SubscriptionFilter
+    termFilters?: TermFilter[]
     includePending?: boolean | null
   },
   userId: string
@@ -355,7 +354,7 @@ export const searchPages = async (
       inFilter = InFilter.ALL,
       hasFilters,
       dateFilters,
-      subscriptionFilter,
+      termFilters,
     } = args
     // default order is descending
     const sortOrder = sort?.order || SortOrder.DESCENDING
@@ -421,8 +420,8 @@ export const searchPages = async (
     if (dateFilters.length > 0) {
       appendDateFilters(body, dateFilters)
     }
-    if (subscriptionFilter) {
-      appendSubscriptionFilter(body, subscriptionFilter)
+    if (termFilters) {
+      appendTermFilters(body, termFilters)
     }
 
     if (!args.includePending) {

--- a/packages/api/src/elastic/types.ts
+++ b/packages/api/src/elastic/types.ts
@@ -203,6 +203,7 @@ export interface Page {
   unsubHttpUrl?: string
   state: ArticleSavingRequestStatus
   taskName?: string
+  language?: string
 }
 
 export interface SearchItem {

--- a/packages/api/src/elastic/types.ts
+++ b/packages/api/src/elastic/types.ts
@@ -17,6 +17,7 @@ export interface SearchBody {
             }
           }
         | { term: { pageType: string } }
+        | { term: { language: string } }
         | { exists: { field: string } }
         | {
             range: {

--- a/packages/api/src/elastic/types.ts
+++ b/packages/api/src/elastic/types.ts
@@ -226,6 +226,7 @@ export interface SearchItem {
   readingProgressAnchorIndex?: number
   userId: string
   state?: ArticleSavingRequestStatus
+  language?: string
 }
 
 const keys = ['_id', 'url', 'slug', 'userId', 'uploadFileId', 'state'] as const

--- a/packages/api/src/elastic/types.ts
+++ b/packages/api/src/elastic/types.ts
@@ -8,16 +8,9 @@ export interface SearchBody {
       filter: (
         | {
             term: {
-              userId: string
+              [K: string]: string
             }
           }
-        | {
-            term: {
-              subscription: string
-            }
-          }
-        | { term: { pageType: string } }
-        | { term: { language: string } }
         | { exists: { field: string } }
         | {
             range: {

--- a/packages/api/src/generated/graphql.ts
+++ b/packages/api/src/generated/graphql.ts
@@ -72,6 +72,7 @@ export type Article = {
   image?: Maybe<Scalars['String']>;
   isArchived: Scalars['Boolean'];
   labels?: Maybe<Array<Label>>;
+  language?: Maybe<Scalars['String']>;
   linkId?: Maybe<Scalars['ID']>;
   originalArticleUrl?: Maybe<Scalars['String']>;
   originalHtml?: Maybe<Scalars['String']>;
@@ -1411,6 +1412,7 @@ export type SearchItem = {
   image?: Maybe<Scalars['String']>;
   isArchived: Scalars['Boolean'];
   labels?: Maybe<Array<Label>>;
+  language?: Maybe<Scalars['String']>;
   originalArticleUrl?: Maybe<Scalars['String']>;
   ownedByViewer?: Maybe<Scalars['Boolean']>;
   pageId?: Maybe<Scalars['ID']>;
@@ -2759,6 +2761,7 @@ export type ArticleResolvers<ContextType = ResolverContext, ParentType extends R
   image?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   isArchived?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   labels?: Resolver<Maybe<Array<ResolversTypes['Label']>>, ParentType, ContextType>;
+  language?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   linkId?: Resolver<Maybe<ResolversTypes['ID']>, ParentType, ContextType>;
   originalArticleUrl?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   originalHtml?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
@@ -3498,6 +3501,7 @@ export type SearchItemResolvers<ContextType = ResolverContext, ParentType extend
   image?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   isArchived?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   labels?: Resolver<Maybe<Array<ResolversTypes['Label']>>, ParentType, ContextType>;
+  language?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   originalArticleUrl?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   ownedByViewer?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
   pageId?: Resolver<Maybe<ResolversTypes['ID']>, ParentType, ContextType>;

--- a/packages/api/src/generated/schema.graphql
+++ b/packages/api/src/generated/schema.graphql
@@ -51,6 +51,7 @@ type Article {
   image: String
   isArchived: Boolean!
   labels: [Label!]
+  language: String
   linkId: ID
   originalArticleUrl: String
   originalHtml: String
@@ -1001,6 +1002,7 @@ type SearchItem {
   image: String
   isArchived: Boolean!
   labels: [Label!]
+  language: String
   originalArticleUrl: String
   ownedByViewer: Boolean
   pageId: ID

--- a/packages/api/src/readability.d.ts
+++ b/packages/api/src/readability.d.ts
@@ -165,6 +165,7 @@ declare module '@omnivore/readability' {
       /** Article published date */
       publishedDate?: Date
       dom?: Element
+      language?: string
     }
   }
 

--- a/packages/api/src/resolvers/article/index.ts
+++ b/packages/api/src/resolvers/article/index.ts
@@ -273,6 +273,7 @@ export const createArticleResolver = authorized<
         readingProgressPercent: 0,
         readingProgressAnchorIndex: 0,
         state: ArticleSavingRequestStatus.Succeeded,
+        language: parsedContent?.language,
       }
 
       let archive = false

--- a/packages/api/src/schema.ts
+++ b/packages/api/src/schema.ts
@@ -347,6 +347,7 @@ const schema = gql`
     unsubMailTo: String
     unsubHttpUrl: String
     state: ArticleSavingRequestStatus
+    language: String
   }
 
   # Query: article
@@ -1464,6 +1465,7 @@ const schema = gql`
     unsubHttpUrl: String
     state: ArticleSavingRequestStatus
     siteName: String
+    language: String
   }
 
   type SearchItemEdge {

--- a/packages/api/src/utils/parser.ts
+++ b/packages/api/src/utils/parser.ts
@@ -287,6 +287,7 @@ export const parsePreparedContent = async (
       siteName: article?.siteName || (await jsonLdLinkMetadata).siteName,
       siteIcon: article?.siteIcon,
       byline: article?.byline || (await jsonLdLinkMetadata).byline,
+      language: article?.language,
     })
     logRecord.parseSuccess = true
   } catch (error) {

--- a/packages/db/elastic_migrations/index_settings.json
+++ b/packages/db/elastic_migrations/index_settings.json
@@ -120,6 +120,9 @@
       },
       "taskName": {
         "type": "keyword"
+      },
+      "language": {
+        "type": "keyword"
       }
     }
   }

--- a/packages/db/elastic_migrations/index_settings.json
+++ b/packages/db/elastic_migrations/index_settings.json
@@ -122,7 +122,8 @@
         "type": "keyword"
       },
       "language": {
-        "type": "keyword"
+        "type": "keyword",
+        "normalizer": "lowercase_normalizer"
       }
     }
   }

--- a/packages/readabilityjs/Readability.js
+++ b/packages/readabilityjs/Readability.js
@@ -1894,13 +1894,13 @@ Readability.prototype = {
 
     // get site name
     metadata.siteName = jsonld.siteName ||
-      values["og:site_name"];
+      values["og:site_name"] || null;
 
     // get website icon
     const iconLink = this._doc.querySelector(
       "link[rel='apple-touch-icon'], link[rel='shortcut icon'], link[rel='icon']"
     );
-    metadata.siteIcon = iconLink ? iconLink.href : '';
+    metadata.siteIcon = iconLink?.href;
 
     // get published date
     metadata.publishedDate = jsonld.publishedDate ||
@@ -2836,6 +2836,11 @@ Readability.prototype = {
   },
 
   _getLanguage: function(code) {
+    if (!code) {
+      // Default to English
+      return 'English';
+    }
+
     let lang = new Intl.DisplayNames(['en'], {type: 'language'});
     return lang.of(code.split('-')[0]);
   },

--- a/packages/readabilityjs/Readability.js
+++ b/packages/readabilityjs/Readability.js
@@ -85,7 +85,7 @@ function Readability(doc, options) {
   this._articleByline = null;
   this._articlePublishedDate = null;
   this._articleDir = null;
-  this._articleSiteName = null;
+  this._languageCode = null;
   this._attempts = [];
 
   // Configurable options
@@ -1921,6 +1921,8 @@ Readability.prototype = {
       values["weibo:article:image"] ||
       values["weibo:webpage:image"];
 
+    metadata.locale = values["og:locale"];
+
     // TODO: Add canonical ULR search here as well
 
     // in many sites the meta value is escaped with HTML entities,
@@ -2833,6 +2835,11 @@ Readability.prototype = {
     return false;
   },
 
+  _getLanguage: function(code) {
+    let lang = new Intl.DisplayNames(['en'], {type: 'language'});
+    return lang.of(code.split('-')[0]);
+  },
+
   /**
    * Runs readability.
    *
@@ -2859,6 +2866,8 @@ Readability.prototype = {
 
     // Extract JSON-LD metadata before removing scripts
     var jsonLd = this._disableJSONLD ? {} : this._getJSONLD(this._doc);
+
+    this._languageCode = this._doc.documentElement.lang
 
     // Remove script tags from the document.
     this._removeScripts(this._doc);
@@ -2898,11 +2907,12 @@ Readability.prototype = {
       textContent: textContent,
       length: textContent.length,
       excerpt: metadata.excerpt,
-      siteName: metadata.siteName || this._articleSiteName,
+      siteName: metadata.siteName,
       siteIcon: metadata.siteIcon,
       previewImage: metadata.previewImage,
       publishedDate: metadata.publishedDate || publishedAt || this._articlePublishedDate,
       dom: articleContent,
+      language: this._getLanguage(metadata.locale || this._languageCode),
     };
   }
 };


### PR DESCRIPTION
* parse language code from document or from open graph locale metadata
* convert language code to language display name and store in elastic when creating article
* support searching items by language: `language: english`