### PR TITLE
Lowercase characters when doing text analysis

### DIFF
--- a/packages/db/elastic_migrations/index_settings.json
+++ b/packages/db/elastic_migrations/index_settings.json
@@ -7,7 +7,8 @@
       "analyzer": {
         "strip_html_analyzer": {
           "tokenizer": "standard",
-          "char_filter": ["html_strip"]
+          "char_filter": ["html_strip"],
+          "filter": ["lowercase"]
         }
       },
       "normalizer": {


### PR DESCRIPTION
Hey @jacksonh, to make this change, I need to reindex in elasticsearch because this changes the analyzer and we cannot do that by updating mappings.