### PR TITLE
[OMN-658] Modal to edit title and description of a page

### DIFF
--- a/packages/web/components/patterns/CardMenu.tsx
+++ b/packages/web/components/patterns/CardMenu.tsx
@@ -14,6 +14,7 @@ export type CardMenuDropdownAction =
   | 'snooze'
   | 'set-labels'
   | 'showOriginal'
+  | 'editTitle'
 
 type CardMenuProps = {
   item: LibraryItemNode
@@ -45,6 +46,10 @@ export function CardMenu(props: CardMenuProps): JSX.Element {
       <DropdownOption
         onSelect={() => props.actionHandler('showOriginal')}
         title="Open Original"
+      />
+      <DropdownOption
+        onSelect={() => props.actionHandler('editTitle')}
+        title="Edit Title"
       />
       {isVipUser(props.viewer) && (
         <DropdownOption

--- a/packages/web/components/patterns/LibraryCards/CardTypes.tsx
+++ b/packages/web/components/patterns/LibraryCards/CardTypes.tsx
@@ -5,6 +5,7 @@ import type { LibraryItemNode } from '../../../lib/networking/queries/useGetLibr
 export type LinkedItemCardAction =
   | 'showDetail'
   | 'showOriginal'
+  | 'editTitle'
   | 'archive'
   | 'unarchive'
   | 'delete'
@@ -13,6 +14,7 @@ export type LinkedItemCardAction =
   | 'share'
   | 'snooze'
   | 'set-labels'
+  | 'update-item'
 
 export type LinkedItemCardProps = {
   item: LibraryItemNode

--- a/packages/web/components/templates/homeFeed/EditTitleModal.tsx
+++ b/packages/web/components/templates/homeFeed/EditTitleModal.tsx
@@ -1,0 +1,157 @@
+import {
+  ModalRoot,
+  ModalContent,
+  ModalOverlay,
+} from '../../elements/ModalPrimitives'
+import { VStack, HStack, Box } from '../../elements/LayoutPrimitives'
+import { Button } from '../../elements/Button'
+import { StyledText } from '../../elements/StyledText'
+import { CrossIcon } from '../../elements/images/CrossIcon'
+import { theme } from '../../tokens/stitches.config'
+import { FormInput } from '../../elements/FormElements'
+import { useState, useCallback } from 'react'
+import { LibraryItem } from '../../../lib/networking/queries/useGetLibraryItemsQuery'
+import { StyledTextArea } from '../../elements/StyledTextArea'
+import { updatePageMutation } from '../../../lib/networking/mutations/updatePageMutation'
+import { showErrorToast, showSuccessToast } from '../../../lib/toastHelpers'
+
+type EditTitleModalProps = {
+  onOpenChange: (open: boolean) => void
+  item: LibraryItem
+  updateItem: (item: LibraryItem) => Promise<void>,
+}
+
+export function EditTitleModal(props: EditTitleModalProps): JSX.Element {
+  const [title, setTitle] = useState(props.item.node.title)
+  const [description, setDescription] = useState(props.item.node.description)
+
+  const handleUpdateTitle = async () => {
+    if (title !== '') {
+      const res = await updatePageMutation({
+        pageId: props.item.node.id,
+        title,
+        description,
+      })
+
+      if (res) {
+        await props.updateItem({
+          cursor: props.item.cursor,
+          node: {
+            ...props.item.node,
+            title: title,
+            description: description,
+          },
+        })
+        showSuccessToast('Link updated succesfully', {
+          position: 'bottom-right',
+        })
+        props.onOpenChange(false)
+      } else {
+        showErrorToast('There was an error updating your link', {
+          position: 'bottom-right',
+        })
+      }
+    } else {
+      showErrorToast('Title can\'t be empty', {
+        position: 'bottom-right',
+      })
+    }
+  }
+
+  return (
+    <ModalRoot defaultOpen onOpenChange={props.onOpenChange}>
+      <ModalOverlay />
+      <ModalContent
+        css={{ bg: '$grayBg', maxWidth: '20em', pt: '0px' }}
+        onInteractOutside={() => {
+          // remove focus from modal
+          (document.activeElement as HTMLElement).blur()
+        }}
+      >
+        <VStack distribution="start" css={{ p: '$2' }}>
+          <HStack
+            distribution="between"
+            alignment="center"
+            css={{ width: '100%', mt: '4px' }}
+          >
+            <StyledText style="modalHeadline">
+              Edit Title or Description
+            </StyledText>
+            <Button
+              css={{ p: '10px', cursor: 'pointer', pt: '2px' }}
+              style="ghost"
+              onClick={() => {
+                props.onOpenChange(false)
+              }}
+            >
+              <CrossIcon
+                size={11}
+                strokeColor={theme.colors.grayTextContrast.toString()}
+              />
+            </Button>
+          </HStack>
+          <StyledText css={{ mt: '22px', mb: '6px' }}>Title</StyledText>
+          <Box css={{ width: '100%' }}>
+            <form
+              onSubmit={(event) => {
+                event.preventDefault()
+              }}
+            >
+              <FormInput
+                type="text"
+                value={title}
+                autoFocus
+                placeholder="Edit Title"
+                onChange={(event) => setTitle(event.target.value)}
+                css={{
+                  borderRadius: '8px',
+                  border: '1px solid $grayTextContrast',
+                  width: '100%',
+                  p: '$2',
+                }}
+              />
+              <StyledText css={{ mt: '22px', mb: '6px' }}>
+                Description
+              </StyledText>
+              <Box
+                css={{
+                  border: '1px solid $grayTextContrast',
+                  borderRadius: '8px',
+                }}
+              >
+                <StyledTextArea
+                  css={{
+                    mt: '$2',
+                    width: '95%',
+                    p: '$1',
+                    height: '$6',
+                  }}
+                  placeholder="Edit Description"
+                  value={description}
+                  onChange={(event) => setDescription(event.target.value)}
+                  maxLength={4000}
+                />
+              </Box>
+              <HStack distribution="end" css={{ mt: '12px', width: '100%' }}>
+                <Button
+                  onClick={() => props.onOpenChange(false)}
+                  style="ctaGray"
+                  css={{ mr: '16px' }}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  onClick={handleUpdateTitle}
+                  style="ctaDarkYellow"
+                  css={{ mb: '0px' }}
+                >
+                  Save
+                </Button>
+              </HStack>
+            </form>
+          </Box>
+        </VStack>
+      </ModalContent>
+    </ModalRoot>
+  )
+}

--- a/packages/web/components/templates/homeFeed/HomeFeedContainer.tsx
+++ b/packages/web/components/templates/homeFeed/HomeFeedContainer.tsx
@@ -39,7 +39,11 @@ import { SetLabelsModal } from '../article/SetLabelsModal'
 import { Label } from '../../../lib/networking/fragments/labelFragment'
 import { EmptyLibrary } from './EmptyLibrary'
 import TopBarProgress from 'react-topbar-progress-indicator'
-import { State, PageType } from '../../../lib/networking/fragments/articleFragment'
+import {
+  State,
+  PageType,
+} from '../../../lib/networking/fragments/articleFragment'
+import { EditTitleModal } from './EditTitleModal'
 
 export type LayoutType = 'LIST_LAYOUT' | 'GRID_LAYOUT'
 
@@ -85,6 +89,7 @@ export function HomeFeedContainer(props: HomeFeedContainerProps): JSX.Element {
   )
 
   const [showAddLinkModal, setShowAddLinkModal] = useState(false)
+  const [showEditTitleModal, setShowEditTitleModal] = useState(false)
 
   const [queryInputs, setQueryInputs] =
     useState<LibraryItemsQueryInput>(defaultQuery)
@@ -261,7 +266,10 @@ export function HomeFeedContainer(props: HomeFeedContainerProps): JSX.Element {
           if (item.node.state === State.PROCESSING) {
             router.push(`/${username}/links/${item.node.id}`)
           } else {
-            const dl = item.node.pageType === PageType.HIGHLIGHTS ? `#${item.node.id}` : ''
+            const dl =
+              item.node.pageType === PageType.HIGHLIGHTS
+                ? `#${item.node.id}`
+                : ''
             router.push(`/${username}/${item.node.slug}` + dl)
           }
         }
@@ -295,6 +303,9 @@ export function HomeFeedContainer(props: HomeFeedContainerProps): JSX.Element {
         break
       case 'set-labels':
         setLabelsTarget(item)
+        break
+      case 'update-item':
+        performActionOnItem('update-item', item)
         break
     }
   }
@@ -454,6 +465,8 @@ export function HomeFeedContainer(props: HomeFeedContainerProps): JSX.Element {
       setLabelsTarget={setLabelsTarget}
       showAddLinkModal={showAddLinkModal}
       setShowAddLinkModal={setShowAddLinkModal}
+      showEditTitleModal={showEditTitleModal}
+      setShowEditTitleModal={setShowEditTitleModal}
       setActiveItem={(item: LibraryItem) => {
         activateCard(item.node.id)
       }}
@@ -479,6 +492,8 @@ type HomeFeedContentProps = {
   setLabelsTarget: (target: LibraryItem | undefined) => void
   showAddLinkModal: boolean
   setShowAddLinkModal: (show: boolean) => void
+  showEditTitleModal: boolean
+  setShowEditTitleModal: (show: boolean) => void
   setActiveItem: (item: LibraryItem) => void
   actionHandler: (
     action: LinkedItemCardAction,
@@ -497,6 +512,7 @@ function HomeFeedGrid(props: HomeFeedContentProps): JSX.Element {
   const [showRemoveLinkConfirmation, setShowRemoveLinkConfirmation] =
     useState(false)
   const [linkToRemove, setLinkToRemove] = useState<LibraryItem>()
+  const [linkToEdit, setLinkToEdit] = useState<LibraryItem>()
 
   const updateLayout = useCallback(
     async (newLayout: LayoutType) => {
@@ -720,6 +736,9 @@ function HomeFeedGrid(props: HomeFeedContentProps): JSX.Element {
                       if (action === 'delete') {
                         setShowRemoveLinkConfirmation(true)
                         setLinkToRemove(linkedItem)
+                      } else if (action === 'editTitle') {
+                        props.setShowEditTitleModal(true)
+                        setLinkToEdit(linkedItem)
                       } else {
                         props.actionHandler(action, linkedItem)
                       }
@@ -752,6 +771,13 @@ function HomeFeedGrid(props: HomeFeedContentProps): JSX.Element {
       </VStack>
       {props.showAddLinkModal && (
         <AddLinkModal onOpenChange={() => props.setShowAddLinkModal(false)} />
+      )}
+      {props.showEditTitleModal && (
+        <EditTitleModal
+          updateItem={(item: LibraryItem) => props.actionHandler('update-item', item)}
+          onOpenChange={() => props.setShowEditTitleModal(false)}
+          item={linkToEdit as LibraryItem}
+        />
       )}
       {props.shareTarget && viewerData?.me?.profile.username && (
         <ShareArticleModal

--- a/packages/web/lib/networking/mutations/updatePageMutation.ts
+++ b/packages/web/lib/networking/mutations/updatePageMutation.ts
@@ -1,0 +1,48 @@
+import { gql } from 'graphql-request'
+import { gqlFetcher } from '../networkHelpers'
+
+export type UpdatePageInput = {
+  pageId: string
+  title: string,
+  description: string,
+}
+
+export async function updatePageMutation(
+  input: UpdatePageInput
+): Promise<string | undefined> {
+  const mutation = gql`
+    mutation {
+      updatePage(
+        input: {
+          pageId: "${input.pageId}"
+          title: "${input.title}"
+          description: "${input.description}"
+        }
+      ) {
+        ... on UpdatePageSuccess {
+          updatedPage {
+            id
+            title
+            url
+            createdAt
+            author
+            image
+            description
+            publishedAt
+          }
+        }
+        ... on UpdatePageError {
+          errorCodes
+        }
+      }
+    }
+  `
+
+  try {
+    const data = await gqlFetcher(mutation)
+    const output = data as any
+    return output.updatePage
+  } catch (err) {
+    return undefined
+  }
+}

--- a/packages/web/lib/networking/queries/useGetLibraryItemsQuery.tsx
+++ b/packages/web/lib/networking/queries/useGetLibraryItemsQuery.tsx
@@ -35,6 +35,7 @@ type LibraryItemAction =
   | 'mark-read'
   | 'mark-unread'
   | 'refresh'
+  | 'update-item'
 
 export type LibraryItemsData = {
   search: LibraryItems
@@ -304,6 +305,10 @@ export function useGetLibraryItemsQuery({
           readingProgressPercent: 0,
           readingProgressAnchorIndex: 0,
         })
+        break
+        case 'update-item':
+          updateData(item)
+          await mutate()
         break
       case 'refresh':
         await mutate()

--- a/packages/web/stories/EditTitleModal.stories.tsx
+++ b/packages/web/stories/EditTitleModal.stories.tsx
@@ -1,0 +1,40 @@
+import { ComponentStory, ComponentMeta } from '@storybook/react'
+import { EditTitleModal } from '../components/templates/homeFeed/EditTitleModal'
+import { LibraryItem } from '../lib/networking/queries/useGetLibraryItemsQuery'
+
+export default {
+  title: 'Components/EditTitleModal',
+  component: EditTitleModal,
+  argTypes: {
+    onOpenChange: {
+      description:
+        'This is the function that changes the open and closed state of the modal',
+    },
+    item: {
+      description: 'The article whose title or description is to be changed.',
+    },
+  },
+  parameters: {
+    docs: {
+      page: null,
+    },
+    previewTabs: {
+      'storybook/docs/panel': { hidden: true },
+    },
+    viewMode: 'canvas',
+  },
+} as ComponentMeta<typeof EditTitleModal>
+
+export const EditTitleModalStory: ComponentStory<typeof EditTitleModal> = (
+  args
+) => (
+  <EditTitleModal
+    onOpenChange={() => {}}
+    item={{
+      cursor: '',
+      node: { title: '', description: '' } as LibraryItem['node'],
+    }}
+    updateItem={async () => console.log('update item')}
+    
+  />
+)


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
There is now a modal to edit title and description of a page

## House Keeping
- [ ] Added video describing your plan of action ?
- [ ] Added Loom video ?
- [x] Is Deployment Link passing ?
- [x] Have you assinged PR to yourself ?
- [x] Is Github action passing ?
- [x] Updated the appropriate tag ?


## Ticket link (if applicable)
<!--- Uncomment the below line and correct the ticket number at the end of URL -->
[Task Link](https://app.gitstart.com/clients/omnivore/tickets/OMN-658)

## Types of changes
<!--- What types of changes does your code introduce? tick boxes that apply: -->
- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Others

## Checklist:
<!--- tick boxes that apply. -->
- [x] I have test my code on different browsers and devices to make sure it is cross-browser compatible (both desktop and mobile).
- [ ] I have confirmed the payload for integrated API matches params on API docs
- [ ] I have confirmed design matches Spec specified on Figma.

## Language translation
<!--- Tick  boxes that apply. -->
- [ ] Did you udpate/add a new text node ?
- [ ] I have updated language mapping JSOn in locale

## Remarks
<!--- Tick  boxes that apply. -->
- [ ] I added a new package to achieve this task.
- [ ] I have updated package.json
