### PR TITLE
Fixes for the sync state UI when errors occur

### DIFF
--- a/apple/OmnivoreKit/Sources/App/AppExtensions/Share/ExtensionSaveService.swift
+++ b/apple/OmnivoreKit/Sources/App/AppExtensions/Share/ExtensionSaveService.swift
@@ -166,12 +166,12 @@ class ExtensionSaveService {
         }
 
       } catch {
-        print("ERROR SYNCING", error)
         updateStatus(newStatus: .syncFailed(error: SaveArticleError.unknown(description: "Unknown Error")))
+        return
       }
 
-      state = .finished
       updateStatus(newStatus: .synced)
+      state = .finished
     }
   }
 }

--- a/apple/OmnivoreKit/Sources/Views/ShareExtensionView.swift
+++ b/apple/OmnivoreKit/Sources/Views/ShareExtensionView.swift
@@ -156,11 +156,11 @@ public struct ShareExtensionChildView: View {
 
   private var titleText: String {
     switch viewModel.status {
-    case .saved, .synced:
+    case .saved, .synced, .syncFailed(error: _):
       return "Saved to Omnivore"
     case .processing:
       return "Saving to Omnivore"
-    default:
+    case .failed(error: _):
       return "Error saving to Omnivore"
     }
   }


### PR DESCRIPTION
If syncing fails, the item is still saved so we don't change the
title.

When syncing fails make sure the red error cloud is shown.
