### PR TITLE
Track last time readingProgress was updated

### DIFF
--- a/packages/api/src/elastic/types.ts
+++ b/packages/api/src/elastic/types.ts
@@ -198,6 +198,7 @@ export interface Page {
   state: ArticleSavingRequestStatus
   taskName?: string
   language?: string
+  readAt?: Date
 }
 
 export interface SearchItem {

--- a/packages/api/src/generated/graphql.ts
+++ b/packages/api/src/generated/graphql.ts
@@ -1246,6 +1246,7 @@ export type Query = {
   newsletterEmails: NewsletterEmailsResult;
   reminder: ReminderResult;
   search: SearchResult;
+  sendInstallInstructions: SendInstallInstructionsResult;
   sharedArticle: SharedArticleResult;
   subscriptions: SubscriptionsResult;
   user: UserResult;
@@ -1515,6 +1516,7 @@ export type SearchItem = {
   pageType: PageType;
   publishedAt?: Maybe<Scalars['Date']>;
   quote?: Maybe<Scalars['String']>;
+  readAt?: Maybe<Scalars['Date']>;
   readingProgressAnchorIndex?: Maybe<Scalars['Int']>;
   readingProgressPercent?: Maybe<Scalars['Float']>;
   shortId?: Maybe<Scalars['String']>;
@@ -3712,6 +3714,7 @@ export type QueryResolvers<ContextType = ResolverContext, ParentType extends Res
   newsletterEmails?: Resolver<ResolversTypes['NewsletterEmailsResult'], ParentType, ContextType>;
   reminder?: Resolver<ResolversTypes['ReminderResult'], ParentType, ContextType, RequireFields<QueryReminderArgs, 'linkId'>>;
   search?: Resolver<ResolversTypes['SearchResult'], ParentType, ContextType, Partial<QuerySearchArgs>>;
+  sendInstallInstructions?: Resolver<ResolversTypes['SendInstallInstructionsResult'], ParentType, ContextType>;
   sharedArticle?: Resolver<ResolversTypes['SharedArticleResult'], ParentType, ContextType, RequireFields<QuerySharedArticleArgs, 'slug' | 'username'>>;
   subscriptions?: Resolver<ResolversTypes['SubscriptionsResult'], ParentType, ContextType, Partial<QuerySubscriptionsArgs>>;
   user?: Resolver<ResolversTypes['UserResult'], ParentType, ContextType, Partial<QueryUserArgs>>;
@@ -3831,6 +3834,7 @@ export type SearchItemResolvers<ContextType = ResolverContext, ParentType extend
   pageType?: Resolver<ResolversTypes['PageType'], ParentType, ContextType>;
   publishedAt?: Resolver<Maybe<ResolversTypes['Date']>, ParentType, ContextType>;
   quote?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  readAt?: Resolver<Maybe<ResolversTypes['Date']>, ParentType, ContextType>;
   readingProgressAnchorIndex?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   readingProgressPercent?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   shortId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;

--- a/packages/api/src/generated/schema.graphql
+++ b/packages/api/src/generated/schema.graphql
@@ -902,6 +902,7 @@ type Query {
   newsletterEmails: NewsletterEmailsResult!
   reminder(linkId: ID!): ReminderResult!
   search(after: String, first: Int, query: String): SearchResult!
+  sendInstallInstructions: SendInstallInstructionsResult!
   sharedArticle(selectedHighlightId: String, slug: String!, username: String!): SharedArticleResult!
   subscriptions(sort: SortParams): SubscriptionsResult!
   user(userId: ID, username: String): UserResult!
@@ -1078,6 +1079,7 @@ type SearchItem {
   pageType: PageType!
   publishedAt: Date
   quote: String
+  readAt: Date
   readingProgressAnchorIndex: Int
   readingProgressPercent: Float
   shortId: String

--- a/packages/api/src/resolvers/article/index.ts
+++ b/packages/api/src/resolvers/article/index.ts
@@ -49,9 +49,9 @@ import {
   isParsingTimeout,
   pageError,
   stringToHash,
+  titleForFilePath,
   userDataToUser,
   validatedDate,
-  titleForFilePath,
 } from '../../utils/helpers'
 import {
   ParsedContentPuppeteer,
@@ -729,9 +729,10 @@ export const saveArticleReadingProgressResolver = authorized<
       readingProgressAnchorIndex: shouldUpdate
         ? readingProgressAnchorIndex
         : page.readingProgressAnchorIndex,
+      readAt: new Date(),
     }
 
-    shouldUpdate && (await updatePage(id, updatedPart, { pubsub, uid }))
+    await updatePage(id, updatedPart, { pubsub, uid })
 
     return {
       updatedArticle: {

--- a/packages/api/src/schema.ts
+++ b/packages/api/src/schema.ts
@@ -1495,6 +1495,7 @@ const schema = gql`
     state: ArticleSavingRequestStatus
     siteName: String
     language: String
+    readAt: Date
   }
 
   type SearchItemEdge {

--- a/packages/api/src/utils/search.ts
+++ b/packages/api/src/utils/search.ts
@@ -61,6 +61,7 @@ export enum SortBy {
   UPDATED = 'updatedAt',
   SCORE = '_score',
   PUBLISHED = 'publishedAt',
+  READ = 'readAt',
 }
 
 export enum SortOrder {
@@ -176,6 +177,11 @@ const parseSortParams = (str?: string): SortParams | undefined => {
     case 'PUBLISHED':
       return {
         by: SortBy.PUBLISHED,
+        order: sortOrder,
+      }
+    case 'READ':
+      return {
+        by: SortBy.READ,
         order: sortOrder,
       }
   }
@@ -323,6 +329,7 @@ export const parseSearchQuery = (query: string | undefined): SearchFilter => {
           break
         }
         case 'saved':
+        case 'read':
         case 'published': {
           const dateFilter = parseDateFilter(keyword.keyword, keyword.value)
           dateFilter && result.dateFilters.push(dateFilter)

--- a/packages/db/elastic_migrations/index_settings.json
+++ b/packages/db/elastic_migrations/index_settings.json
@@ -124,6 +124,9 @@
       "language": {
         "type": "keyword",
         "normalizer": "lowercase_normalizer"
+      },
+      "readAt": {
+        "type": "date"
       }
     }
   }

--- a/packages/web/components/templates/homeFeed/LibrarySearchBar.tsx
+++ b/packages/web/components/templates/homeFeed/LibrarySearchBar.tsx
@@ -22,7 +22,7 @@ type LibraryFilter =
   | 'type:file'
   | 'type:highlights'
   | `saved:${string}`
-  | `sort:updated`
+  | `sort:read`
 
 // get last week's date
 const recentlySavedStartDate = new Date(
@@ -122,13 +122,27 @@ export function LibrarySearchBar(props: LibrarySearchBarProps): JSX.Element {
           </form>
         </Box>
         {searchTerm && (
-          <Button style='plainIcon' onClick={(event) => {
+          <Button
+            style="plainIcon"
+            onClick={(event) => {
               event.preventDefault()
               setSearchTerm('')
               props.applySearchQuery('')
               inputRef.current?.blur()
-            }} css={{ display: 'flex', flexDirection: 'row', mr: '8px', height: '100%', alignItems: 'center' }}>
-              <X width={16} height={16} color={theme.colors.grayTextContrast.toString()} />
+            }}
+            css={{
+              display: 'flex',
+              flexDirection: 'row',
+              mr: '8px',
+              height: '100%',
+              alignItems: 'center',
+            }}
+          >
+            <X
+              width={16}
+              height={16}
+              color={theme.colors.grayTextContrast.toString()}
+            />
           </Button>
         )}
       </HStack>
@@ -175,7 +189,7 @@ export function DropdownFilterMenu(
         hideSeparator
       />
       <DropdownOption
-        onSelect={() => props.onFilterChange(`sort:updated`)}
+        onSelect={() => props.onFilterChange(`sort:read`)}
         title="Recently Read"
         hideSeparator
       />

--- a/packages/web/lib/networking/queries/useGetLibraryItemsQuery.tsx
+++ b/packages/web/lib/networking/queries/useGetLibraryItemsQuery.tsx
@@ -76,6 +76,7 @@ export type LibraryItemNode = {
   state: State
   pageType: PageType
   siteName?: string
+  readAt?: string
 }
 
 export type PageInfo = {
@@ -127,6 +128,7 @@ export function useGetLibraryItemsQuery({
               annotation
               state
               siteName
+              readAt
             }
           }
           pageInfo {


### PR DESCRIPTION
- Add readAt field to page properties
- Add readAt to page type
- Update readAt when saving reading progress
- Support sort/filter by readAt
- Add readAt to search API response
- Update sort by `readAt` query on Web