### PR TITLE
Fix issue with ShareExtension.js not executing on iOS

### DIFF
--- a/apple/Sources/ShareExtension/ShareExtension.js
+++ b/apple/Sources/ShareExtension/ShareExtension.js
@@ -7,7 +7,7 @@ function iconURL() {
 
     return document.querySelector("link[rel='apple-touch-icon'], link[rel='shortcut icon'], link[rel='icon']").href
   } catch {}
-  return null
+  return undefined
 }
 
 ShareExtension.prototype = {


### PR DESCRIPTION
Returning undefined here fixes issues where pages would fail
to scrape if there was no preview image available.
