### PR TITLE
[Omn-749] - Connect to SendInstallInstructions API on onboarding/02 page

### DIFF
--- a/packages/web/components/templates/OnboardingLayout.tsx
+++ b/packages/web/components/templates/OnboardingLayout.tsx
@@ -5,6 +5,7 @@ import { OmnivoreNameLogo } from '../elements/images/OmnivoreNameLogo'
 import { StyledText } from '../elements/StyledText'
 import { Button } from '../elements/Button'
 import { useRouter } from 'next/router'
+import { Toaster } from 'react-hot-toast'
 
 const TOTAL_ONBOARDING_PAGES = 6
 
@@ -65,6 +66,7 @@ export const OnboardingLayout = ({
         path={`/onboarding/0${pageNumber}`}
         title={`Onboarding - ${pageNumber}`}
       />
+      <Toaster />
       <Box
         css={{
           display: 'grid',

--- a/packages/web/components/templates/onboarding/OnboardingInstallInstructions.tsx
+++ b/packages/web/components/templates/onboarding/OnboardingInstallInstructions.tsx
@@ -1,16 +1,27 @@
 import React from 'react'
-import Link from 'next/link'
 import { OnboardingLayout } from '../OnboardingLayout'
 import MobileInstallHelp from '../../elements/MobileInstallHelp'
 import ExtensionsInstallHelp from '../../elements/ExtensionsInstallHelp'
-import { StyledAnchor } from '../../elements/StyledText'
 import { Box } from '../../elements/LayoutPrimitives'
+import { sendInstallInstructions } from '../../../lib/networking/queries/sendInstallInstructions'
+import { Button } from '../../elements/Button'
+import { showErrorToast, showSuccessToast } from '../../../lib/toastHelpers'
 
 type OnboardingInstallInstructionsProps = {
   pageNumber: number
 }
 
 export const OnboardingInstallInstructions = (props: OnboardingInstallInstructionsProps) => {
+  const onEmailInstructionsClick = async () => {
+    const res = await sendInstallInstructions()
+    if (res !== undefined) {
+      showSuccessToast('Instructions Email Sent', { position: 'bottom-right' })
+    }
+    else {
+      showErrorToast('Failed to send', { position: 'bottom-right' })
+    }
+  }
+
   return (
     <OnboardingLayout
       pageNumber={props.pageNumber}
@@ -68,19 +79,19 @@ export const OnboardingInstallInstructions = (props: OnboardingInstallInstructio
             },
           }}
         >
-          <Link passHref href="#">
-            <StyledAnchor
-              css={{
-                fontWeight: '400',
-                fontSize: '14px',
-                lineHeight: '17.5px',
-                color: 'rgba(10, 8, 6, 0.8)',
-                textDecoration: 'underline',
-              }}
-            >
-              Email me instructions
-            </StyledAnchor>
-          </Link>
+          <Box
+            onClick={onEmailInstructionsClick}
+            css={{
+              fontWeight: '400',
+              fontSize: '14px',
+              lineHeight: '17.5px',
+              color: 'rgba(10, 8, 6, 0.8)',
+              textDecoration: 'underline',
+              cursor: 'pointer',
+            }}
+          >
+            Email me instructions
+          </Box>
         </Box>
       </Box>
     </OnboardingLayout>

--- a/packages/web/lib/networking/queries/sendInstallInstructions.tsx
+++ b/packages/web/lib/networking/queries/sendInstallInstructions.tsx
@@ -1,0 +1,33 @@
+import { gql } from 'graphql-request'
+import { gqlFetcher } from '../networkHelpers'
+
+type QueryResult = {
+  sent: boolean
+  errorCodes?: unknown[]
+}
+
+export async function sendInstallInstructions(): Promise<any | undefined> {
+  const query = gql`
+    query SendInstallInstructions {
+      sendInstallInstructions {
+        ... on SendInstallInstructionsSuccess {
+          sent
+        }
+      }
+
+      sendInstallInstructions {
+        ... on SendInstallInstructionsError {
+          errorCodes
+        }
+      }
+    }
+  `
+
+  try {
+    const data = (await gqlFetcher(query)) as QueryResult
+    return data.errorCodes ? undefined : data.sent
+  } catch (error) {
+    console.log('sendInstallInstructions error', error)
+    return undefined
+  }
+}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
On the onboarding/02 page we have an Email me Instructions button. When that button is clicked/tapped we should make an API call to the SendInstallInstructions API created in OMN-633. After this API is called we should display a success Toast "Instructions Email Sent"

## House Keeping
- [ ] Added Loom video ?
- [x] Is Deployment Link passing ?
- [x] Have you assinged PR to yourself ?
- [x] Is Github action passing ?
- [x] Have you updated the appropriate tag ?


## Ticket link (if applicable)
- https://github.com/omnivore-app/omnivore/issues/749
- https://app.gitstart.com/clients/omnivore/tickets/OMN-749


## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->

## Types of changes
<!--- What types of changes does your code introduce? tick boxes that apply: -->
- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Others

## Remarks
<!--- Tick  boxes that apply. -->
- [ ] I added a new package to achieve this task.
- [ ] I have updated package.json
