### PR TITLE
fix/upload request file urls

### DIFF
--- a/apple/OmnivoreKit/Sources/Models/DataModels/PDFItem.swift
+++ b/apple/OmnivoreKit/Sources/Models/DataModels/PDFItem.swift
@@ -22,7 +22,7 @@ public struct PDFItem {
       objectID: item.objectID,
       itemID: item.unwrappedID,
       pdfURL: URL(string: item.unwrappedPageURLString),
-      localPdfURL: nil, // item.localPdfURL.flatMap { URL(string: $0) },
+      localPdfURL: item.localPdfURL.flatMap { URL(string: $0) },
       title: item.unwrappedID,
       slug: item.unwrappedSlug,
       readingProgress: item.readingProgress,

--- a/apple/OmnivoreKit/Sources/Models/DataModels/PDFItem.swift
+++ b/apple/OmnivoreKit/Sources/Models/DataModels/PDFItem.swift
@@ -22,7 +22,7 @@ public struct PDFItem {
       objectID: item.objectID,
       itemID: item.unwrappedID,
       pdfURL: URL(string: item.unwrappedPageURLString),
-      localPdfURL: item.localPdfURL.flatMap { URL(string: $0) },
+      localPdfURL: nil, // item.localPdfURL.flatMap { URL(string: $0) },
       title: item.unwrappedID,
       slug: item.unwrappedSlug,
       readingProgress: item.readingProgress,

--- a/packages/api/src/datalayer/upload_files/model.ts
+++ b/packages/api/src/datalayer/upload_files/model.ts
@@ -46,7 +46,7 @@ export const createKeys = exclude(keys, defaultedKeys)
 export type CreateSet = PickTuple<UploadFileData, typeof createKeys> &
   Partialize<DefaultedSet>
 
-export const updateKeys = ['status'] as const
+export const updateKeys = ['url', 'status'] as const
 
 export type UpdateSet = PickTuple<UploadFileData, typeof updateKeys>
 

--- a/packages/api/src/resolvers/upload_files/index.ts
+++ b/packages/api/src/resolvers/upload_files/index.ts
@@ -11,6 +11,7 @@ import { WithDataSourcesContext } from '../types'
 import {
   generateUploadSignedUrl,
   generateUploadFilePathName,
+  getFilePublicUrl,
 } from '../../utils/uploads'
 import path from 'path'
 import normalizeUrl from 'normalize-url'
@@ -99,11 +100,12 @@ export const uploadFileRequestResolver: ResolverFn<
       input.contentType
     )
 
-    // If this is a file URL, we swap in the GCS signed
-    // URL
+    const publicUrl = getFilePublicUrl(uploadFilePathName)
+
+    // If this is a file URL, we swap in the GCS public URL
     if (isFileUrl(input.url)) {
       await models.uploadFile.update(uploadFileData.id, {
-        url: uploadSignedUrl,
+        url: publicUrl,
         status: UploadFileStatus.Initialized,
       })
     }
@@ -135,7 +137,7 @@ export const uploadFileRequestResolver: ResolverFn<
       } else {
         const pageId = await createPage(
           {
-            url: isFileUrl(input.url) ? uploadSignedUrl : input.url,
+            url: isFileUrl(input.url) ? publicUrl : input.url,
             id: input.clientRequestId || '',
             userId: claims.uid,
             title: title,

--- a/packages/api/src/resolvers/upload_files/index.ts
+++ b/packages/api/src/resolvers/upload_files/index.ts
@@ -115,10 +115,12 @@ export const uploadFileRequestResolver: ResolverFn<
       // If we have a file:// URL, don't try to match it
       // and create a copy of the page, just create a
       // new item.
-      const page = isFileUrl(input.url) ? await getPageByParam({
-        userId: claims.uid,
-        url: input.url,
-      }) : undefined
+      const page = isFileUrl(input.url)
+        ? await getPageByParam({
+            userId: claims.uid,
+            url: input.url,
+          })
+        : undefined
 
       if (page) {
         if (

--- a/packages/api/src/utils/uploads.ts
+++ b/packages/api/src/utils/uploads.ts
@@ -16,10 +16,7 @@ const storage = env.fileUpload?.gcsUploadSAKeyFilePath
 const bucketName = env.fileUpload.gcsUploadBucket
 
 export const getFilePublicUrl = (filePathName: string): string => {
-  return storage
-    .bucket(bucketName)
-    .file(filePathName)
-    .publicUrl()
+  return storage.bucket(bucketName).file(filePathName).publicUrl()
 }
 
 export const generateUploadSignedUrl = async (

--- a/packages/api/src/utils/uploads.ts
+++ b/packages/api/src/utils/uploads.ts
@@ -15,6 +15,13 @@ const storage = env.fileUpload?.gcsUploadSAKeyFilePath
   : new Storage()
 const bucketName = env.fileUpload.gcsUploadBucket
 
+export const getFilePublicUrl = (filePathName: string): string => {
+  return storage
+    .bucket(bucketName)
+    .file(filePathName)
+    .publicUrl()
+}
+
 export const generateUploadSignedUrl = async (
   filePathName: string,
   contentType: string,

--- a/packages/api/test/resolvers/upload_file_request.test.ts
+++ b/packages/api/test/resolvers/upload_file_request.test.ts
@@ -89,10 +89,17 @@ describe('uploadFileRequest API', () => {
       })
 
       it('should create an article if create article is true', async () => {
-        const res = uploadFileRequest(authToken, 'https://www.google.com', clientRequestId, true).expect(200)
+        const res = await uploadFileRequest(authToken, 'https://www.google.com', clientRequestId, true)
         expect(res.body.data.uploadFileRequest.createdPageId).to.eql(clientRequestId)
         const page = await getPageById(clientRequestId)
         expect(page).to.be
+      })
+
+      it('should not save a file:// URL', async () => {
+        const res = await uploadFileRequest(authToken, 'file://foo.bar', clientRequestId, true)
+        expect(res.body.data.uploadFileRequest.createdPageId).to.eql(clientRequestId)
+        const page = await getPageById(clientRequestId)
+        expect(page.url).to.startWith("https://")
       })
     })
   })

--- a/packages/api/test/resolvers/upload_file_request.test.ts
+++ b/packages/api/test/resolvers/upload_file_request.test.ts
@@ -99,7 +99,7 @@ describe('uploadFileRequest API', () => {
         const res = await uploadFileRequest(authToken, 'file://foo.bar', clientRequestId, true)
         expect(res.body.data.uploadFileRequest.createdPageId).to.eql(clientRequestId)
         const page = await getPageById(clientRequestId)
-        expect(page.url).to.startWith("https://")
+        expect(page?.url).to.startWith("https://")
       })
     })
   })

--- a/packages/api/test/resolvers/upload_file_request.test.ts
+++ b/packages/api/test/resolvers/upload_file_request.test.ts
@@ -1,0 +1,100 @@
+import { createTestUser, deleteTestUser } from '../db'
+import {
+  generateFakeUuid,
+  graphqlRequest,
+  request,
+} from '../util'
+import * as chai from 'chai'
+import { expect } from 'chai'
+import 'mocha'
+import { User } from '../../src/entity/user'
+import chaiString from 'chai-string'
+import {
+  PageContext,
+} from '../../src/elastic/types'
+import { createPubSubClient } from '../../src/datalayer/pubsub'
+import {
+  deletePage,
+  getPageById,
+} from '../../src/elastic/pages'
+
+chai.use(chaiString)
+
+// INPUT
+// clientRequestId?: InputMaybe<Scalars['String']>;
+// contentType: Scalars['String'];
+// createPageEntry?: InputMaybe<Scalars['Boolean']>;
+// url: Scalars['String'];
+
+const uploadFileRequest = async (
+  authToken: string,
+  inputUrl: string,
+  clientRequestId: string,
+  createPageEntry = true
+  ) => {
+  const query = `
+  mutation {
+    uploadFileRequest(
+      input: {
+        contentType: "application/pdf",
+        clientRequestId: "${clientRequestId}",
+        createPageEntry: ${createPageEntry},
+        url: "${inputUrl}"
+      }
+    ) {
+      ... on ArchiveLinkSuccess {
+        linkId
+      }
+      ... on ArchiveLinkError {
+        errorCodes
+      }
+    }
+  }
+  `
+  return graphqlRequest(query, authToken).expect(200)
+}
+
+describe('uploadFileRequest API', () => {
+  const username = 'fakeUser'
+  let authToken: string
+  let user: User
+  let ctx: PageContext
+
+  before(async () => {
+    // create test user and login
+    user = await createTestUser(username)
+    const res = await request
+      .post('/local/debug/fake-user-login')
+      .send({ fakeEmail: user.email })
+
+    authToken = res.body.authToken
+
+    ctx = {
+      pubsub: createPubSubClient(),
+      refresh: true,
+      uid: user.id,
+    }
+  })
+
+  after(async () => {
+    await deleteTestUser(username)
+  })
+
+  describe('UploadFileRequest', () => {
+    context('when create article is true', () => {
+      const clientRequestId = generateFakeUuid()
+
+      after(async () => {
+        await deletePage(clientRequestId, ctx)
+      })
+
+      it('should create an article if create article is true', async () => {
+        const res = uploadFileRequest(authToken, 'https://www.google.com', clientRequestId, true).expect(200)
+        expect(res.body.data.uploadFileRequest.createdPageId).to.eql(clientRequestId)
+        const page = await getPageById(clientRequestId)
+        expect(page).to.be
+      })
+    })
+  })
+})
+


### PR DESCRIPTION
- If creating a request from a file URL, dont try fuzzy matching on URL
- When creating pages from uploaded files use their signed URL as the page URL
- Use the public GCS URL for local uploaded files
