### PR TITLE
Fix: Inactive Reader Nav 

### DIFF
--- a/apple/OmnivoreKit/Sources/App/Views/WebReader/WebReaderContainer.swift
+++ b/apple/OmnivoreKit/Sources/App/Views/WebReader/WebReaderContainer.swift
@@ -165,7 +165,7 @@ import WebKit
               showNavBarActionID = UUID()
             }
           }
-          .sheet(item: $safariWebLink) {
+          .fullScreenCover(item: $safariWebLink) {
             SafariView(url: $0.url)
           }
           .sheet(isPresented: $showHighlightAnnotationModal) {


### PR DESCRIPTION
For some reason the back button and web prefs button gets disabled when we open a SafariView as a sheet. No idea why but using `fullScreenCover` instead doesn't create the same issue. 