### PR TITLE
add savedAt to searchItem

### DIFF
--- a/packages/api/src/elastic/highlights.ts
+++ b/packages/api/src/elastic/highlights.ts
@@ -206,7 +206,15 @@ export const searchHighlights = async (
       ],
       from,
       size,
-      _source: ['title', 'slug', 'url', 'createdAt', 'highlights'],
+      _source: [
+        'title',
+        'slug',
+        'url',
+        'savedAt',
+        'highlights',
+        'readingProgressPercent',
+        'readingProgressAnchorIndex',
+      ],
     }
 
     console.log('searching highlights in elastic', JSON.stringify(searchBody))

--- a/packages/api/src/elastic/types.ts
+++ b/packages/api/src/elastic/types.ts
@@ -162,7 +162,7 @@ export interface Highlight {
   suffix?: string | null
   annotation?: string | null
   sharedAt?: Date | null
-  updatedAt?: Date | null
+  updatedAt?: Date
   labels?: Label[]
 }
 
@@ -226,6 +226,7 @@ export interface SearchItem {
   language?: string
   readAt?: Date
   savedAt: Date
+  updatedAt?: Date
 }
 
 const keys = ['_id', 'url', 'slug', 'userId', 'uploadFileId', 'state'] as const

--- a/packages/api/src/elastic/types.ts
+++ b/packages/api/src/elastic/types.ts
@@ -219,12 +219,13 @@ export interface SearchItem {
   uploadFileId?: string | null
   url: string
   archivedAt?: Date | null
-  readingProgressPercent?: number
-  readingProgressAnchorIndex?: number
+  readingProgressPercent: number
+  readingProgressAnchorIndex: number
   userId: string
   state?: ArticleSavingRequestStatus
   language?: string
   readAt?: Date
+  savedAt: Date
 }
 
 const keys = ['_id', 'url', 'slug', 'userId', 'uploadFileId', 'state'] as const

--- a/packages/api/src/generated/graphql.ts
+++ b/packages/api/src/generated/graphql.ts
@@ -1524,8 +1524,9 @@ export type SearchItem = {
   publishedAt?: Maybe<Scalars['Date']>;
   quote?: Maybe<Scalars['String']>;
   readAt?: Maybe<Scalars['Date']>;
-  readingProgressAnchorIndex?: Maybe<Scalars['Int']>;
-  readingProgressPercent?: Maybe<Scalars['Float']>;
+  readingProgressAnchorIndex: Scalars['Int'];
+  readingProgressPercent: Scalars['Float'];
+  savedAt: Scalars['Date'];
   shortId?: Maybe<Scalars['String']>;
   siteName?: Maybe<Scalars['String']>;
   slug: Scalars['String'];
@@ -3852,8 +3853,9 @@ export type SearchItemResolvers<ContextType = ResolverContext, ParentType extend
   publishedAt?: Resolver<Maybe<ResolversTypes['Date']>, ParentType, ContextType>;
   quote?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   readAt?: Resolver<Maybe<ResolversTypes['Date']>, ParentType, ContextType>;
-  readingProgressAnchorIndex?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
-  readingProgressPercent?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  readingProgressAnchorIndex?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  readingProgressPercent?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
+  savedAt?: Resolver<ResolversTypes['Date'], ParentType, ContextType>;
   shortId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   siteName?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   slug?: Resolver<ResolversTypes['String'], ParentType, ContextType>;

--- a/packages/api/src/generated/graphql.ts
+++ b/packages/api/src/generated/graphql.ts
@@ -1535,7 +1535,7 @@ export type SearchItem = {
   title: Scalars['String'];
   unsubHttpUrl?: Maybe<Scalars['String']>;
   unsubMailTo?: Maybe<Scalars['String']>;
-  updatedAt: Scalars['Date'];
+  updatedAt?: Maybe<Scalars['Date']>;
   uploadFileId?: Maybe<Scalars['ID']>;
   url: Scalars['String'];
 };
@@ -3864,7 +3864,7 @@ export type SearchItemResolvers<ContextType = ResolverContext, ParentType extend
   title?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   unsubHttpUrl?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   unsubMailTo?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  updatedAt?: Resolver<ResolversTypes['Date'], ParentType, ContextType>;
+  updatedAt?: Resolver<Maybe<ResolversTypes['Date']>, ParentType, ContextType>;
   uploadFileId?: Resolver<Maybe<ResolversTypes['ID']>, ParentType, ContextType>;
   url?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;

--- a/packages/api/src/generated/schema.graphql
+++ b/packages/api/src/generated/schema.graphql
@@ -1093,7 +1093,7 @@ type SearchItem {
   title: String!
   unsubHttpUrl: String
   unsubMailTo: String
-  updatedAt: Date!
+  updatedAt: Date
   uploadFileId: ID
   url: String!
 }

--- a/packages/api/src/generated/schema.graphql
+++ b/packages/api/src/generated/schema.graphql
@@ -1082,8 +1082,9 @@ type SearchItem {
   publishedAt: Date
   quote: String
   readAt: Date
-  readingProgressAnchorIndex: Int
-  readingProgressPercent: Float
+  readingProgressAnchorIndex: Int!
+  readingProgressPercent: Float!
+  savedAt: Date!
   shortId: String
   siteName: String
   slug: String!

--- a/packages/api/src/resolvers/article/index.ts
+++ b/packages/api/src/resolvers/article/index.ts
@@ -813,7 +813,7 @@ export const searchResolver = authorized<
     },
   })
 
-  let results: (SearchItemData | Page)[]
+  let results: SearchItemData[]
   let totalCount: number
 
   const searchType = searchQuery.typeFilter

--- a/packages/api/src/schema.ts
+++ b/packages/api/src/schema.ts
@@ -1473,7 +1473,7 @@ const schema = gql`
     pageType: PageType!
     contentReader: ContentReader!
     createdAt: Date!
-    updatedAt: Date!
+    updatedAt: Date
     isArchived: Boolean!
     readingProgressPercent: Float!
     readingProgressAnchorIndex: Int!

--- a/packages/api/src/schema.ts
+++ b/packages/api/src/schema.ts
@@ -1475,8 +1475,8 @@ const schema = gql`
     createdAt: Date!
     updatedAt: Date!
     isArchived: Boolean!
-    readingProgressPercent: Float
-    readingProgressAnchorIndex: Int
+    readingProgressPercent: Float!
+    readingProgressAnchorIndex: Int!
     author: String
     image: String
     description: String
@@ -1498,6 +1498,7 @@ const schema = gql`
     siteName: String
     language: String
     readAt: Date
+    savedAt: Date!
   }
 
   type SearchItemEdge {


### PR DESCRIPTION
- Add savedAt to searchItem and make readingProgress required
- Add savedAt to searchItem and make readingProgress required in elastic
- Make updatedAt optional
- Fetch page savedAt, readingProgress from elastic
- Update resolver
