### PR TITLE
Force the height of the primary layout content space

### DIFF
--- a/packages/web/components/templates/PrimaryLayout.tsx
+++ b/packages/web/components/templates/PrimaryLayout.tsx
@@ -82,8 +82,8 @@ export function PrimaryLayout(props: PrimaryLayoutProps): JSX.Element {
         />
         <Box
           css={{
-            minHeight: '100%',
-            minWidth: '100vw',
+            height: '100%',
+            width: '100vw',
             bg: '$grayBase',
           }}
         >


### PR DESCRIPTION
This is needed so the PDF container gets a size set
on it, because it can't expand content to fit its size.
