### PR TITLE
never expire tokens

### DIFF
--- a/packages/web/pages/settings/api.tsx
+++ b/packages/web/pages/settings/api.tsx
@@ -91,7 +91,7 @@ export default function Api(): JSX.Element {
         label: 'Name',
         onChange: setName,
         name: 'name',
-        value: `${router.query ? router.query?.create : value}`,
+        value: `${router.query?.create ? router.query?.create : value}`,
         required: true,
       },
       {

--- a/packages/web/pages/settings/api.tsx
+++ b/packages/web/pages/settings/api.tsx
@@ -35,6 +35,7 @@ export default function Api(): JSX.Element {
   const defaultExpiresAt = new Date(Date.now() + 1000 * 60 * 60 * 24 * 365)
     .toISOString()
     .split('T')[0]
+  const neverExpiresDate = new Date(8640000000000000)
 
   const router = useRouter()
   useEffect(() => {
@@ -56,7 +57,9 @@ export default function Api(): JSX.Element {
         usedAt: apiKey.usedAt
           ? new Date(apiKey.usedAt).toISOString()
           : 'Never used',
-        expiresAt: new Date(apiKey.expiresAt).toDateString(),
+        expiresAt: new Date(apiKey.expiresAt).getTime() != neverExpiresDate.getTime()
+          ? new Date(apiKey.expiresAt).toDateString()
+          : 'Never',
       })
     )
     return rows
@@ -116,7 +119,7 @@ export default function Api(): JSX.Element {
             case 'Never':
               break;
           }
-          const newExpires = additionalDays ? new Date() : new Date(8640000000000000)
+          const newExpires = additionalDays ? new Date() : neverExpiresDate
           if (additionalDays) {
             newExpires.setDate(newExpires.getDate() + additionalDays)
           }

--- a/packages/web/pages/settings/api.tsx
+++ b/packages/web/pages/settings/api.tsx
@@ -95,33 +95,35 @@ export default function Api(): JSX.Element {
         required: true,
       },
       {
-        label: 'Expires in',
+        label: 'Expires',
         name: 'expiredAt',
         required: true,
         onChange: (e) => {
           let additionalDays = 0
           switch (e.target.value) {
-            case '7 days':
+            case 'in 7 days':
               additionalDays = 7
               break
-            case '30 days':
+            case 'in 30 days':
               additionalDays = 30
               break
-            case '90 days':
+            case 'in 90 days':
               additionalDays = 90
               break
-            case '1 year':
+            case 'in 1 year':
               additionalDays = 365
               break
-            case 'never':
+            case 'Never':
               break;
           }
-          const newExpires = new Date()
-          newExpires.setDate(newExpires.getDate() + additionalDays)
+          const newExpires = additionalDays ? new Date() : new Date(8640000000000000)
+          if (additionalDays) {
+            newExpires.setDate(newExpires.getDate() + additionalDays)
+          }
           setExpiresAt(newExpires)
         },
         type: 'select',
-        options: ['7 days', '30 days', '90 days', '1 year', 'never'],
+        options: ['in 7 days', 'in 30 days', 'in 90 days', 'in 1 year', 'Never'],
         value: defaultExpiresAt,
       },
     ])

--- a/packages/web/pages/settings/api.tsx
+++ b/packages/web/pages/settings/api.tsx
@@ -39,13 +39,12 @@ export default function Api(): JSX.Element {
   const router = useRouter()
   useEffect(() => {
     if (Object.keys(router.query).length) {
-      //setValue(`${router.query.create}`)
-      //console.log(value);
+      setValue(`${router.query?.create}`)
       setExpiresAt(new Date(defaultExpiresAt))
       onAdd()
       setAddModalOpen(true)
     }
-  }, [router])
+  }, [router.query])
 
   const headers = ['Name', 'Scopes', 'Used at', 'Expires on']
   const rows = useMemo(() => {
@@ -92,7 +91,7 @@ export default function Api(): JSX.Element {
         label: 'Name',
         onChange: setName,
         name: 'name',
-        value: value,
+        value: `${router.query ? router.query?.create : value}`,
         required: true,
       },
       {

--- a/packages/web/pages/settings/api.tsx
+++ b/packages/web/pages/settings/api.tsx
@@ -113,13 +113,15 @@ export default function Api(): JSX.Element {
             case '1 year':
               additionalDays = 365
               break
+            case 'never':
+              break;
           }
           const newExpires = new Date()
           newExpires.setDate(newExpires.getDate() + additionalDays)
           setExpiresAt(newExpires)
         },
         type: 'select',
-        options: ['7 days', '30 days', '90 days', '1 year'],
+        options: ['7 days', '30 days', '90 days', '1 year', 'never'],
         value: defaultExpiresAt,
       },
     ])

--- a/packages/web/styles/globals.css
+++ b/packages/web/styles/globals.css
@@ -274,6 +274,15 @@ div#appleid-signin {
   cursor: pointer;
 }
 
+select {
+  color: var(--colors-grayTextContrast);
+  background-color: transparent;
+}
+
+select option {
+  background-color: transparent;
+}
+
 input[type=range]::-webkit-slider-thumb {
   -webkit-appearance: none;
   border: none;


### PR DESCRIPTION
- Allow opening the create api token dialog on the /settings/api page via a URL
- adding prepopulation for input
- Set select color and background colors so OS themes dont override them
- fixed bug for input text showing undefined value
- Added never as one of the options
- Add support for "never" expiring tokens by setting to the Date MAX_AGE
- Better printing of never expiring tokens
