### PR TITLE
Shorten the timeout requesting pages

### DIFF
--- a/packages/content-fetch/fetch-content.js
+++ b/packages/content-fetch/fetch-content.js
@@ -540,7 +540,7 @@ async function retrievePage(url) {
   });
 
   try {
-    const response = await page.goto(url, { waitUntil: ['networkidle2'] });
+    const response = await page.goto(url, { timeout: 8 * 1000, waitUntil: ['networkidle2'] });
     const finalUrl = response.url();
     const contentType = response.headers()['content-type'];
 


### PR DESCRIPTION
I believe our process is sometimes being terminated before this
timeout is hit, which means we then don't have time to fetch
with a fallback.
