### PR TITLE
Add support for newsletters hosted on getrevue.co

### DIFF
--- a/packages/api/src/utils/parser.ts
+++ b/packages/api/src/utils/parser.ts
@@ -443,6 +443,14 @@ export const isProbablyNewsletter = async (html: string): Promise<boolean> => {
     }
   }
 
+  // Check if this is a newsletter from revue
+  if (dom.querySelectorAll('img[src*="getrevue.co"]').length > 0) {
+    const getrevueUrl = revueNewsletterHref(dom)
+    if (getrevueUrl) {
+      return true
+    }
+  }
+
   return false
 }
 

--- a/packages/api/src/utils/parser.ts
+++ b/packages/api/src/utils/parser.ts
@@ -457,6 +457,17 @@ const beehiivNewsletterHref = (dom: Document): string | undefined => {
   return res
 }
 
+const revueNewsletterHref = (dom: Document): string | undefined => {
+  const viewOnline = dom.querySelectorAll('table tr td div a[target="_blank"]')
+  let res: string | undefined = undefined
+  viewOnline.forEach((e) => {
+    if (e.textContent === 'View online') {
+      res = e.getAttribute('href') || undefined
+    }
+  })
+  return res
+}
+
 const findNewsletterHeaderHref = (dom: Document): string | undefined => {
   // Substack header links
   const postLink = dom.querySelector('h1 a ')
@@ -468,6 +479,12 @@ const findNewsletterHeaderHref = (dom: Document): string | undefined => {
   const beehiiv = beehiivNewsletterHref(dom)
   if (beehiiv) {
     return beehiiv
+  }
+
+  // Check if this is a revue newsletter
+  const revue = revueNewsletterHref(dom)
+  if (revue) {
+    return revue
   }
 
   return undefined


### PR DESCRIPTION
- Check and get Revue newsletter url from email
- Add support for newsletters hosted on getrevue.co
