### PR TITLE
fix/unsubscribe email not saved

### DIFF
--- a/packages/api/src/routers/svc/emails.ts
+++ b/packages/api/src/routers/svc/emails.ts
@@ -13,6 +13,8 @@ interface ForwardEmailMessage {
   to: string
   subject: string
   html: string
+  unsubMailTo?: string
+  unsubHttpUrl?: string
 }
 
 export function emailsServiceRouter() {
@@ -61,6 +63,8 @@ export function emailsServiceRouter() {
           url:
             (await findNewsletterUrl(data.html)) ||
             'https://omnivore.app/no_url?q' + uuid(),
+          unsubMailTo: data.unsubMailTo,
+          unsubHttpUrl: data.unsubHttpUrl,
         })
         res.status(200).send('Newsletter')
         return

--- a/packages/inbound-email-handler/src/index.ts
+++ b/packages/inbound-email-handler/src/index.ts
@@ -19,8 +19,15 @@ import { BloombergHandler } from './bloomberg-handler'
 import { GolangHandler } from './golang-handler'
 import { MorningBrewHandler } from './morning-brew-handler'
 
+interface Unsubscribe {
+  mailTo?: string
+  httpUrl?: string
+}
+
 const NON_NEWSLETTER_EMAIL_TOPIC = 'nonNewsletterEmailReceived'
 const pubsub = new PubSub()
+const UNSUBSCRIBE_HTTP_URL_PATTERN = /<(https?:\/\/[^>]*)>/
+const UNSUBSCRIBE_MAIL_TO_PATTERN = /<mailto:([^>]*)>/
 
 const NEWSLETTER_HANDLERS = [
   new SubstackHandler(),
@@ -29,6 +36,15 @@ const NEWSLETTER_HANDLERS = [
   new GolangHandler(),
   new MorningBrewHandler(),
 ]
+
+export const parseUnsubscribe = (unSubHeader: string): Unsubscribe => {
+  // parse list-unsubscribe header
+  // e.g. List-Unsubscribe: <https://omnivore.com/unsub>, <mailto:unsub@omnivore.com>
+  return {
+    mailTo: unSubHeader.match(UNSUBSCRIBE_MAIL_TO_PATTERN)?.[1],
+    httpUrl: unSubHeader.match(UNSUBSCRIBE_HTTP_URL_PATTERN)?.[1],
+  }
+}
 
 export const getNewsletterHandler = (
   postHeader: string,

--- a/packages/inbound-email-handler/src/index.ts
+++ b/packages/inbound-email-handler/src/index.ts
@@ -130,6 +130,7 @@ export const inboundEmailHandler = Sentry.GCPFunction.wrapHttpFunction(
             )
           }
 
+          const unsubscribe = parseUnsubscribe(unSubHeader)
           // queue non-newsletter emails
           await pubsub.topic(NON_NEWSLETTER_EMAIL_TOPIC).publishMessage({
             json: {
@@ -138,6 +139,8 @@ export const inboundEmailHandler = Sentry.GCPFunction.wrapHttpFunction(
               subject: subject,
               html: html,
               text: text,
+              unsubMailTo: unsubscribe.mailTo,
+              unsubHttpUrl: unsubscribe.httpUrl,
             },
           })
         }

--- a/packages/inbound-email-handler/src/index.ts
+++ b/packages/inbound-email-handler/src/index.ts
@@ -10,6 +10,7 @@ import {
   handleConfirmation,
   isConfirmationEmail,
   NewsletterHandler,
+  parseUnsubscribe,
 } from './newsletter'
 import { PubSub } from '@google-cloud/pubsub'
 import { handlePdfAttachment } from './pdf'
@@ -19,16 +20,8 @@ import { BloombergHandler } from './bloomberg-handler'
 import { GolangHandler } from './golang-handler'
 import { MorningBrewHandler } from './morning-brew-handler'
 
-interface Unsubscribe {
-  mailTo?: string
-  httpUrl?: string
-}
-
 const NON_NEWSLETTER_EMAIL_TOPIC = 'nonNewsletterEmailReceived'
 const pubsub = new PubSub()
-const UNSUBSCRIBE_HTTP_URL_PATTERN = /<(https?:\/\/[^>]*)>/
-const UNSUBSCRIBE_MAIL_TO_PATTERN = /<mailto:([^>]*)>/
-
 const NEWSLETTER_HANDLERS = [
   new SubstackHandler(),
   new AxiosHandler(),
@@ -36,15 +29,6 @@ const NEWSLETTER_HANDLERS = [
   new GolangHandler(),
   new MorningBrewHandler(),
 ]
-
-export const parseUnsubscribe = (unSubHeader: string): Unsubscribe => {
-  // parse list-unsubscribe header
-  // e.g. List-Unsubscribe: <https://omnivore.com/unsub>, <mailto:unsub@omnivore.com>
-  return {
-    mailTo: unSubHeader.match(UNSUBSCRIBE_MAIL_TO_PATTERN)?.[1],
-    httpUrl: unSubHeader.match(UNSUBSCRIBE_HTTP_URL_PATTERN)?.[1],
-  }
-}
 
 export const getNewsletterHandler = (
   postHeader: string,

--- a/packages/inbound-email-handler/src/newsletter.ts
+++ b/packages/inbound-email-handler/src/newsletter.ts
@@ -1,7 +1,11 @@
 import { PubSub } from '@google-cloud/pubsub'
 import { v4 as uuidv4 } from 'uuid'
 import addressparser from 'addressparser'
-import { parseUnsubscribe } from './index'
+
+interface Unsubscribe {
+  mailTo?: string
+  httpUrl?: string
+}
 
 const pubsub = new PubSub()
 const NEWSLETTER_EMAIL_RECEIVED_TOPIC = 'newsletterEmailReceived'
@@ -10,6 +14,17 @@ const EMAIL_FORWARDING_SENDER_ADDRESSES = [
   'Gmail Team <forwarding-noreply@google.com>',
 ]
 const CONFIRMATION_CODE_PATTERN = /^\(#\d+\)/
+const UNSUBSCRIBE_HTTP_URL_PATTERN = /<(https?:\/\/[^>]*)>/
+const UNSUBSCRIBE_MAIL_TO_PATTERN = /<mailto:([^>]*)>/
+
+export const parseUnsubscribe = (unSubHeader: string): Unsubscribe => {
+  // parse list-unsubscribe header
+  // e.g. List-Unsubscribe: <https://omnivore.com/unsub>, <mailto:unsub@omnivore.com>
+  return {
+    mailTo: unSubHeader.match(UNSUBSCRIBE_MAIL_TO_PATTERN)?.[1],
+    httpUrl: unSubHeader.match(UNSUBSCRIBE_HTTP_URL_PATTERN)?.[1],
+  }
+}
 
 export class NewsletterHandler {
   protected senderRegex = /NEWSLETTER_SENDER_REGEX/

--- a/packages/inbound-email-handler/test/newsletter.test.ts
+++ b/packages/inbound-email-handler/test/newsletter.test.ts
@@ -8,7 +8,7 @@ import { SubstackHandler } from '../src/substack-handler'
 import { AxiosHandler } from '../src/axios-handler'
 import { BloombergHandler } from '../src/bloomberg-handler'
 import { GolangHandler } from '../src/golang-handler'
-import { getNewsletterHandler } from '../src'
+import { getNewsletterHandler, parseUnsubscribe } from '../src'
 import { MorningBrewHandler } from '../src/morning-brew-handler'
 
 describe('Confirmation email test', () => {
@@ -158,17 +158,13 @@ describe('Newsletter email test', () => {
     it('returns mail to address if exists', () => {
       const header = `<https://omnivore.com/unsub>, <mailto:${mailTo}>`
 
-      expect(new NewsletterHandler().parseUnsubscribe(header).mailTo).to.equal(
-        mailTo
-      )
+      expect(parseUnsubscribe(header).mailTo).to.equal(mailTo)
     })
 
     it('returns http url if exists', () => {
       const header = `<${httpUrl}>`
 
-      expect(new NewsletterHandler().parseUnsubscribe(header).httpUrl).to.equal(
-        httpUrl
-      )
+      expect(parseUnsubscribe(header).httpUrl).to.equal(httpUrl)
     })
   })
 })

--- a/packages/inbound-email-handler/test/newsletter.test.ts
+++ b/packages/inbound-email-handler/test/newsletter.test.ts
@@ -3,12 +3,13 @@ import {
   getConfirmationCode,
   isConfirmationEmail,
   NewsletterHandler,
+  parseUnsubscribe,
 } from '../src/newsletter'
 import { SubstackHandler } from '../src/substack-handler'
 import { AxiosHandler } from '../src/axios-handler'
 import { BloombergHandler } from '../src/bloomberg-handler'
 import { GolangHandler } from '../src/golang-handler'
-import { getNewsletterHandler, parseUnsubscribe } from '../src'
+import { getNewsletterHandler } from '../src'
 import { MorningBrewHandler } from '../src/morning-brew-handler'
 
 describe('Confirmation email test', () => {


### PR DESCRIPTION
- Move parseUnsubscribeHeader to index.ts
- Publish unsubscribe header info in the non-newsletter queue
- Save unsubscribe email address or http url of newsletter emails
