### PR TITLE
Improve formatting for content display report emails

### DIFF
--- a/packages/api/src/events/reports/content_display_report_created.ts
+++ b/packages/api/src/events/reports/content_display_report_created.ts
@@ -19,7 +19,9 @@ export class ContentDisplayReportSubscriber
 
   async afterInsert(event: InsertEvent<ContentDisplayReport>): Promise<void> {
     const report = event.entity
-    const message = `A new content display report was created by ${report.userId} for URL': ${report.originalUrl}: ${report.reportComment}`
+    const message = `A new content display report was created by:
+                    ${report.userId} for URL': ${report.originalUrl}
+                    ${report.reportComment}`
 
     console.log(message)
 


### PR DESCRIPTION
With the previous formatting the `:` could be appended
to the end of URLs.
