### PR TITLE
Set a z-index on the omnivore name logo element

### DIFF
--- a/packages/web/components/patterns/PrimaryHeader.tsx
+++ b/packages/web/components/patterns/PrimaryHeader.tsx
@@ -239,6 +239,7 @@ function FloatingNavHeader(props: NavHeaderProps): JSX.Element {
             position: 'fixed',
             display: 'flex',
             alignItems: 'center',
+            zIndex: 100,
           }}
         >
           <OmnivoreNameLogo href={props.username ? '/home' : '/login'} />


### PR DESCRIPTION
When the OmnivoreNameLogo is a floating element we need to
set a z-index on it to ensure that it is above the left
article action menu items.

This fixes issues where the name logo might not be clickable on
wider screens.
