### PR TITLE
Apple App Association: Webcredentials

### DIFF
--- a/packages/web/public/.well-known/apple-app-site-association
+++ b/packages/web/public/.well-known/apple-app-site-association
@@ -13,5 +13,10 @@
         ]
       }
     ]
+  },
+  "webcredentials": {
+    "apps": [
+      "QJF2XZ86HB.app.omnivore.app"
+    ]
   }
 }


### PR DESCRIPTION
Adds webcredentials to our apple app association file so credential auto-fill can work.
