### PR TITLE
Save articles by sending emails to omnivore inbox

### DIFF
--- a/packages/api/src/routers/svc/newsletters.ts
+++ b/packages/api/src/routers/svc/newsletters.ts
@@ -96,7 +96,7 @@ export function newsletterServiceRouter() {
 
       const result = await saveNewsletterEmail(data)
       if (!result) {
-        console.log('Error createing newsletter link from data', data)
+        console.log('Error creating newsletter link from data', data)
         res.status(500).send('Error creating newsletter link')
         return
       }

--- a/packages/api/src/services/save_newsletter_email.ts
+++ b/packages/api/src/services/save_newsletter_email.ts
@@ -11,6 +11,7 @@ import { getDeviceTokensByUserId } from './user_device_tokens'
 import { Page } from '../elastic/types'
 import { addLabelToPage } from './labels'
 import { saveSubscription } from './subscriptions'
+import { NewsletterEmail } from '../entity/newsletter_email'
 
 interface NewsletterMessage {
   email: string
@@ -20,6 +21,7 @@ interface NewsletterMessage {
   author: string
   unsubMailTo?: string
   unsubHttpUrl?: string
+  newsletterEmail?: NewsletterEmail
 }
 
 // Returns true if the link was created successfully. Can still fail to
@@ -29,7 +31,8 @@ export const saveNewsletterEmail = async (
   ctx?: SaveContext
 ): Promise<boolean> => {
   // get user from newsletter email
-  const newsletterEmail = await getNewsletterEmail(data.email)
+  const newsletterEmail =
+    data.newsletterEmail || (await getNewsletterEmail(data.email))
 
   if (!newsletterEmail) {
     console.log('newsletter email not found', data.email)

--- a/packages/api/src/utils/parser.ts
+++ b/packages/api/src/utils/parser.ts
@@ -18,6 +18,7 @@ import { parseHTML } from 'linkedom'
 import { getRepository } from '../entity/utils'
 import { User } from '../entity/user'
 import { ILike } from 'typeorm'
+import { v4 as uuid } from 'uuid'
 
 const logger = buildLogger('utils.parse')
 
@@ -558,4 +559,11 @@ export const isProbablyArticle = async (
     email: ILike(email),
   })
   return !!user || subject.includes(ARTICLE_PREFIX)
+}
+
+export const generateUniqueUrl = () => 'https://omnivore.app/no_url?q=' + uuid()
+
+export const getTitleFromEmailSubject = (subject: string) => {
+  const title = subject.replace(ARTICLE_PREFIX, '')
+  return title.trim()
 }

--- a/packages/api/src/utils/parser.ts
+++ b/packages/api/src/utils/parser.ts
@@ -15,6 +15,9 @@ import { GolangHandler } from './golang-handler'
 import * as hljs from 'highlightjs'
 import { decode } from 'html-entities'
 import { parseHTML } from 'linkedom'
+import { getRepository } from '../entity/utils'
+import { User } from '../entity/user'
+import { ILike } from 'typeorm'
 
 const logger = buildLogger('utils.parse')
 
@@ -37,6 +40,7 @@ const DOM_PURIFY_CONFIG = {
     'data-feature',
   ],
 }
+const ARTICLE_PREFIX = 'omnivore:'
 
 interface ContentHandler {
   shouldPrehandle: (url: URL, dom: Document) => boolean
@@ -544,4 +548,14 @@ export const findNewsletterUrl = async (
   }
 
   return undefined
+}
+
+export const isProbablyArticle = async (
+  email: string,
+  subject: string
+): Promise<boolean> => {
+  const user = await getRepository(User).findOneBy({
+    email: ILike(email),
+  })
+  return !!user || subject.includes(ARTICLE_PREFIX)
 }

--- a/packages/api/test/routers/auth.test.ts
+++ b/packages/api/test/routers/auth.test.ts
@@ -1,6 +1,5 @@
 import { createTestUser, deleteTestUser } from '../db'
 import { generateFakeUuid, request } from '../util'
-import { expect } from 'chai'
 import { StatusType } from '../../src/datalayer/user/model'
 import { getRepository } from '../../src/entity/utils'
 import { User } from '../../src/entity/user'
@@ -13,6 +12,10 @@ import {
   generateVerificationToken,
   hashPassword,
 } from '../../src/utils/auth'
+import sinonChai from 'sinon-chai'
+import chai, { expect } from 'chai'
+
+chai.use(sinonChai)
 
 describe('auth router', () => {
   const route = '/api/auth'

--- a/packages/api/test/routers/emails.test.ts
+++ b/packages/api/test/routers/emails.test.ts
@@ -10,6 +10,7 @@ import { expect } from 'chai'
 import { request } from '../util'
 import * as parser from '../../src/utils/parser'
 import * as sendNotification from '../../src/utils/sendNotification'
+import * as sendEmail from '../../src/utils/sendEmail'
 
 describe('Emails Router', () => {
   const username = 'fakeUser'
@@ -29,6 +30,7 @@ describe('Emails Router', () => {
       'sendMulticastPushNotifications',
       sinon.fake.resolves(undefined)
     )
+    sinon.replace(sendEmail, 'sendEmail', sinon.fake.resolves(true))
   })
 
   after(async () => {

--- a/packages/api/test/routers/emails.test.ts
+++ b/packages/api/test/routers/emails.test.ts
@@ -1,0 +1,134 @@
+import {
+  createTestNewsletterEmail,
+  createTestUser,
+  deleteTestUser,
+} from '../db'
+import { User } from '../../src/entity/user'
+import 'mocha'
+import sinon from 'sinon'
+import { expect } from 'chai'
+import { request } from '../util'
+import * as parser from '../../src/utils/parser'
+import * as sendNotification from '../../src/utils/sendNotification'
+
+describe('Emails Router', () => {
+  const username = 'fakeUser'
+  const newsletterEmail = 'fakeUser@omnivore.app'
+
+  let user: User
+  let token: string
+
+  before(async () => {
+    // create test user and login
+    user = await createTestUser(username)
+
+    await createTestNewsletterEmail(user, newsletterEmail)
+    token = process.env.PUBSUB_VERIFICATION_TOKEN!
+    sinon.replace(
+      sendNotification,
+      'sendMulticastPushNotifications',
+      sinon.fake.resolves(undefined)
+    )
+  })
+
+  after(async () => {
+    // clean up
+    await deleteTestUser(username)
+    sinon.restore()
+  })
+
+  describe('forward', () => {
+    const from = 'from@omnivore.app'
+    const to = newsletterEmail
+    const subject = 'test subject'
+    const html = 'test html'
+
+    context('when email is a newsletter', () => {
+      before(() => {
+        sinon.replace(parser, 'isProbablyNewsletter', sinon.fake.resolves(true))
+      })
+
+      after(() => {
+        sinon.restore()
+      })
+
+      it('saves the email as a newsletter', async () => {
+        const data = {
+          message: {
+            data: Buffer.from(
+              JSON.stringify({ from, to, subject, html })
+            ).toString('base64'),
+            publishTime: new Date().toISOString(),
+          },
+        }
+        const res = await request
+          .post(`/svc/pubsub/emails/forward?token=${token}`)
+          .send(data)
+          .expect(200)
+        expect(res.text).to.eql('Newsletter')
+      })
+    })
+
+    context('when email is an article', () => {
+      before(() => {
+        sinon.replace(
+          parser,
+          'isProbablyNewsletter',
+          sinon.fake.resolves(false)
+        )
+        sinon.replace(parser, 'isProbablyArticle', sinon.fake.resolves(true))
+      })
+
+      after(() => {
+        sinon.restore()
+      })
+
+      it('saves the email as an article', async () => {
+        const data = {
+          message: {
+            data: Buffer.from(
+              JSON.stringify({ from, to, subject, html })
+            ).toString('base64'),
+            publishTime: new Date().toISOString(),
+          },
+        }
+        const res = await request
+          .post(`/svc/pubsub/emails/forward?token=${token}`)
+          .send(data)
+          .expect(200)
+        expect(res.text).to.eql('Article')
+      })
+    })
+
+    context('when email is a regular email', () => {
+      before(() => {
+        sinon.replace(
+          parser,
+          'isProbablyNewsletter',
+          sinon.fake.resolves(false)
+        )
+        sinon.replace(parser, 'isProbablyArticle', sinon.fake.resolves(false))
+      })
+
+      after(() => {
+        sinon.restore()
+      })
+
+      it('forwards the email', async () => {
+        const data = {
+          message: {
+            data: Buffer.from(
+              JSON.stringify({ from, to, subject, html })
+            ).toString('base64'),
+            publishTime: new Date().toISOString(),
+          },
+        }
+        const res = await request
+          .post(`/svc/pubsub/emails/forward?token=${token}`)
+          .send(data)
+          .expect(200)
+        expect(res.text).to.eql('Email forwarded')
+      })
+    })
+  })
+})

--- a/packages/api/test/routers/emails.test.ts
+++ b/packages/api/test/routers/emails.test.ts
@@ -25,12 +25,6 @@ describe('Emails Router', () => {
 
     await createTestNewsletterEmail(user, newsletterEmail)
     token = process.env.PUBSUB_VERIFICATION_TOKEN!
-    sinon.replace(
-      sendNotification,
-      'sendMulticastPushNotifications',
-      sinon.fake.resolves(undefined)
-    )
-    sinon.replace(sendEmail, 'sendEmail', sinon.fake.resolves(true))
   })
 
   after(async () => {
@@ -45,13 +39,22 @@ describe('Emails Router', () => {
     const subject = 'test subject'
     const html = 'test html'
 
+    beforeEach(async () => {
+      sinon.replace(
+        sendNotification,
+        'sendMulticastPushNotifications',
+        sinon.fake.resolves(undefined)
+      )
+      sinon.replace(sendEmail, 'sendEmail', sinon.fake.resolves(true))
+    })
+
+    afterEach(() => {
+      sinon.restore()
+    })
+
     context('when email is a newsletter', () => {
       before(() => {
         sinon.replace(parser, 'isProbablyNewsletter', sinon.fake.resolves(true))
-      })
-
-      after(() => {
-        sinon.restore()
       })
 
       it('saves the email as a newsletter', async () => {
@@ -81,10 +84,6 @@ describe('Emails Router', () => {
         sinon.replace(parser, 'isProbablyArticle', sinon.fake.resolves(true))
       })
 
-      after(() => {
-        sinon.restore()
-      })
-
       it('saves the email as an article', async () => {
         const data = {
           message: {
@@ -110,10 +109,6 @@ describe('Emails Router', () => {
           sinon.fake.resolves(false)
         )
         sinon.replace(parser, 'isProbablyArticle', sinon.fake.resolves(false))
-      })
-
-      after(() => {
-        sinon.restore()
       })
 
       it('forwards the email', async () => {

--- a/packages/api/test/utils/parser.test.ts
+++ b/packages/api/test/utils/parser.test.ts
@@ -5,12 +5,15 @@ import 'chai/register-should'
 import fs from 'fs'
 import {
   findNewsletterUrl,
+  isProbablyArticle,
   isProbablyNewsletter,
   parsePageMetadata,
   parsePreparedContent,
 } from '../../src/utils/parser'
 import nock from 'nock'
 import chaiAsPromised from 'chai-as-promised'
+import { User } from '../../src/entity/user'
+import { createTestUser, deleteTestUser } from '../db'
 
 chai.use(chaiAsPromised)
 
@@ -133,5 +136,27 @@ describe('parsePreparedContent', async () => {
     expect(result.parsedContent?.title).to.equal(
       'The Ultimate Guide to Practicing Medicine in Singapore – Part 2'
     )
+  })
+})
+
+describe('isProbablyArticle', () => {
+  let user: User
+
+  before(async () => {
+    user = await createTestUser('fakeUser')
+  })
+
+  after(async () => {
+    await deleteTestUser(user.name)
+  })
+
+  it('returns true when email is signed up with us', async () => {
+    const email = user.email
+    expect(await isProbablyArticle(email, 'test subject')).to.be.true
+  })
+
+  it('returns true when subject has omnivore: prefix', async () => {
+    const subject = 'omnivore: test subject'
+    expect(await isProbablyArticle('test-email', subject)).to.be.true
   })
 })

--- a/packages/api/test/utils/parser.test.ts
+++ b/packages/api/test/utils/parser.test.ts
@@ -5,6 +5,8 @@ import 'chai/register-should'
 import fs from 'fs'
 import {
   findNewsletterUrl,
+  generateUniqueUrl,
+  getTitleFromEmailSubject,
   isProbablyArticle,
   isProbablyNewsletter,
   parsePageMetadata,
@@ -158,5 +160,22 @@ describe('isProbablyArticle', () => {
   it('returns true when subject has omnivore: prefix', async () => {
     const subject = 'omnivore: test subject'
     expect(await isProbablyArticle('test-email', subject)).to.be.true
+  })
+})
+
+describe('generateUniqueUrl', () => {
+  it('generates a unique URL', () => {
+    const url1 = generateUniqueUrl()
+    const url2 = generateUniqueUrl()
+
+    expect(url1).to.not.eql(url2)
+  })
+})
+
+describe('getTitleFromEmailSubject', () => {
+  it('returns the title from the email subject', () => {
+    const title = 'test subject'
+    const subject = `omnivore: ${title}`
+    expect(getTitleFromEmailSubject(subject)).to.eql(title)
   })
 })

--- a/packages/inbound-email-handler/src/index.ts
+++ b/packages/inbound-email-handler/src/index.ts
@@ -119,11 +119,11 @@ export const inboundEmailHandler = Sentry.GCPFunction.wrapHttpFunction(
         // queue non-newsletter emails
         await pubsub.topic(NON_NEWSLETTER_EMAIL_TOPIC).publishMessage({
           json: {
-            from: from,
+            from,
             to: recipientAddress,
-            subject: subject,
-            html: html,
-            text: text,
+            subject,
+            html,
+            text,
             unsubMailTo: unsubscribe.mailTo,
             unsubHttpUrl: unsubscribe.httpUrl,
           },
@@ -140,11 +140,11 @@ export const inboundEmailHandler = Sentry.GCPFunction.wrapHttpFunction(
         // queue error emails
         await pubsub.topic(NON_NEWSLETTER_EMAIL_TOPIC).publishMessage({
           json: {
-            from: from,
+            from,
             to: recipientAddress,
-            subject: subject,
-            html: html,
-            text: text,
+            subject,
+            html,
+            text,
           },
         })
       }


### PR DESCRIPTION
- Add function isProbablyArticle to test if a forwarded email contains an article to save
- Save article from forwarding emails
- Save emails with a subject containing `omnivore:` (case-insensitive) or from a sender email registered with us