### PR TITLE
Use a more muted colour for the PWA splash screen

### DIFF
--- a/packages/web/public/manifest.webmanifest
+++ b/packages/web/public/manifest.webmanifest
@@ -26,7 +26,7 @@
   },
   "display": "standalone",
   "display_override": ["standalone", "minimal-ui", "browser"],
-  "background_color": "#ffffff",
+  "background_color": "#3D3D3D",
   "theme_color": "#FFDE8C",
   "screenshots": [{
     "src": "/static/media/about/library-mobile.png",


### PR DESCRIPTION
PWA's cant respect light/dark mode yet, so use a muted colour
so we don't have the bold white for people in dark mode.
