### PR TITLE
Use parsed from, to and subject from email headers

### DIFF
--- a/packages/api/src/elastic/types.ts
+++ b/packages/api/src/elastic/types.ts
@@ -246,7 +246,15 @@ export interface SearchItem {
   highlights?: Highlight[]
 }
 
-const keys = ['_id', 'url', 'slug', 'userId', 'uploadFileId', 'state'] as const
+const keys = [
+  '_id',
+  'url',
+  'slug',
+  'userId',
+  'uploadFileId',
+  'state',
+  'id',
+] as const
 
 export type ParamSet = PickTuple<Page, typeof keys>
 

--- a/packages/api/src/services/save_page.ts
+++ b/packages/api/src/services/save_page.ts
@@ -112,7 +112,7 @@ export const savePage = async (
         existingPage.id,
         {
           savedAt: new Date(),
-          archivedAt: undefined,
+          archivedAt: null,
         },
         ctx
       ))

--- a/packages/inbound-email-handler/src/index.ts
+++ b/packages/inbound-email-handler/src/index.ts
@@ -66,8 +66,8 @@ export const inboundEmailHandler = Sentry.GCPFunction.wrapHttpFunction(
       console.log('headers: ', headers)
 
       // original sender email address
-      const from = headers['from'].toString()
-      const subject = headers['subject']?.toString()
+      const from = parsed['from']
+      const subject = parsed['subject']
       const html = parsed['html']
       const text = parsed['text']
 
@@ -80,7 +80,7 @@ export const inboundEmailHandler = Sentry.GCPFunction.wrapHttpFunction(
       const forwardedFrom = headers['x-forwarded-for']?.toString().split(' ')[0]
 
       // if an email is forwarded to the inbox, the to is the forwarding email recipient
-      const to = forwardedTo || headers['to'].toString()
+      const to = forwardedTo || parsed['to']
       const postHeader = headers['list-post']?.toString()
       const unSubHeader = headers['list-unsubscribe']?.toString()
 


### PR DESCRIPTION
<img width="571" alt="Screenshot 2022-08-05 at 10 03 56 AM" src="https://user-images.githubusercontent.com/12963965/182985975-a8a51b61-54c2-43c1-b689-efcba1d55c14.png">
The email subject in headers may contain encoded strings so we need to use parsed ones instead.