### PR TITLE
Fix getting script_exception when updating labels in highlights by checking null before updating

### DIFF
--- a/packages/api/src/elastic/labels.ts
+++ b/packages/api/src/elastic/labels.ts
@@ -186,7 +186,7 @@ export const updateLabel = async (
                      ctx._source.labels.add(params.label);
                      ctx._source.updatedAt = params.updatedAt
                    }
-                   if (ctx._source.highlights != null) {
+                   if (ctx._source.highlights != null && ctx._source.highlights[0].labels != null) {
                      ctx._source.highlights[0].labels.removeIf(l -> l.id == params.label.id);
                      ctx._source.highlights[0].labels.add(params.label);
                      ctx._source.updatedAt = params.updatedAt


### PR DESCRIPTION
Fixed this bug reported by Sentry: https://sentry.io/organizations/omnivore/issues/3514062195/?project=5591542&query=is%3Aunresolved