### PR TITLE
Android Apple Login Endpoint

### DIFF
--- a/packages/api/src/routers/auth/apple_auth.ts
+++ b/packages/api/src/routers/auth/apple_auth.ts
@@ -41,8 +41,7 @@ async function fetchApplePublicKey(kid: string): Promise<string | null> {
 }
 
 export async function decodeAppleToken(
-  token: string,
-  isWeb?: boolean
+  token: string
 ): Promise<DecodeTokenResult> {
   const decodedToken = jwt.decode(token, { complete: true })
   const { kid, alg } = (decodedToken as any).header
@@ -54,8 +53,8 @@ export async function decodeAppleToken(
     }
     const jwtClaims: any = jwt.verify(token, publicKey, { algorithms: [alg] })
     const issVerified = (jwtClaims.iss ?? '') === appleBaseURL
-    const audVerified =
-      (jwtClaims.aud ?? '') === isWeb ? webAudienceName : audienceName
+    const audience = jwtClaims.aud ?? ''
+    const audVerified = audience == webAudienceName || audience === audienceName
     if (issVerified && audVerified && jwtClaims.email) {
       return {
         email: jwtClaims.email,
@@ -106,7 +105,7 @@ export async function handleAppleWebAuth(
 
     return env.client.url
   }
-  const decodedTokenResult = await decodeAppleToken(idToken, true)
+  const decodedTokenResult = await decodeAppleToken(idToken)
   const authFailedRedirect = `${baseURL()}/login?errorCodes=${
     LoginErrorCode.AuthFailed
   }`

--- a/packages/api/src/routers/auth/mobile/mobile_auth_router.ts
+++ b/packages/api/src/routers/auth/mobile/mobile_auth_router.ts
@@ -12,6 +12,8 @@ import {
 } from './sign_up'
 import { createMobileAccountCreationResponse } from './account_creation'
 import { env } from '../../../env'
+import { corsConfig } from '../../../utils/corsConfig'
+import cors from 'cors'
 
 export function mobileAuthRouter() {
   const router = express.Router()
@@ -60,6 +62,12 @@ export function mobileAuthRouter() {
     )
     res.status(payload.statusCode).json(payload.json)
   })
+
+  // Required since this will be called from Android WebView
+  router.options(
+    '/android-apple-redirect',
+    cors<express.Request>({ ...corsConfig, maxAge: 600 })
+  )
 
   router.post('/android-apple-redirect', (req, res) => {
     const { id_token } = req.body

--- a/packages/api/src/routers/auth/mobile/mobile_auth_router.ts
+++ b/packages/api/src/routers/auth/mobile/mobile_auth_router.ts
@@ -11,6 +11,7 @@ import {
   createMobileEmailSignUpResponse,
 } from './sign_up'
 import { createMobileAccountCreationResponse } from './account_creation'
+import { env } from '../../../env'
 
 export function mobileAuthRouter() {
   const router = express.Router()
@@ -58,6 +59,13 @@ export function mobileAuthRouter() {
       userProfile
     )
     res.status(payload.statusCode).json(payload.json)
+  })
+
+  router.post('/android-apple-redirect', (req, res) => {
+    const { id_token } = req.body
+    return res.redirect(
+      `${env.client.url}/android-apple-token?token=${id_token as string}`
+    )
   })
 
   return router


### PR DESCRIPTION
Simple endpoint for an Android WebView to extract the Apple id_token. Once it's fetched we can use the same endpoints that iOS uses for a pending user and an already registered user.