### PR TITLE
Fix not setting confirmation code from Google Japan confiramtion emails

### DIFF
--- a/packages/inbound-email-handler/src/index.ts
+++ b/packages/inbound-email-handler/src/index.ts
@@ -107,7 +107,7 @@ export const inboundEmailHandler = Sentry.GCPFunction.wrapHttpFunction(
 
         console.log('non-newsletter email from', from, 'to', to)
 
-        if (isConfirmationEmail(from)) {
+        if (isConfirmationEmail(from, subject)) {
           console.log('handleConfirmation', from)
           await handleConfirmation(to, subject)
           return res.send('ok')

--- a/packages/inbound-email-handler/src/newsletter.ts
+++ b/packages/inbound-email-handler/src/newsletter.ts
@@ -11,10 +11,9 @@ interface Unsubscribe {
 const pubsub = new PubSub()
 const NEWSLETTER_EMAIL_RECEIVED_TOPIC = 'newsletterEmailReceived'
 const EMAIL_CONFIRMATION_CODE_RECEIVED_TOPIC = 'emailConfirmationCodeReceived'
-const EMAIL_FORWARDING_SENDER_ADDRESSES = [
-  'Gmail Team <forwarding-noreply@google.com>',
-]
-const CONFIRMATION_CODE_PATTERN = /^\(#\d+\)/
+const CONFIRMATION_EMAIL = 'forwarding-noreply@google.com'
+// check unicode parentheses too
+const CONFIRMATION_CODE_PATTERN = /^[(（]#\d+[)）]/u
 const UNSUBSCRIBE_HTTP_URL_PATTERN = /<(https?:\/\/[^>]*)>/
 const UNSUBSCRIBE_MAIL_TO_PATTERN = /<mailto:([^>]*)>/
 
@@ -26,6 +25,14 @@ export const parseUnsubscribe = (unSubHeader: string): Unsubscribe => {
     mailTo: decoded.match(UNSUBSCRIBE_MAIL_TO_PATTERN)?.[1],
     httpUrl: decoded.match(UNSUBSCRIBE_HTTP_URL_PATTERN)?.[1],
   }
+}
+
+const parseAddress = (address: string): string => {
+  const parsed = addressparser(address)
+  if (parsed.length > 0) {
+    return parsed[0].address
+  }
+  return ''
 }
 
 export class NewsletterHandler {
@@ -123,8 +130,11 @@ export const getConfirmationCode = (subject: string): string | undefined => {
   return undefined
 }
 
-export const isConfirmationEmail = (from: string): boolean => {
-  return EMAIL_FORWARDING_SENDER_ADDRESSES.includes(from)
+export const isConfirmationEmail = (from: string, subject: string): boolean => {
+  return (
+    parseAddress(from) === CONFIRMATION_EMAIL &&
+    CONFIRMATION_CODE_PATTERN.test(subject)
+  )
 }
 
 const publishMessage = async (

--- a/packages/inbound-email-handler/src/newsletter.ts
+++ b/packages/inbound-email-handler/src/newsletter.ts
@@ -11,7 +11,7 @@ interface Unsubscribe {
 const pubsub = new PubSub()
 const NEWSLETTER_EMAIL_RECEIVED_TOPIC = 'newsletterEmailReceived'
 const EMAIL_CONFIRMATION_CODE_RECEIVED_TOPIC = 'emailConfirmationCodeReceived'
-const CONFIRMATION_EMAIL = 'forwarding-noreply@google.com'
+const CONFIRMATION_EMAIL_SENDER_ADDRESS = 'forwarding-noreply@google.com'
 // check unicode parentheses too
 const CONFIRMATION_CODE_PATTERN = /^[(（]#\d+[)）]/u
 const UNSUBSCRIBE_HTTP_URL_PATTERN = /<(https?:\/\/[^>]*)>/
@@ -132,7 +132,7 @@ export const getConfirmationCode = (subject: string): string | undefined => {
 
 export const isConfirmationEmail = (from: string, subject: string): boolean => {
   return (
-    parseAddress(from) === CONFIRMATION_EMAIL &&
+    parseAddress(from) === CONFIRMATION_EMAIL_SENDER_ADDRESS &&
     CONFIRMATION_CODE_PATTERN.test(subject)
   )
 }

--- a/packages/inbound-email-handler/test/newsletter.test.ts
+++ b/packages/inbound-email-handler/test/newsletter.test.ts
@@ -14,17 +14,39 @@ import { MorningBrewHandler } from '../src/morning-brew-handler'
 
 describe('Confirmation email test', () => {
   describe('#isConfirmationEmail()', () => {
-    it('returns true when email is from Gmail Team', () => {
-      const from = 'Gmail Team <forwarding-noreply@google.com>'
+    let from: string
+    let subject: string
 
-      expect(isConfirmationEmail(from)).to.be.true
+    it('returns true when email is from Gmail Team', () => {
+      from = 'Gmail Team <forwarding-noreply@google.com>'
+      subject = `(#123456789) Gmail Forwarding Confirmation - Receive Mail from sam@omnivore.com`
+
+      expect(isConfirmationEmail(from, subject)).to.be.true
+    })
+
+    it('returns true when email is from Japan Gmail Team', () => {
+      from = 'SWG チーム <forwarding-noreply@google.com>'
+      subject =
+        '（#745359589）SWG の転送の確認 - miyanohara@nbi.academy からメールを受信'
+
+      expect(isConfirmationEmail(from, subject)).to.be.true
     })
   })
 
   describe('#getConfirmationCode()', () => {
+    let code: string
+    let subject: string
+
     it('returns the confirmation code from the email', () => {
-      const code = '593781109'
-      const subject = `(#${code}) Gmail Forwarding Confirmation - Receive Mail from sam@omnivore.com`
+      code = '593781109'
+      subject = `(#${code}) Gmail Forwarding Confirmation - Receive Mail from sam@omnivore.com`
+
+      expect(getConfirmationCode(subject)).to.equal(code)
+    })
+
+    it('returns the confirmation code from the Google Japan email', () => {
+      code = '745359589'
+      subject = `（#${code}）SWG の転送の確認 - miyanohara@nbi.academy からメールを受信`
 
       expect(getConfirmationCode(subject)).to.equal(code)
     })

--- a/packages/inbound-email-handler/test/newsletter.test.ts
+++ b/packages/inbound-email-handler/test/newsletter.test.ts
@@ -19,7 +19,7 @@ describe('Confirmation email test', () => {
 
     it('returns true when email is from Gmail Team', () => {
       from = 'Gmail Team <forwarding-noreply@google.com>'
-      subject = `(#123456789) Gmail Forwarding Confirmation - Receive Mail from sam@omnivore.com`
+      subject = `(#123456789) Gmail Forwarding Confirmation - Receive Mail from test@omnivore.app`
 
       expect(isConfirmationEmail(from, subject)).to.be.true
     })
@@ -27,7 +27,7 @@ describe('Confirmation email test', () => {
     it('returns true when email is from Japan Gmail Team', () => {
       from = 'SWG チーム <forwarding-noreply@google.com>'
       subject =
-        '（#745359589）SWG の転送の確認 - miyanohara@nbi.academy からメールを受信'
+        '（#123456789）SWG の転送の確認 - test@omnivore.app からメールを受信'
 
       expect(isConfirmationEmail(from, subject)).to.be.true
     })
@@ -38,15 +38,15 @@ describe('Confirmation email test', () => {
     let subject: string
 
     it('returns the confirmation code from the email', () => {
-      code = '593781109'
-      subject = `(#${code}) Gmail Forwarding Confirmation - Receive Mail from sam@omnivore.com`
+      code = '123456789'
+      subject = `(#${code}) Gmail Forwarding Confirmation - Receive Mail from test@omnivore.app`
 
       expect(getConfirmationCode(subject)).to.equal(code)
     })
 
     it('returns the confirmation code from the Google Japan email', () => {
-      code = '745359589'
-      subject = `（#${code}）SWG の転送の確認 - miyanohara@nbi.academy からメールを受信`
+      code = '123456789'
+      subject = `（#${code}）SWG の転送の確認 - test@omnivore.app からメールを受信`
 
       expect(getConfirmationCode(subject)).to.equal(code)
     })


### PR DESCRIPTION
- Match both email from and subject
- Match unicode parentheses in the subject
