### PR TITLE
Update UI after seeking, dont try to detect end of stream using currentTime

### DIFF
--- a/apple/OmnivoreKit/Sources/App/Views/AudioPlayer/MiniPlayer.swift
+++ b/apple/OmnivoreKit/Sources/App/Views/AudioPlayer/MiniPlayer.swift
@@ -402,15 +402,24 @@ public struct MiniPlayer: View {
     }
   }
 
+  var scrubbing: Bool {
+    switch audioController.scrubState {
+    case .scrubStarted:
+      return true
+    default:
+      return false
+    }
+  }
+
   func onDragChanged(value: DragGesture.Value) {
-    if value.translation.height > 0, expanded {
+    if value.translation.height > 0, expanded, !scrubbing {
       offset = value.translation.height
     }
   }
 
   func onDragEnded(value: DragGesture.Value) {
     withAnimation(.interactiveSpring()) {
-      if value.translation.height > minExpandedHeight {
+      if value.translation.height > minExpandedHeight, !scrubbing {
         expanded = false
       }
       offset = 0

--- a/apple/OmnivoreKit/Sources/Services/AudioSession/AudioController.swift
+++ b/apple/OmnivoreKit/Sources/Services/AudioSession/AudioController.swift
@@ -204,12 +204,14 @@ public class AudioController: NSObject, ObservableObject, AVAudioPlayerDelegate 
       if let playerItem = player?.currentItem as? SpeechPlayerItem {
         if playerItem.speechItem.audioIdx == foundIdx {
           playerItem.seek(to: CMTimeMakeWithSeconds(remainder, preferredTimescale: 600), completionHandler: nil)
+          fireTimer()
           return
         }
       }
 
-      // Move the playback to the found index, we should also seek a bit
-      // within this index, but this is probably accurate enough for now.
+      // Move the playback to the found index, we also seek by the remainder amount
+      // before moving we pause the player so playback doesnt jump to a previous spot
+      player?.pause()
       player?.removeAllItems()
       synthesizeFrom(start: foundIdx, playWhenReady: state == .playing, atOffset: remainder)
     } else {

--- a/apple/OmnivoreKit/Sources/Services/AudioSession/AudioController.swift
+++ b/apple/OmnivoreKit/Sources/Services/AudioSession/AudioController.swift
@@ -468,9 +468,13 @@ public class AudioController: NSObject, ObservableObject, AVAudioPlayerDelegate 
       case .scrubStarted:
         break
       case let .scrubEnded(seekTime):
-        scrubState = .reset
         timeElapsed = seekTime
         timeElapsedString = formatTimeInterval(timeElapsed)
+        if var nowPlaying = MPNowPlayingInfoCenter.default().nowPlayingInfo {
+          nowPlaying[MPMediaItemPropertyPlaybackDuration] = NSNumber(value: duration)
+          nowPlaying[MPNowPlayingInfoPropertyElapsedPlaybackTime] = NSNumber(value: timeElapsed)
+          MPNowPlayingInfoCenter.default().nowPlayingInfo = nowPlaying
+        }
       }
     }
 

--- a/apple/OmnivoreKit/Sources/Services/AudioSession/AudioController.swift
+++ b/apple/OmnivoreKit/Sources/Services/AudioSession/AudioController.swift
@@ -204,6 +204,7 @@ public class AudioController: NSObject, ObservableObject, AVAudioPlayerDelegate 
       if let playerItem = player?.currentItem as? SpeechPlayerItem {
         if playerItem.speechItem.audioIdx == foundIdx {
           playerItem.seek(to: CMTimeMakeWithSeconds(remainder, preferredTimescale: 600), completionHandler: nil)
+          scrubState = .reset
           fireTimer()
           return
         }
@@ -222,6 +223,8 @@ public class AudioController: NSObject, ObservableObject, AVAudioPlayerDelegate 
         synthesizeFrom(start: durations.count - 1, playWhenReady: state == .playing, atOffset: last)
       }
     }
+
+    scrubState = .reset
     fireTimer()
   }
 

--- a/apple/OmnivoreKit/Sources/Services/AudioSession/AudioController.swift
+++ b/apple/OmnivoreKit/Sources/Services/AudioSession/AudioController.swift
@@ -458,17 +458,19 @@ public class AudioController: NSObject, ObservableObject, AVAudioPlayerDelegate 
           let itemElapsed = playerItem.status == .readyToPlay ? CMTimeGetSeconds(playerItem.currentTime()) : 0
           timeElapsed = durationBefore(playerIndex: playerItem.speechItem.audioIdx) + itemElapsed
           timeElapsedString = formatTimeInterval(timeElapsed)
-        }
-        if var nowPlaying = MPNowPlayingInfoCenter.default().nowPlayingInfo {
-          nowPlaying[MPMediaItemPropertyPlaybackDuration] = NSNumber(value: duration)
-          nowPlaying[MPNowPlayingInfoPropertyElapsedPlaybackTime] = NSNumber(value: timeElapsed)
-          MPNowPlayingInfoCenter.default().nowPlayingInfo = nowPlaying
+
+          if var nowPlaying = MPNowPlayingInfoCenter.default().nowPlayingInfo {
+            nowPlaying[MPMediaItemPropertyPlaybackDuration] = NSNumber(value: duration)
+            nowPlaying[MPNowPlayingInfoPropertyElapsedPlaybackTime] = NSNumber(value: timeElapsed)
+            MPNowPlayingInfoCenter.default().nowPlayingInfo = nowPlaying
+          }
         }
       case .scrubStarted:
         break
       case let .scrubEnded(seekTime):
         scrubState = .reset
         timeElapsed = seekTime
+        timeElapsedString = formatTimeInterval(timeElapsed)
       }
     }
 

--- a/apple/OmnivoreKit/Sources/Services/AudioSession/SpeechSynthesizer.swift
+++ b/apple/OmnivoreKit/Sources/Services/AudioSession/SpeechSynthesizer.swift
@@ -187,7 +187,6 @@ func fetchUtterance(appEnvironment: AppEnvironment,
 
   if let ssml = try utterance.toSSML(document: document) {
     request.httpBody = ssml
-    print("FETCHING: ", String(decoding: ssml, as: UTF8.self))
   }
 
   for (header, value) in networker.defaultHeaders {
@@ -219,7 +218,6 @@ func fetchUtterance(appEnvironment: AppEnvironment,
     try audioData.write(to: tempPath)
     try? FileManager.default.removeItem(at: audioPath)
     try FileManager.default.moveItem(at: tempPath, to: audioPath)
-    print("wrote", audioData.count, "bytes to", audioPath)
   } catch {
     let errorMessage = "audioFetch failed. could not write MP3 data to disk"
     throw BasicError.message(messageText: errorMessage)

--- a/apple/OmnivoreKit/Sources/Views/FeedItem/HomeFeedCardView.swift
+++ b/apple/OmnivoreKit/Sources/Views/FeedItem/HomeFeedCardView.swift
@@ -77,7 +77,7 @@ public struct FeedCard: View {
         .padding(.top, 8)
       }
     }
-    .padding(.top, 10)
+    .padding(.top, 0)
     .padding(.bottom, 8)
     .frame(
       minWidth: nil,

--- a/apple/OmnivoreKit/Sources/Views/FeedItem/HomeFeedCardView.swift
+++ b/apple/OmnivoreKit/Sources/Views/FeedItem/HomeFeedCardView.swift
@@ -74,7 +74,7 @@ public struct FeedCard: View {
             Spacer()
           }
         }
-        .padding(.top, 8)
+        .padding(.top, 0)
       }
     }
     .padding(.top, 0)


### PR DESCRIPTION
This helps with two issues:
- after seeking sometimes you will see the loading spinner even
after audio has resumed.

- sometimes if we are still pulling data we might detect that
we are at the end of the stream.
