### PR TITLE
UI improvements and bug fixes for text to speech

### DIFF
--- a/apple/OmnivoreKit/Sources/App/Views/AudioPlayer/MiniPlayer.swift
+++ b/apple/OmnivoreKit/Sources/App/Views/AudioPlayer/MiniPlayer.swift
@@ -304,7 +304,7 @@ public struct MiniPlayer: View {
         withAnimation(.easeIn(duration: 0.08)) { expanded = true }
       }.sheet(isPresented: $showVoiceSheet) {
         NavigationView {
-          TextToSpeechVoiceSelectionView(forLanguage: audioController.currentVoiceLanguage)
+          TextToSpeechVoiceSelectionView(forLanguage: audioController.currentVoiceLanguage, showLanguageChanger: true)
             .navigationBarTitle("Voice")
             .navigationBarTitleDisplayMode(.inline)
             .navigationBarItems(leading: Button(action: { self.showVoiceSheet = false }) {

--- a/apple/OmnivoreKit/Sources/App/Views/AudioPlayer/MiniPlayer.swift
+++ b/apple/OmnivoreKit/Sources/App/Views/AudioPlayer/MiniPlayer.swift
@@ -210,28 +210,15 @@ public struct MiniPlayer: View {
         Spacer()
 
         if expanded {
-          Text(itemAudioProperties.title)
-            .lineLimit(1)
-            .font(expanded ? .appTitle : .appCallout)
-            .lineSpacing(1.25)
+          Marquee(text: itemAudioProperties.title, font: UIFont(name: "Inter-Regular", size: 22)!)
             .foregroundColor(.appGrayTextContrast)
-            .frame(maxWidth: .infinity, alignment: expanded ? .center : .leading)
-            .matchedGeometryEffect(id: "ArticleTitle", in: animation)
             .onTapGesture {
               viewArticle()
             }
 
-          HStack {
-            Spacer()
-            if let byline = itemAudioProperties.byline {
-              Text(byline)
-                .lineLimit(1)
-                .font(.appCallout)
-                .lineSpacing(1.25)
-                .foregroundColor(.appGrayText)
-                .frame(alignment: .trailing)
-            }
-            Spacer()
+          if let byline = itemAudioProperties.byline {
+            Marquee(text: byline, font: UIFont(name: "Inter-Regular", size: 16)!)
+              .foregroundColor(.appGrayText)
           }
 
           Slider(value: $audioController.timeElapsed,

--- a/apple/OmnivoreKit/Sources/App/Views/AudioPlayer/MiniPlayer.swift
+++ b/apple/OmnivoreKit/Sources/App/Views/AudioPlayer/MiniPlayer.swift
@@ -192,11 +192,11 @@ public struct MiniPlayer: View {
 
           if !expanded {
             Text(itemAudioProperties.title)
-              .font(expanded ? .appTitle : .appCallout)
+              .font(.appCallout)
               .lineSpacing(1.25)
               .foregroundColor(.appGrayTextContrast)
               .fixedSize(horizontal: false, vertical: false)
-              .frame(maxWidth: .infinity, alignment: expanded ? .center : .leading)
+              .frame(maxWidth: .infinity, alignment: .leading)
               .matchedGeometryEffect(id: "ArticleTitle", in: animation)
 
             playPauseButtonItem
@@ -221,31 +221,15 @@ public struct MiniPlayer: View {
               .foregroundColor(.appGrayText)
           }
 
-          Slider(value: $audioController.timeElapsed,
-                 in: 0 ... self.audioController.duration,
-                 onEditingChanged: { scrubStarted in
-                   if scrubStarted {
-                     self.audioController.scrubState = .scrubStarted
-                   } else {
-                     self.audioController.scrubState = .scrubEnded(self.audioController.timeElapsed)
-                   }
-                 })
-            .accentColor(.appCtaYellow)
-            .introspectSlider { slider in
-              // Make the thumb a little smaller than the default and give it the CTA color
-              // for some reason this doesn't work on my iPad though.
-              let tintColor = UIColor(Color.appCtaYellow)
-
-              let image = UIImage(systemName: "circle.fill",
-                                  withConfiguration: UIImage.SymbolConfiguration(scale: .small))?
-                .withTintColor(tintColor)
-                .withRenderingMode(.alwaysOriginal)
-
-              slider.setThumbImage(image, for: .selected)
-              slider.setThumbImage(image, for: .normal)
-
-              slider.minimumTrackTintColor = tintColor
-            }
+          ScrubberView(value: $audioController.timeElapsed,
+                       minValue: 0, maxValue: self.audioController.duration,
+                       onEditingChanged: { scrubStarted in
+                         if scrubStarted {
+                           self.audioController.scrubState = .scrubStarted
+                         } else {
+                           self.audioController.scrubState = .scrubEnded(self.audioController.timeElapsed)
+                         }
+                       })
 
           HStack {
             Text(audioController.timeElapsedString ?? "0:00")

--- a/apple/OmnivoreKit/Sources/App/Views/AudioPlayer/ScrubberView.swift
+++ b/apple/OmnivoreKit/Sources/App/Views/AudioPlayer/ScrubberView.swift
@@ -1,0 +1,73 @@
+//
+//  ScrubberView.swift
+//
+//
+//  Created by Jackson Harper on 9/27/22.
+//
+
+import Foundation
+import SwiftUI
+
+struct ScrubberView: UIViewRepresentable {
+  typealias UIViewType = UISlider
+
+  @Binding var value: Double
+  var minValue: Double
+  var maxValue: Double
+  var onEditingChanged: (Bool) -> Void
+
+  init(value: Binding<Double>, minValue: Double, maxValue: Double, onEditingChanged: @escaping (Bool) -> Void) {
+    self._value = value
+    self.minValue = minValue
+    self.maxValue = maxValue
+    self.onEditingChanged = onEditingChanged
+  }
+
+  func makeUIView(context: Context) -> UISlider {
+    let slider = UISlider(frame: .zero)
+    slider.maximumValue = Float(minValue)
+    slider.maximumValue = Float(maxValue)
+
+    let tintColor = UIColor(Color.appCtaYellow)
+
+    let image = UIImage(systemName: "circle.fill",
+                        withConfiguration: UIImage.SymbolConfiguration(scale: .small))?
+      .withTintColor(tintColor)
+      .withRenderingMode(.alwaysOriginal)
+
+    slider.setThumbImage(image, for: .selected)
+    slider.setThumbImage(image, for: .normal)
+
+    slider.minimumTrackTintColor = tintColor
+    slider.addTarget(context.coordinator,
+                     action: #selector(Coordinator.valueChanged(_:)),
+                     for: .valueChanged)
+
+    return slider
+  }
+
+  func updateUIView(_ uiView: UISlider, context _: Context) {
+    uiView.value = Float(value)
+  }
+
+  func makeCoordinator() -> Coordinator {
+    let coordinator = Coordinator(value: $value, onEditingChanged: onEditingChanged)
+    return coordinator
+  }
+
+  class Coordinator: NSObject {
+    var value: Binding<Double>
+    var onEditingChanged: (Bool) -> Void
+
+    init(value: Binding<Double>, onEditingChanged: @escaping (Bool) -> Void) {
+      self.value = value
+      self.onEditingChanged = onEditingChanged
+      super.init()
+    }
+
+    @objc func valueChanged(_ sender: UISlider) {
+      value.wrappedValue = Double(sender.value)
+      onEditingChanged(sender.isTracking)
+    }
+  }
+}

--- a/apple/OmnivoreKit/Sources/App/Views/Profile/TextToSpeechView.swift
+++ b/apple/OmnivoreKit/Sources/App/Views/Profile/TextToSpeechView.swift
@@ -30,7 +30,7 @@ struct TextToSpeechView: View {
   private var innerBody: some View {
     Section("Voices") {
       ForEach(Voices.Languages, id: \.key) { language in
-        NavigationLink(destination: TextToSpeechVoiceSelectionView(forLanguage: language)) {
+        NavigationLink(destination: TextToSpeechVoiceSelectionView(forLanguage: language, showLanguageChanger: false)) {
           Text(language.name)
         }
       }

--- a/apple/OmnivoreKit/Sources/App/Views/Profile/TextToSpeechVoiceSelectionView.swift
+++ b/apple/OmnivoreKit/Sources/App/Views/Profile/TextToSpeechVoiceSelectionView.swift
@@ -6,18 +6,22 @@ import Views
 struct TextToSpeechVoiceSelectionView: View {
   @EnvironmentObject var audioController: AudioController
   let language: VoiceLanguage
+  let showLanguageChanger: Bool
 
-  init(forLanguage: VoiceLanguage) {
+  init(forLanguage: VoiceLanguage, showLanguageChanger: Bool) {
     self.language = forLanguage
+    self.showLanguageChanger = showLanguageChanger
   }
 
   var body: some View {
     Group {
       #if os(iOS)
         Form {
-          Section("Language") {
-            NavigationLink(destination: TextToSpeechLanguageView().navigationTitle("Language")) {
-              Text(audioController.currentVoiceLanguage.name)
+          if showLanguageChanger {
+            Section("Language") {
+              NavigationLink(destination: TextToSpeechLanguageView().navigationTitle("Language")) {
+                Text(audioController.currentVoiceLanguage.name)
+              }
             }
           }
           innerBody


### PR DESCRIPTION
- Use marquee text on audio player for long titles/info sections
- Use a UIViewRepresentable to set slider images instead of introspection
- Dont show the language changer on the settings voice picker
