### PR TITLE
Chore: Corrected the terminal commands specified on the README's Frontend Development section

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ with docker compose and the frontend locally:
 ```bash
 docker-compose up api content-fetch
 cd packages/web
-cp .env.local .env
+cp .env.template .env
 yarn dev
 ```
 


### PR DESCRIPTION
Based on this [Discord discussion](https://discord.com/channels/844965259462311966/943967463299764314/1027150176940474368), where I had issues setting up my local environment due to the missing `.env.local` file.

**What does this PR do?**

 Replace `.env.local` with `.env.template`. The latter does not exists under the `/packages/web` directory.