### PR TITLE
Fix: Improve the icon alignment in toggle buttons

### DIFF
--- a/packages/web/components/templates/homeFeed/HomeFeedContainer.tsx
+++ b/packages/web/components/templates/homeFeed/HomeFeedContainer.tsx
@@ -651,6 +651,9 @@ function HomeFeedGrid(props: HomeFeedContentProps): JSX.Element {
   const [, updateState] = useState({})
 
   const StyledToggleButton = styled('button', {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
     p: '0px',
     backgroundColor: 'transparent',
     border: 'none',


### PR DESCRIPTION
While browsing the web app, I've noticed that the icons for list/grid mode aren't centered properly.

**What does this PR do?**

Centers the content of the `StyledToggleButton` by adding a couple of additional CSS attributes.

**Screenshots**

Before (Slightly off centered)

![image](https://user-images.githubusercontent.com/53674742/194038092-5ec5ea86-c92a-443c-9cf2-a5d9f7c650e8.png)

After (Pixel perfect if you ask me)

![image](https://user-images.githubusercontent.com/53674742/194038000-fbc08175-ea6f-4088-9482-fb60e39f0a86.png)

