### PR TITLE
Highlights List View - iOS

### DIFF
--- a/apple/OmnivoreKit/Sources/App/Views/Highlights/HighlightsListCard.swift
+++ b/apple/OmnivoreKit/Sources/App/Views/Highlights/HighlightsListCard.swift
@@ -2,9 +2,56 @@ import Models
 import SwiftUI
 
 struct HighlightsListCard: View {
+  @State var isContextMenuOpen = false
+
   let highlight: Highlight
 
+  var contextMenuView: some View {
+    Group {
+      Button(
+        action: {},
+        label: { Label("Stubby One", systemImage: "highlighter") }
+      )
+      Button(
+        action: {},
+        label: { Label("Stubby Two", systemImage: "textbox") }
+      )
+    }
+  }
+
   var body: some View {
-    Text(highlight.quote ?? "no quote")
+    VStack(alignment: .leading) {
+      HStack {
+        Image(systemName: "highlighter")
+
+        Text(highlight.shortId ?? "no short Id")
+          .font(.appHeadline)
+          .foregroundColor(.appGrayTextContrast)
+          .lineLimit(1)
+
+        Spacer()
+
+        Menu(
+          content: { contextMenuView },
+          label: {
+            Image(systemName: "ellipsis")
+              .foregroundColor(.appGrayTextContrast)
+              .padding()
+          }
+        )
+        .frame(width: 16, height: 16, alignment: .center)
+        .onTapGesture { isContextMenuOpen = true }
+      }
+      .padding(.top, 8)
+
+      HStack {
+        Divider()
+          .frame(width: 6)
+          .overlay(Color.appYellow48)
+
+        Text(highlight.quote ?? "")
+      }
+      .padding(.bottom, 8)
+    }
   }
 }

--- a/apple/OmnivoreKit/Sources/App/Views/Highlights/HighlightsListCard.swift
+++ b/apple/OmnivoreKit/Sources/App/Views/Highlights/HighlightsListCard.swift
@@ -1,0 +1,10 @@
+import Models
+import SwiftUI
+
+struct HighlightsListCard: View {
+  let highlight: Highlight
+
+  var body: some View {
+    Text(highlight.quote ?? "no quote")
+  }
+}

--- a/apple/OmnivoreKit/Sources/App/Views/Highlights/HighlightsListCard.swift
+++ b/apple/OmnivoreKit/Sources/App/Views/Highlights/HighlightsListCard.swift
@@ -1,8 +1,11 @@
 import Models
 import SwiftUI
+import Views
 
 struct HighlightsListCard: View {
   @State var isContextMenuOpen = false
+  @State var annotation = String()
+  @State var showAnnotationModal = false
 
   let highlight: Highlight
 
@@ -34,6 +37,10 @@ struct HighlightsListCard: View {
 
       Text(highlight.annotation ?? "")
     }
+    .onTapGesture {
+      annotation = highlight.annotation ?? ""
+      showAnnotationModal = true
+    }
   }
 
   var addNoteSection: some View {
@@ -48,7 +55,8 @@ struct HighlightsListCard: View {
       Spacer()
     }
     .onTapGesture {
-      print("add a note")
+      annotation = highlight.annotation ?? ""
+      showAnnotationModal = true
     }
   }
 
@@ -95,6 +103,19 @@ struct HighlightsListCard: View {
         }
       }
       .padding(.bottom, 8)
+    }
+    .sheet(isPresented: $showAnnotationModal) {
+      HighlightAnnotationSheet(
+        annotation: $annotation,
+        onSave: {
+          print("new annotation = \(annotation)")
+          showAnnotationModal = false
+        },
+        onCancel: {
+          print("cancel annotation")
+          showAnnotationModal = false
+        }
+      )
     }
   }
 }

--- a/apple/OmnivoreKit/Sources/App/Views/Highlights/HighlightsListCard.swift
+++ b/apple/OmnivoreKit/Sources/App/Views/Highlights/HighlightsListCard.swift
@@ -7,7 +7,8 @@ struct HighlightsListCard: View {
   @State var annotation = String()
   @State var showAnnotationModal = false
 
-  let highlight: Highlight
+  let highlightParams: HighlightListItemParams
+  let onSaveAnnotation: (String) -> Void
 
   var contextMenuView: some View {
     Group {
@@ -35,10 +36,10 @@ struct HighlightsListCard: View {
         Spacer()
       }
 
-      Text(highlight.annotation ?? "")
+      Text(highlightParams.annotation)
     }
     .onTapGesture {
-      annotation = highlight.annotation ?? ""
+      annotation = highlightParams.annotation
       showAnnotationModal = true
     }
   }
@@ -55,7 +56,7 @@ struct HighlightsListCard: View {
       Spacer()
     }
     .onTapGesture {
-      annotation = highlight.annotation ?? ""
+      annotation = highlightParams.annotation
       showAnnotationModal = true
     }
   }
@@ -65,7 +66,7 @@ struct HighlightsListCard: View {
       HStack {
         Image(systemName: "highlighter")
 
-        Text(highlight.highlightCardTitle)
+        Text(highlightParams.title)
           .font(.appHeadline)
           .foregroundColor(.appGrayTextContrast)
           .lineLimit(1)
@@ -91,11 +92,11 @@ struct HighlightsListCard: View {
           .overlay(Color.appYellow48)
 
         VStack(alignment: .leading, spacing: 8) {
-          Text(highlight.quote ?? "")
+          Text(highlightParams.quote)
 
           Divider()
 
-          if highlight.annotation == nil || highlight.annotation?.isEmpty == true {
+          if highlightParams.annotation.isEmpty {
             addNoteSection
           } else {
             noteSection
@@ -108,11 +109,10 @@ struct HighlightsListCard: View {
       HighlightAnnotationSheet(
         annotation: $annotation,
         onSave: {
-          print("new annotation = \(annotation)")
+          onSaveAnnotation(annotation)
           showAnnotationModal = false
         },
         onCancel: {
-          print("cancel annotation")
           showAnnotationModal = false
         }
       )

--- a/apple/OmnivoreKit/Sources/App/Views/Highlights/HighlightsListCard.swift
+++ b/apple/OmnivoreKit/Sources/App/Views/Highlights/HighlightsListCard.swift
@@ -10,16 +10,29 @@ struct HighlightsListCard: View {
   let highlightParams: HighlightListItemParams
   @Binding var hasHighlightMutations: Bool
   let onSaveAnnotation: (String) -> Void
+  let onDeleteHighlight: () -> Void
 
   var contextMenuView: some View {
     Group {
       Button(
-        action: {},
-        label: { Label("Stubby One", systemImage: "highlighter") }
+        action: {
+          #if os(iOS)
+            UIPasteboard.general.string = highlightParams.quote
+          #endif
+
+          #if os(macOS)
+            let pasteBoard = NSPasteboard.general
+            pasteBoard.clearContents()
+            pasteBoard.writeObjects([highlightParams.quote as NSString])
+          #endif
+
+          Snackbar.show(message: "Highlight copied")
+        },
+        label: { Label("Copy", systemImage: "doc.on.doc") }
       )
       Button(
-        action: {},
-        label: { Label("Stubby Two", systemImage: "textbox") }
+        action: onDeleteHighlight,
+        label: { Label("Delete", systemImage: "trash") }
       )
     }
   }

--- a/apple/OmnivoreKit/Sources/App/Views/Highlights/HighlightsListCard.swift
+++ b/apple/OmnivoreKit/Sources/App/Views/Highlights/HighlightsListCard.swift
@@ -19,12 +19,33 @@ struct HighlightsListCard: View {
     }
   }
 
+  var noteSection: some View {
+    Group {
+      HStack {
+        Image(systemName: "note.text")
+
+        Text("Note")
+          .font(.appSubheadline)
+          .foregroundColor(.appGrayTextContrast)
+          .lineLimit(1)
+
+        Spacer()
+      }
+
+      Text(highlight.annotation ?? "")
+    }
+  }
+
+  var addNoteSection: some View {
+    Text("Tap to add a note")
+  }
+
   var body: some View {
     VStack(alignment: .leading) {
       HStack {
         Image(systemName: "highlighter")
 
-        Text(highlight.shortId ?? "no short Id")
+        Text(highlight.highlightCardTitle)
           .font(.appHeadline)
           .foregroundColor(.appGrayTextContrast)
           .lineLimit(1)
@@ -49,7 +70,17 @@ struct HighlightsListCard: View {
           .frame(width: 6)
           .overlay(Color.appYellow48)
 
-        Text(highlight.quote ?? "")
+        VStack(alignment: .leading, spacing: 8) {
+          Text(highlight.quote ?? "")
+
+          Divider()
+
+          if highlight.annotation == nil || highlight.annotation?.isEmpty == true {
+            addNoteSection
+          } else {
+            noteSection
+          }
+        }
       }
       .padding(.bottom, 8)
     }

--- a/apple/OmnivoreKit/Sources/App/Views/Highlights/HighlightsListCard.swift
+++ b/apple/OmnivoreKit/Sources/App/Views/Highlights/HighlightsListCard.swift
@@ -37,7 +37,19 @@ struct HighlightsListCard: View {
   }
 
   var addNoteSection: some View {
-    Text("Tap to add a note")
+    HStack {
+      Image(systemName: "note.text.badge.plus").foregroundColor(.appGrayTextContrast)
+
+      Text("Add a Note")
+        .font(.appSubheadline)
+        .foregroundColor(.appGrayTextContrast)
+        .lineLimit(1)
+
+      Spacer()
+    }
+    .onTapGesture {
+      print("add a note")
+    }
   }
 
   var body: some View {

--- a/apple/OmnivoreKit/Sources/App/Views/Highlights/HighlightsListCard.swift
+++ b/apple/OmnivoreKit/Sources/App/Views/Highlights/HighlightsListCard.swift
@@ -8,6 +8,7 @@ struct HighlightsListCard: View {
   @State var showAnnotationModal = false
 
   let highlightParams: HighlightListItemParams
+  @Binding var hasHighlightMutations: Bool
   let onSaveAnnotation: (String) -> Void
 
   var contextMenuView: some View {
@@ -111,6 +112,7 @@ struct HighlightsListCard: View {
         onSave: {
           onSaveAnnotation(annotation)
           showAnnotationModal = false
+          hasHighlightMutations = true
         },
         onCancel: {
           showAnnotationModal = false

--- a/apple/OmnivoreKit/Sources/App/Views/Highlights/HighlightsListView.swift
+++ b/apple/OmnivoreKit/Sources/App/Views/Highlights/HighlightsListView.swift
@@ -1,0 +1,60 @@
+import Models
+import Services
+import SwiftUI
+import Views
+
+struct HighlightsListView: View {
+  @EnvironmentObject var dataService: DataService
+  @Environment(\.presentationMode) private var presentationMode
+  @StateObject var viewModel = HighlightsListViewModel()
+
+  let item: LinkedItem
+
+  var innerBody: some View {
+    List {
+      Section {
+        ForEach(viewModel.highlights, id: \.self) { highlight in
+          Text(highlight.quote ?? "no quote")
+        }
+      }
+    }
+    .navigationTitle("Highlights")
+    #if os(iOS)
+      .navigationBarTitleDisplayMode(.inline)
+      .toolbar {
+        ToolbarItem(placement: .navigationBarTrailing) {
+          dismissButton
+        }
+      }
+    #else
+      .toolbar {
+        ToolbarItemGroup {
+          dismissButton
+        }
+      }
+    #endif
+  }
+
+  var dismissButton: some View {
+    Button(
+      action: { presentationMode.wrappedValue.dismiss() },
+      label: { Text("Done").foregroundColor(.appGrayTextContrast) }
+    )
+  }
+
+  var body: some View {
+    Group {
+      #if os(iOS)
+        NavigationView {
+          innerBody
+        }
+      #elseif os(macOS)
+        innerBody
+          .frame(minWidth: 400, minHeight: 400)
+      #endif
+    }
+    .task {
+      viewModel.load(item: item)
+    }
+  }
+}

--- a/apple/OmnivoreKit/Sources/App/Views/Highlights/HighlightsListView.swift
+++ b/apple/OmnivoreKit/Sources/App/Views/Highlights/HighlightsListView.swift
@@ -1,3 +1,4 @@
+import CoreData
 import Models
 import Services
 import SwiftUI
@@ -8,13 +9,19 @@ struct HighlightsListView: View {
   @Environment(\.presentationMode) private var presentationMode
   @StateObject var viewModel = HighlightsListViewModel()
 
-  let item: LinkedItem
+  let itemObjectID: NSManagedObjectID
 
   var innerBody: some View {
     List {
       Section {
-        ForEach(viewModel.highlights, id: \.self) { highlight in
-          HighlightsListCard(highlight: highlight)
+        ForEach(viewModel.highlightItems) { highlightParams in
+          HighlightsListCard(highlightParams: highlightParams) { newAnnotation in
+            viewModel.updateAnnotation(
+              highlightID: highlightParams.highlightID,
+              annotation: newAnnotation,
+              dataService: dataService
+            )
+          }
         }
       }
     }
@@ -55,7 +62,7 @@ struct HighlightsListView: View {
       #endif
     }
     .task {
-      viewModel.load(item: item)
+      viewModel.load(itemObjectID: itemObjectID, dataService: dataService)
     }
   }
 }

--- a/apple/OmnivoreKit/Sources/App/Views/Highlights/HighlightsListView.swift
+++ b/apple/OmnivoreKit/Sources/App/Views/Highlights/HighlightsListView.swift
@@ -10,12 +10,16 @@ struct HighlightsListView: View {
   @StateObject var viewModel = HighlightsListViewModel()
 
   let itemObjectID: NSManagedObjectID
+  @Binding var hasHighlightMutations: Bool
 
   var innerBody: some View {
     List {
       Section {
         ForEach(viewModel.highlightItems) { highlightParams in
-          HighlightsListCard(highlightParams: highlightParams) { newAnnotation in
+          HighlightsListCard(
+            highlightParams: highlightParams,
+            hasHighlightMutations: $hasHighlightMutations
+          ) { newAnnotation in
             viewModel.updateAnnotation(
               highlightID: highlightParams.highlightID,
               annotation: newAnnotation,

--- a/apple/OmnivoreKit/Sources/App/Views/Highlights/HighlightsListView.swift
+++ b/apple/OmnivoreKit/Sources/App/Views/Highlights/HighlightsListView.swift
@@ -14,11 +14,12 @@ struct HighlightsListView: View {
     List {
       Section {
         ForEach(viewModel.highlights, id: \.self) { highlight in
-          Text(highlight.quote ?? "no quote")
+          HighlightsListCard(highlight: highlight)
         }
       }
     }
     .navigationTitle("Highlights")
+    .listStyle(PlainListStyle())
     #if os(iOS)
       .navigationBarTitleDisplayMode(.inline)
       .toolbar {

--- a/apple/OmnivoreKit/Sources/App/Views/Highlights/HighlightsListView.swift
+++ b/apple/OmnivoreKit/Sources/App/Views/Highlights/HighlightsListView.swift
@@ -18,14 +18,23 @@ struct HighlightsListView: View {
         ForEach(viewModel.highlightItems) { highlightParams in
           HighlightsListCard(
             highlightParams: highlightParams,
-            hasHighlightMutations: $hasHighlightMutations
-          ) { newAnnotation in
-            viewModel.updateAnnotation(
-              highlightID: highlightParams.highlightID,
-              annotation: newAnnotation,
-              dataService: dataService
-            )
-          }
+            hasHighlightMutations: $hasHighlightMutations,
+            onSaveAnnotation: {
+              viewModel.updateAnnotation(
+                highlightID: highlightParams.highlightID,
+                annotation: $0,
+                dataService: dataService
+              )
+            },
+            onDeleteHighlight: {
+              hasHighlightMutations = true
+
+              viewModel.deleteHighlight(
+                highlightID: highlightParams.highlightID,
+                dataService: dataService
+              )
+            }
+          )
         }
       }
     }

--- a/apple/OmnivoreKit/Sources/App/Views/Highlights/HighlightsListViewModel.swift
+++ b/apple/OmnivoreKit/Sources/App/Views/Highlights/HighlightsListViewModel.swift
@@ -34,6 +34,11 @@ struct HighlightListItemParams: Identifiable {
     }
   }
 
+  func deleteHighlight(highlightID: String, dataService: DataService) {
+    dataService.deleteHighlight(highlightID: highlightID)
+    highlightItems.removeAll { $0.highlightID == highlightID }
+  }
+
   private func loadHighlights(item: LinkedItem) {
     let unsortedHighlights = item.highlights.asArray(of: Highlight.self)
 

--- a/apple/OmnivoreKit/Sources/App/Views/Highlights/HighlightsListViewModel.swift
+++ b/apple/OmnivoreKit/Sources/App/Views/Highlights/HighlightsListViewModel.swift
@@ -11,3 +11,9 @@ import Views
     highlights = item.highlights.asArray(of: Highlight.self)
   }
 }
+
+extension Highlight {
+  var highlightCardTitle: String {
+    "Highlight"
+  }
+}

--- a/apple/OmnivoreKit/Sources/App/Views/Highlights/HighlightsListViewModel.swift
+++ b/apple/OmnivoreKit/Sources/App/Views/Highlights/HighlightsListViewModel.swift
@@ -1,0 +1,13 @@
+import CoreData
+import Models
+import Services
+import SwiftUI
+import Views
+
+@MainActor final class HighlightsListViewModel: ObservableObject {
+  @Published var highlights = [Highlight]()
+
+  func load(item: LinkedItem) {
+    highlights = item.highlights.asArray(of: Highlight.self)
+  }
+}

--- a/apple/OmnivoreKit/Sources/App/Views/Highlights/HighlightsListViewModel.swift
+++ b/apple/OmnivoreKit/Sources/App/Views/Highlights/HighlightsListViewModel.swift
@@ -4,20 +4,50 @@ import Services
 import SwiftUI
 import Views
 
-@MainActor final class HighlightsListViewModel: ObservableObject {
-  @Published var highlights = [Highlight]()
-
-  func load(item: LinkedItem) {
-    let unsortedHighlights = item.highlights.asArray(of: Highlight.self)
-
-    highlights = unsortedHighlights.sorted {
-      ($0.createdAt ?? Date()) < ($1.createdAt ?? Date())
-    }
-  }
+struct HighlightListItemParams: Identifiable {
+  let id = UUID()
+  let highlightID: String
+  let title: String
+  let annotation: String
+  let quote: String
 }
 
-extension Highlight {
-  var highlightCardTitle: String {
-    "Highlight"
+@MainActor final class HighlightsListViewModel: ObservableObject {
+  @Published var highlightItems = [HighlightListItemParams]()
+
+  func load(itemObjectID: NSManagedObjectID, dataService: DataService) {
+    if let linkedItem = dataService.viewContext.object(with: itemObjectID) as? LinkedItem {
+      loadHighlights(item: linkedItem)
+    }
+  }
+
+  func updateAnnotation(highlightID: String, annotation: String, dataService: DataService) {
+    dataService.updateHighlightAttributes(highlightID: highlightID, annotation: annotation)
+
+    if let index = highlightItems.firstIndex(where: { $0.highlightID == highlightID }) {
+      highlightItems[index] = HighlightListItemParams(
+        highlightID: highlightID,
+        title: highlightItems[index].title,
+        annotation: annotation,
+        quote: highlightItems[index].quote
+      )
+    }
+  }
+
+  private func loadHighlights(item: LinkedItem) {
+    let unsortedHighlights = item.highlights.asArray(of: Highlight.self)
+
+    let highlights = unsortedHighlights.sorted {
+      ($0.createdAt ?? Date()) < ($1.createdAt ?? Date())
+    }
+
+    highlightItems = highlights.map {
+      HighlightListItemParams(
+        highlightID: $0.unwrappedID,
+        title: "Highlight",
+        annotation: $0.annotation ?? "",
+        quote: $0.quote ?? ""
+      )
+    }
   }
 }

--- a/apple/OmnivoreKit/Sources/App/Views/Highlights/HighlightsListViewModel.swift
+++ b/apple/OmnivoreKit/Sources/App/Views/Highlights/HighlightsListViewModel.swift
@@ -8,7 +8,11 @@ import Views
   @Published var highlights = [Highlight]()
 
   func load(item: LinkedItem) {
-    highlights = item.highlights.asArray(of: Highlight.self)
+    let unsortedHighlights = item.highlights.asArray(of: Highlight.self)
+
+    highlights = unsortedHighlights.sorted {
+      ($0.createdAt ?? Date()) < ($1.createdAt ?? Date())
+    }
   }
 }
 

--- a/apple/OmnivoreKit/Sources/App/Views/Home/HomeFeedViewIOS.swift
+++ b/apple/OmnivoreKit/Sources/App/Views/Home/HomeFeedViewIOS.swift
@@ -63,7 +63,7 @@ import Views
           LinkedItemTitleEditView(item: item)
         }
         .sheet(item: $viewModel.itemForHighlightsView) { item in
-          HighlightsListView(item: item)
+          HighlightsListView(itemObjectID: item.objectID)
         }
         .toolbar {
           ToolbarItem(placement: .barTrailing) {

--- a/apple/OmnivoreKit/Sources/App/Views/Home/HomeFeedViewIOS.swift
+++ b/apple/OmnivoreKit/Sources/App/Views/Home/HomeFeedViewIOS.swift
@@ -11,6 +11,7 @@ import Views
   private let enableGrid = UIDevice.isIPad || FeatureFlag.enableGridCardsOnPhone
 
   struct HomeFeedContainerView: View {
+    @State var hasHighlightMutations = false
     @EnvironmentObject var dataService: DataService
     @EnvironmentObject var audioController: AudioController
 
@@ -63,7 +64,7 @@ import Views
           LinkedItemTitleEditView(item: item)
         }
         .sheet(item: $viewModel.itemForHighlightsView) { item in
-          HighlightsListView(itemObjectID: item.objectID)
+          HighlightsListView(itemObjectID: item.objectID, hasHighlightMutations: $hasHighlightMutations)
         }
         .toolbar {
           ToolbarItem(placement: .barTrailing) {

--- a/apple/OmnivoreKit/Sources/App/Views/Home/HomeFeedViewIOS.swift
+++ b/apple/OmnivoreKit/Sources/App/Views/Home/HomeFeedViewIOS.swift
@@ -63,7 +63,7 @@ import Views
           LinkedItemTitleEditView(item: item)
         }
         .sheet(item: $viewModel.itemForHighlightsView) { item in
-          Text("Highlights view for: \(item.unwrappedTitle)") // TODO: implement view
+          HighlightsListView(item: item)
         }
         .toolbar {
           ToolbarItem(placement: .barTrailing) {

--- a/apple/OmnivoreKit/Sources/App/Views/Home/HomeFeedViewIOS.swift
+++ b/apple/OmnivoreKit/Sources/App/Views/Home/HomeFeedViewIOS.swift
@@ -62,6 +62,9 @@ import Views
         .sheet(item: $viewModel.itemUnderTitleEdit) { item in
           LinkedItemTitleEditView(item: item)
         }
+        .sheet(item: $viewModel.itemForHighlightsView) { item in
+          Text("Highlights view for: \(item.unwrappedTitle)") // TODO: implement view
+        }
         .toolbar {
           ToolbarItem(placement: .barTrailing) {
             Button("", action: {})
@@ -256,6 +259,10 @@ import Views
               )
               .contextMenu {
                 Button(
+                  action: { viewModel.itemForHighlightsView = item },
+                  label: { Label("View Highlights", systemImage: "highlighter") }
+                )
+                Button(
                   action: { viewModel.itemUnderTitleEdit = item },
                   label: { Label("Edit Title/Description", systemImage: "textbox") }
                 )
@@ -372,6 +379,8 @@ import Views
 
     func contextMenuActionHandler(item: LinkedItem, action: GridCardAction) {
       switch action {
+      case .viewHighlights:
+        viewModel.itemForHighlightsView = item
       case .toggleArchiveStatus:
         viewModel.setLinkArchived(dataService: dataService, objectID: item.objectID, archived: !item.isArchived)
       case .delete:

--- a/apple/OmnivoreKit/Sources/App/Views/Home/HomeFeedViewMac.swift
+++ b/apple/OmnivoreKit/Sources/App/Views/Home/HomeFeedViewMac.swift
@@ -36,6 +36,7 @@ import Views
                 viewModel: viewModel
               )
               .contextMenu {
+                // TODO: add highlights view button
                 Button(
                   action: { viewModel.itemUnderTitleEdit = item },
                   label: { Label("Edit Title/Description", systemImage: "textbox") }
@@ -137,6 +138,7 @@ import Views
       .sheet(item: $viewModel.itemUnderTitleEdit) { item in
         LinkedItemTitleEditView(item: item)
       }
+      // TODO: add highlights view sheet
       .task {
         if viewModel.items.isEmpty {
           loadItems(isRefresh: true)

--- a/apple/OmnivoreKit/Sources/App/Views/Home/HomeFeedViewModel.swift
+++ b/apple/OmnivoreKit/Sources/App/Views/Home/HomeFeedViewModel.swift
@@ -17,6 +17,7 @@ import Views
   @Published var showPushNotificationPrimer = false
   @Published var itemUnderLabelEdit: LinkedItem?
   @Published var itemUnderTitleEdit: LinkedItem?
+  @Published var itemForHighlightsView: LinkedItem?
   @Published var searchTerm = ""
   @Published var selectedLabels = [LinkedItemLabel]()
   @Published var negatedLabels = [LinkedItemLabel]()

--- a/apple/OmnivoreKit/Sources/App/Views/WebReader/WebReader.swift
+++ b/apple/OmnivoreKit/Sources/App/Views/WebReader/WebReader.swift
@@ -70,6 +70,7 @@ struct WebReader: PlatformViewRepresentable {
     context.coordinator.linkHandler = openLinkAction
     context.coordinator.webViewActionHandler = webViewActionHandler
     context.coordinator.updateNavBarVisibilityRatio = navBarVisibilityRatioUpdater
+    context.coordinator.articleContentID = articleContent.id
     loadContent(webView: webView)
 
     return webView
@@ -101,8 +102,10 @@ struct WebReader: PlatformViewRepresentable {
     }
 
     // If the webview had been terminated `needsReload` will have been set to true
-    if context.coordinator.needsReload {
+    // Or if the articleContent value has changed then it's id will be different from the coordinator's
+    if context.coordinator.needsReload || context.coordinator.articleContentID != articleContent.id {
       loadContent(webView: webView)
+      context.coordinator.articleContentID = articleContent.id
       context.coordinator.needsReload = false
       return
     }

--- a/apple/OmnivoreKit/Sources/App/Views/WebReader/WebReaderContainer.swift
+++ b/apple/OmnivoreKit/Sources/App/Views/WebReader/WebReaderContainer.swift
@@ -12,6 +12,7 @@ struct WebReaderContainerView: View {
   @State private var showPreferencesPopover = false
   @State private var showLabelsModal = false
   @State private var showTitleEdit = false
+  @State private var showHighlightsView = false
   @State var showHighlightAnnotationModal = false
   @State var safariWebLink: SafariWebLink?
   @State private var navBarVisibilityRatio = 1.0
@@ -132,6 +133,10 @@ struct WebReaderContainerView: View {
         content: {
           Group {
             Button(
+              action: { showHighlightsView = true },
+              label: { Label("View Highlights", systemImage: "highlighter") }
+            )
+            Button(
               action: { showTitleEdit = true },
               label: { Label("Edit Title/Description", systemImage: "textbox") }
             )
@@ -197,6 +202,9 @@ struct WebReaderContainerView: View {
     }
     .sheet(isPresented: $showTitleEdit) {
       LinkedItemTitleEditView(item: item)
+    }
+    .sheet(isPresented: $showHighlightsView) {
+      HighlightsListView(item: item)
     }
     #if os(macOS)
       .buttonStyle(PlainButtonStyle())

--- a/apple/OmnivoreKit/Sources/App/Views/WebReader/WebReaderContainer.swift
+++ b/apple/OmnivoreKit/Sources/App/Views/WebReader/WebReaderContainer.swift
@@ -46,8 +46,20 @@ struct WebReaderContainerView: View {
   }
 
   func onHighlightListViewDismissal() {
-    print("has mutations: \(hasPerformedHighlightMutations)")
-    hasPerformedHighlightMutations = false
+    // Reload the web view if mutation happened in highlights list modal
+    guard hasPerformedHighlightMutations else { return }
+
+    hasPerformedHighlightMutations.toggle()
+
+    Task {
+      if let username = dataService.currentViewer?.username {
+        await viewModel.loadContent(
+          dataService: dataService,
+          username: username,
+          itemID: item.unwrappedID
+        )
+      }
+    }
   }
 
   private func handleHighlightAction(message: WKScriptMessage) {

--- a/apple/OmnivoreKit/Sources/App/Views/WebReader/WebReaderContainer.swift
+++ b/apple/OmnivoreKit/Sources/App/Views/WebReader/WebReaderContainer.swift
@@ -204,7 +204,7 @@ struct WebReaderContainerView: View {
       LinkedItemTitleEditView(item: item)
     }
     .sheet(isPresented: $showHighlightsView) {
-      HighlightsListView(item: item)
+      HighlightsListView(itemObjectID: item.objectID)
     }
     #if os(macOS)
       .buttonStyle(PlainButtonStyle())

--- a/apple/OmnivoreKit/Sources/App/Views/WebReader/WebReaderContainer.swift
+++ b/apple/OmnivoreKit/Sources/App/Views/WebReader/WebReaderContainer.swift
@@ -13,6 +13,7 @@ struct WebReaderContainerView: View {
   @State private var showLabelsModal = false
   @State private var showTitleEdit = false
   @State private var showHighlightsView = false
+  @State private var hasPerformedHighlightMutations = false
   @State var showHighlightAnnotationModal = false
   @State var safariWebLink: SafariWebLink?
   @State private var navBarVisibilityRatio = 1.0
@@ -42,6 +43,11 @@ struct WebReaderContainerView: View {
     if message.name == WebViewAction.highlightAction.rawValue {
       handleHighlightAction(message: message)
     }
+  }
+
+  func onHighlightListViewDismissal() {
+    print("has mutations: \(hasPerformedHighlightMutations)")
+    hasPerformedHighlightMutations = false
   }
 
   private func handleHighlightAction(message: WKScriptMessage) {
@@ -203,8 +209,11 @@ struct WebReaderContainerView: View {
     .sheet(isPresented: $showTitleEdit) {
       LinkedItemTitleEditView(item: item)
     }
-    .sheet(isPresented: $showHighlightsView) {
-      HighlightsListView(itemObjectID: item.objectID)
+    .sheet(isPresented: $showHighlightsView, onDismiss: onHighlightListViewDismissal) {
+      HighlightsListView(
+        itemObjectID: item.objectID,
+        hasHighlightMutations: $hasPerformedHighlightMutations
+      )
     }
     #if os(macOS)
       .buttonStyle(PlainButtonStyle())

--- a/apple/OmnivoreKit/Sources/App/Views/WebReader/WebReaderCoordinator.swift
+++ b/apple/OmnivoreKit/Sources/App/Views/WebReader/WebReaderCoordinator.swift
@@ -19,6 +19,7 @@ final class WebReaderCoordinator: NSObject {
   var previousShowNavBarActionID: UUID?
   var previousShareActionID: UUID?
   var updateNavBarVisibilityRatio: (Double) -> Void = { _ in }
+  var articleContentID = UUID()
   private var yOffsetAtStartOfDrag: Double?
   private var lastYOffset: Double = 0
   private var hasDragged = false

--- a/apple/OmnivoreKit/Sources/Models/DataModels/ArticleContent.swift
+++ b/apple/OmnivoreKit/Sources/Models/DataModels/ArticleContent.swift
@@ -9,6 +9,7 @@ public enum ArticleContentStatus: String {
 }
 
 public struct ArticleContent {
+  public let id = UUID()
   public let title: String
   public let htmlContent: String
   public let highlightsJSONString: String

--- a/apple/OmnivoreKit/Sources/Models/DataModels/FeedItem.swift
+++ b/apple/OmnivoreKit/Sources/Models/DataModels/FeedItem.swift
@@ -87,6 +87,12 @@ public extension LinkedItem {
     }
   }
 
+  var sortedHighlights: [Highlight] {
+    highlights.asArray(of: Highlight.self).sorted {
+      ($0.createdAt ?? Date()) < ($1.createdAt ?? Date())
+    }
+  }
+
   var labelsJSONString: String {
     let labels = self.labels.asArray(of: LinkedItemLabel.self).map { label in
       [

--- a/apple/OmnivoreKit/Sources/Utils/FeatureFlags.swift
+++ b/apple/OmnivoreKit/Sources/Utils/FeatureFlags.swift
@@ -15,4 +15,5 @@ public enum FeatureFlag {
   public static let enableSnooze = false
   public static let enableGridCardsOnPhone = false
   public static let enableTextToSpeechButton = true
+  public static let enableHighlightsView = true
 }

--- a/apple/OmnivoreKit/Sources/Utils/FeatureFlags.swift
+++ b/apple/OmnivoreKit/Sources/Utils/FeatureFlags.swift
@@ -13,7 +13,7 @@ public enum FeatureFlag {
   public static let enablePushNotifications = false
   public static let enableShareButton = false
   public static let enableSnooze = false
-  public static let enableGridCardsOnPhone = false
+  public static let enableGridCardsOnPhone = true
   public static let enableTextToSpeechButton = true
   public static let enableHighlightsView = true
 }

--- a/apple/OmnivoreKit/Sources/Utils/FeatureFlags.swift
+++ b/apple/OmnivoreKit/Sources/Utils/FeatureFlags.swift
@@ -13,7 +13,7 @@ public enum FeatureFlag {
   public static let enablePushNotifications = false
   public static let enableShareButton = false
   public static let enableSnooze = false
-  public static let enableGridCardsOnPhone = true
+  public static let enableGridCardsOnPhone = false
   public static let enableTextToSpeechButton = true
   public static let enableHighlightsView = true
 }

--- a/apple/OmnivoreKit/Sources/Views/Article/HighlightAnnotationSheet.swift
+++ b/apple/OmnivoreKit/Sources/Views/Article/HighlightAnnotationSheet.swift
@@ -22,15 +22,13 @@ public struct HighlightAnnotationSheet: View {
       HStack {
         Button("Cancel", action: onCancel)
         Spacer()
-        HStack {
-          Image(systemName: "note.text")
-          Text("Note")
-        }
+        Label("Note", systemImage: "note.text")
         Spacer()
         Button("Save") {
           onSave()
         }
       }
+      .foregroundColor(.appGrayTextContrast)
 
       ScrollView {
         TextEditor(text: $annotation)

--- a/apple/OmnivoreKit/Sources/Views/FeedItem/GridCard.swift
+++ b/apple/OmnivoreKit/Sources/Views/FeedItem/GridCard.swift
@@ -8,6 +8,7 @@ public enum GridCardAction {
   case editLabels
   case editTitle
   case downloadAudio
+  case viewHighlights
 }
 
 public struct GridCard: View {
@@ -45,6 +46,10 @@ public struct GridCard: View {
 
   var contextMenuView: some View {
     Group {
+      Button(
+        action: { menuActionHandler(.viewHighlights) },
+        label: { Label("View Highlights", systemImage: "highlighter") }
+      )
       Button(
         action: { menuActionHandler(.editTitle) },
         label: { Label("Edit Title/Description", systemImage: "textbox") }


### PR DESCRIPTION
- add view highlights context menu to home feed items
- add a basic highlights list view
- create highlight list card
- style highlights card
- add note section to highlights view
- sort highlights by createdAt
- show highlight annotation sheet when tapping on note or 'add a note'
- persist annotation changes from highlights view
- message web container view when highlight view is dismissed and mutations have occurred
- reload web view if article highlights had been mutated from the highlits list modal
