### PR TITLE
Create a content handler for GitHub pages

### DIFF
--- a/packages/content-handler/src/index.ts
+++ b/packages/content-handler/src/index.ts
@@ -9,6 +9,7 @@ import { TDotCoHandler } from './websites/t-dot-co-handler'
 import { TwitterHandler } from './websites/twitter-handler'
 import { YoutubeHandler } from './websites/youtube-handler'
 import { WikipediaHandler } from './websites/wikipedia-handler'
+import { GitHubHandler } from './websites/github-handler'
 import {
   ContentHandler,
   NewsletterInput,
@@ -52,6 +53,7 @@ const contentHandlers: ContentHandler[] = [
   new TwitterHandler(),
   new YoutubeHandler(),
   new WikipediaHandler(),
+  new GitHubHandler(),
   new AxiosHandler(),
   new GolangHandler(),
   new MorningBrewHandler(),

--- a/packages/content-handler/src/websites/github-handler.ts
+++ b/packages/content-handler/src/websites/github-handler.ts
@@ -1,0 +1,23 @@
+import { ContentHandler } from '../content-handler'
+
+export class GitHubHandler extends ContentHandler {
+  constructor() {
+    super()
+    this.name = 'github'
+  }
+
+  shouldPreParse(url: string, dom: Document): boolean {
+    return new URL(url).hostname.endsWith('github.com')
+  }
+
+  async preParse(url: string, dom: Document): Promise<Document> {
+    const body = dom.querySelector('body')
+    const article = dom.querySelector('article')
+
+    if (body && article) {
+      body?.replaceChildren(article)
+    }
+
+    return Promise.resolve(dom)
+  }
+}


### PR DESCRIPTION
This will search for the markdown <article> element and make it
the only page element so we add a repo's README.
