### PR TITLE
Add the iOS Saving Links article as a default read for new Omnivore users on iOS

### DIFF
--- a/packages/api/src/services/popular_reads.ts
+++ b/packages/api/src/services/popular_reads.ts
@@ -124,7 +124,6 @@ export const addPopularReadsForNewUser = async (
   const defaultReads = [
     'omnivore_organize',
     'power_read_it_later',
-    'omnivore_get_started',
   ]
 
   // get client from request context
@@ -142,6 +141,9 @@ export const addPopularReadsForNewUser = async (
       break
   }
 
+  // We always want this to be the top-most article in the user's
+  // list. So we save it last to have the greatest saved_at
+  defaultReads.push('omnivore_get_started')
   await addPopularReads(userId, defaultReads)
 }
 
@@ -156,6 +158,16 @@ const popularReads = [
       'https://proxy-prod.omnivore-image-cache.app/88x88,sBp_gMyIp8Y4Mje8lzL39vzrBQg5m9KbprssrGjCbbHw/https://substackcdn.com/image/fetch/w_1200,h_600,c_limit,f_jpg,q_auto:good,fl_progressive:steep/https%3A%2F%2Fbucketeer-e05bbc84-baa3-437e-9518-adb32be77984.s3.amazonaws.com%2Fpublic%2Fimages%2F658efff4-341a-4720-8cf6-9b2bdbedfaa7_800x668.gif',
     publishedAt: new Date('2021-10-13'),
     siteName: 'Omnivore Blog',
+  },
+  {
+    key: 'omnivore_ios',
+    url: 'https://blog.omnivore.app/p/saving-links-from-your-iphone-or',
+    title: "Saving Links from Your iPhone or iPad",
+    author: 'Omnivore',
+    description: 'Learn how to save articles on iOS.',
+    previewImage: 'https://proxy-prod.omnivore-image-cache.app/260x260,suM2fz_-6_1PDsQDursGPD2bQqnpgGH9Ymj-IVb5dUR4/https://substackcdn.com/image/youtube/w_728,c_limit/k6RkIqepAig',
+    publishedAt:  new Date('2021-10-19'),
+    siteName: 'Omnivore Blog'
   },
   {
     key: 'omnivore_organize',

--- a/packages/api/src/services/popular_reads.ts
+++ b/packages/api/src/services/popular_reads.ts
@@ -121,10 +121,7 @@ const addPopularReads = async (
 export const addPopularReadsForNewUser = async (
   userId: string
 ): Promise<void> => {
-  const defaultReads = [
-    'omnivore_organize',
-    'power_read_it_later',
-  ]
+  const defaultReads = ['omnivore_organize', 'power_read_it_later']
 
   // get client from request context
   const client = httpContext.get('client') as string | undefined
@@ -162,12 +159,13 @@ const popularReads = [
   {
     key: 'omnivore_ios',
     url: 'https://blog.omnivore.app/p/saving-links-from-your-iphone-or',
-    title: "Saving Links from Your iPhone or iPad",
+    title: 'Saving Links from Your iPhone or iPad',
     author: 'Omnivore',
     description: 'Learn how to save articles on iOS.',
-    previewImage: 'https://proxy-prod.omnivore-image-cache.app/260x260,suM2fz_-6_1PDsQDursGPD2bQqnpgGH9Ymj-IVb5dUR4/https://substackcdn.com/image/youtube/w_728,c_limit/k6RkIqepAig',
-    publishedAt:  new Date('2021-10-19'),
-    siteName: 'Omnivore Blog'
+    previewImage:
+      'https://proxy-prod.omnivore-image-cache.app/260x260,suM2fz_-6_1PDsQDursGPD2bQqnpgGH9Ymj-IVb5dUR4/https://substackcdn.com/image/youtube/w_728,c_limit/k6RkIqepAig',
+    publishedAt: new Date('2021-10-19'),
+    siteName: 'Omnivore Blog',
   },
   {
     key: 'omnivore_organize',

--- a/packages/api/src/services/popular_reads/omnivore_ios-content.html
+++ b/packages/api/src/services/popular_reads/omnivore_ios-content.html
@@ -1,0 +1,94 @@
+<DIV class="page" id="readability-page-1">
+    <article>
+        <div dir="auto">
+            <p>
+                <span>With the</span> <a href="https://omnivore.app/install/ios" rel="">Omnivore app for iOS</a><span>, it’s easy to save web pages and articles or archive web content to read later.</span>
+            </p>
+            <p>
+                <span>The Omnivore app uses the</span> <em>iOS Share System</em><span>, which lets you send items from one app (such as Safari) to another (such as Messages or Mail).&nbsp;</span>
+            </p>
+            <ul>
+                <li>
+                    <p> Step 1: Log in to the Omnivore app. </p>
+                </li>
+                <li>
+                    <p> Step 2: Add Omnivore to your Share menu favorites. </p>
+                </li>
+                <li>
+                    <p> Step 3: Save links to your Omnivore Library. </p>
+                </li>
+            </ul>
+            <div id="youtube2-k6RkIqepAig" data-attrs="{&quot;videoId&quot;:&quot;k6RkIqepAig&quot;,&quot;startTime&quot;:null,&quot;endTime&quot;:null}">
+                <P>
+                    <iframe src="https://www.youtube-nocookie.com/embed/k6RkIqepAig?rel=0&autoplay=0&showinfo=0&enablejsapi=0" frameborder="0" loading="lazy" gesture="media" allow="autoplay; fullscreen" allowautoplay="true" allowfullscreen="true" width="728" height="409"></iframe>
+                </P>
+            </div>
+            <p> You must be logged in before you can save links via the Share menu. If you don’t already have an Omnivore account, you can sign up for free from the login screen. </p>
+            <p>
+                <em>Note:</em> <span>If you haven’t installed the iOS app, download it here:</span> <a href="https://omnivore.app/install/ios" rel="">https://omnivore.app/install/ios</a>
+            </p>
+            <h2>
+                <strong>Step 2: Add Omnivore to your Share menu favorites.</strong>
+            </h2>
+            <p> Start by viewing the Share menu from within any supported iOS app (we’ve used Safari for this example). </p>
+            <ol>
+                <li>
+                    <p>
+                        <span>Tap the</span> <strong>Share</strong> <span>icon at the bottom of the screen.</span>
+                    </p>
+                </li>
+                <li>
+                    <p>
+                        <span>Swipe left to the end of the list of app icons and tap</span> <strong>More</strong><span>.</span>
+                    </p>
+                </li>
+                <li>
+                    <p>
+                        <span>Tap</span> <strong>Edit</strong> <span>at the top of the screen.</span>
+                    </p>
+                </li>
+                <li>
+                    <p>
+                        <span>Scroll down until you see the</span> <strong>Omnivore</strong> <span>icon and tap the</span> <strong>+</strong> <span>icon next to it.&nbsp;</span>
+                    </p>
+                </li>
+                <li>
+                    <p>
+                        <span>Press and hold the three-bar icon and drag Omnivore to one of the top positions under Favorites. Tap</span> <strong>Done</strong> <span>to close the menu.</span>
+                    </p>
+                </li>
+                <li>
+                    <p>
+                        <strong>Omnivore</strong> <span>will appear as one of the first options the next time you use the Share feature (you may need to restart Safari).</span>
+                    </p>
+                </li>
+            </ol>
+            <h2>
+                <strong>Step 3: Save links to your Omnivore Library</strong>
+            </h2>
+            <p>
+                <span>Start by navigating to the page or article you wish to save. Please note that Omnivore will save the content that appears on your screen (not just a link), so</span> <em>if the page is behind a paywall and you are logged into the paywalled site, you will save the paid content.</em><span>&nbsp;</span>
+            </p>
+            <ol>
+                <li>
+                    <p>
+                        <span>While viewing the page you’d like to save, tap the</span> <strong>Share</strong> <span>icon.</span>
+                    </p>
+                </li>
+                <li>
+                    <p>
+                        <span>Tap the</span> <strong>Omnivore</strong> <span>icon in the Share menu.</span>
+                    </p>
+                </li>
+                <li>
+                    <p>
+                        <span>Tag the article with one or more labels (optional) and tap</span> <strong>Read Now</strong> <span>or</span> <strong>Read Later</strong><span>.&nbsp;</span>
+                    </p>
+                </li>
+                <li>
+                    <p> If you choose Read Later, the link will appear in your Library the next time you open the Omnivore app. </p>
+                </li>
+            </ol>
+        </div>
+    </article>
+</DIV>

--- a/packages/api/src/services/popular_reads/omnivore_ios-original.html
+++ b/packages/api/src/services/popular_reads/omnivore_ios-original.html
@@ -1,0 +1,1456 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+    <head>
+        <meta charset="utf-8" />
+        <meta name="norton-safeweb-site-verification" content="24usqpep0ejc5w6hod3dulxwciwp0djs6c6ufp96av3t4whuxovj72wfkdjxu82yacb7430qjm8adbd5ezlt4592dq4zrvadcn9j9n-0btgdzpiojfzno16-fnsnu7xd" />
+        <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0" />
+        <meta name="author" content="Omnivore" />
+        <meta property="og:url" content="https://blog.omnivore.app/p/saving-links-from-your-iphone-or" />
+        <link rel="canonical" href="https://blog.omnivore.app/p/saving-links-from-your-iphone-or" />
+        <link rel="shortcut icon" href="https://bucketeer-e05bbc84-baa3-437e-9518-adb32be77984.s3.amazonaws.com/public/images/8f6c575c-355b-44a6-a8e6-67a1c3745b59/favicon.ico" />
+        <link rel="icon" type="image/png" sizes="16x16" href="https://bucketeer-e05bbc84-baa3-437e-9518-adb32be77984.s3.amazonaws.com/public/images/8f6c575c-355b-44a6-a8e6-67a1c3745b59/favicon-16x16.png" />
+        <link rel="icon" type="image/png" sizes="32x32" href="https://bucketeer-e05bbc84-baa3-437e-9518-adb32be77984.s3.amazonaws.com/public/images/8f6c575c-355b-44a6-a8e6-67a1c3745b59/favicon-32x32.png" />
+        <link rel="apple-touch-icon" sizes="57x57" href="https://bucketeer-e05bbc84-baa3-437e-9518-adb32be77984.s3.amazonaws.com/public/images/8f6c575c-355b-44a6-a8e6-67a1c3745b59/apple-touch-icon-57x57.png" />
+        <link rel="apple-touch-icon" sizes="60x60" href="https://bucketeer-e05bbc84-baa3-437e-9518-adb32be77984.s3.amazonaws.com/public/images/8f6c575c-355b-44a6-a8e6-67a1c3745b59/apple-touch-icon-60x60.png" />
+        <link rel="apple-touch-icon" sizes="72x72" href="https://bucketeer-e05bbc84-baa3-437e-9518-adb32be77984.s3.amazonaws.com/public/images/8f6c575c-355b-44a6-a8e6-67a1c3745b59/apple-touch-icon-72x72.png" />
+        <link rel="apple-touch-icon" sizes="76x76" href="https://bucketeer-e05bbc84-baa3-437e-9518-adb32be77984.s3.amazonaws.com/public/images/8f6c575c-355b-44a6-a8e6-67a1c3745b59/apple-touch-icon-76x76.png" />
+        <link rel="apple-touch-icon" sizes="114x114" href="https://bucketeer-e05bbc84-baa3-437e-9518-adb32be77984.s3.amazonaws.com/public/images/8f6c575c-355b-44a6-a8e6-67a1c3745b59/apple-touch-icon-114x114.png" />
+        <link rel="apple-touch-icon" sizes="120x120" href="https://bucketeer-e05bbc84-baa3-437e-9518-adb32be77984.s3.amazonaws.com/public/images/8f6c575c-355b-44a6-a8e6-67a1c3745b59/apple-touch-icon-120x120.png" />
+        <link rel="apple-touch-icon" sizes="144x144" href="https://bucketeer-e05bbc84-baa3-437e-9518-adb32be77984.s3.amazonaws.com/public/images/8f6c575c-355b-44a6-a8e6-67a1c3745b59/apple-touch-icon-144x144.png" />
+        <link rel="apple-touch-icon" sizes="152x152" href="https://bucketeer-e05bbc84-baa3-437e-9518-adb32be77984.s3.amazonaws.com/public/images/8f6c575c-355b-44a6-a8e6-67a1c3745b59/apple-touch-icon-152x152.png" />
+        <link rel="apple-touch-icon" sizes="167x167" href="https://bucketeer-e05bbc84-baa3-437e-9518-adb32be77984.s3.amazonaws.com/public/images/8f6c575c-355b-44a6-a8e6-67a1c3745b59/apple-touch-icon-167x167.png" />
+        <link rel="apple-touch-icon" sizes="180x180" href="https://bucketeer-e05bbc84-baa3-437e-9518-adb32be77984.s3.amazonaws.com/public/images/8f6c575c-355b-44a6-a8e6-67a1c3745b59/apple-touch-icon-180x180.png" />
+        <link rel="apple-touch-icon" sizes="1024x1024" href="https://bucketeer-e05bbc84-baa3-437e-9518-adb32be77984.s3.amazonaws.com/public/images/8f6c575c-355b-44a6-a8e6-67a1c3745b59/apple-touch-icon-1024x1024.png" />
+        <title>
+            Saving Links from Your iPhone or iPad - Omnivore
+        </title>
+        <link rel="alternate" type="application/rss+xml" href="/feed" title="Omnivore" />
+        <style>
+        <![CDATA[
+        /*https://fonts.googleapis.com/css?family=Spectral:400,400i,600,600i*/
+        /* cyrillic */
+        @font-face {
+        font-family: 'Spectral';
+        font-style: italic;
+        font-weight: 400;
+        src: local('Spectral Italic'), local('Spectral-Italic'), url(https://fonts.gstatic.com/s/spectral/v5/rnCt-xNNww_2s0amA9M8on7mTNmnUHowCw.woff2) format('woff2');
+        unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
+        font-display: fallback;
+        }
+        /* vietnamese */
+        @font-face {
+        font-family: 'Spectral';
+        font-style: italic;
+        font-weight: 400;
+        src: local('Spectral Italic'), local('Spectral-Italic'), url(https://fonts.gstatic.com/s/spectral/v5/rnCt-xNNww_2s0amA9M8onXmTNmnUHowCw.woff2) format('woff2');
+        unicode-range: U+0102-0103, U+0110-0111, U+1EA0-1EF9, U+20AB;
+        font-display: fallback;
+        }
+        /* latin-ext */
+        @font-face {
+        font-family: 'Spectral';
+        font-style: italic;
+        font-weight: 400;
+        src: local('Spectral Italic'), local('Spectral-Italic'), url(https://fonts.gstatic.com/s/spectral/v5/rnCt-xNNww_2s0amA9M8onTmTNmnUHowCw.woff2) format('woff2');
+        unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+        font-display: fallback;
+        }
+        /* latin */
+        @font-face {
+        font-family: 'Spectral';
+        font-style: italic;
+        font-weight: 400;
+        src: local('Spectral Italic'), local('Spectral-Italic'), url(https://fonts.gstatic.com/s/spectral/v5/rnCt-xNNww_2s0amA9M8onrmTNmnUHo.woff2) format('woff2');
+        unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+        font-display: fallback;
+        }
+        /* cyrillic */
+        @font-face {
+        font-family: 'Spectral';
+        font-style: italic;
+        font-weight: 600;
+        src: local('Spectral SemiBold Italic'), local('Spectral-SemiBoldItalic'), url(https://fonts.gstatic.com/s/spectral/v5/rnCu-xNNww_2s0amA9M8qqXCWfCFXVAKArdqqQ.woff2) format('woff2');
+        unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
+        font-display: fallback;
+        }
+        /* vietnamese */
+        @font-face {
+        font-family: 'Spectral';
+        font-style: italic;
+        font-weight: 600;
+        src: local('Spectral SemiBold Italic'), local('Spectral-SemiBoldItalic'), url(https://fonts.gstatic.com/s/spectral/v5/rnCu-xNNww_2s0amA9M8qqXCWfuFXVAKArdqqQ.woff2) format('woff2');
+        unicode-range: U+0102-0103, U+0110-0111, U+1EA0-1EF9, U+20AB;
+        font-display: fallback;
+        }
+        /* latin-ext */
+        @font-face {
+        font-family: 'Spectral';
+        font-style: italic;
+        font-weight: 600;
+        src: local('Spectral SemiBold Italic'), local('Spectral-SemiBoldItalic'), url(https://fonts.gstatic.com/s/spectral/v5/rnCu-xNNww_2s0amA9M8qqXCWfqFXVAKArdqqQ.woff2) format('woff2');
+        unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+        font-display: fallback;
+        }
+        /* latin */
+        @font-face {
+        font-family: 'Spectral';
+        font-style: italic;
+        font-weight: 600;
+        src: local('Spectral SemiBold Italic'), local('Spectral-SemiBoldItalic'), url(https://fonts.gstatic.com/s/spectral/v5/rnCu-xNNww_2s0amA9M8qqXCWfSFXVAKArc.woff2) format('woff2');
+        unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+        font-display: fallback;
+        }
+        /* cyrillic */
+        @font-face {
+        font-family: 'Spectral';
+        font-style: normal;
+        font-weight: 400;
+        src: local('Spectral Regular'), local('Spectral-Regular'), url(https://fonts.gstatic.com/s/spectral/v5/rnCr-xNNww_2s0amA9M9knjsS_ulYHs.woff2) format('woff2');
+        unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
+        font-display: fallback;
+        }
+        /* vietnamese */
+        @font-face {
+        font-family: 'Spectral';
+        font-style: normal;
+        font-weight: 400;
+        src: local('Spectral Regular'), local('Spectral-Regular'), url(https://fonts.gstatic.com/s/spectral/v5/rnCr-xNNww_2s0amA9M2knjsS_ulYHs.woff2) format('woff2');
+        unicode-range: U+0102-0103, U+0110-0111, U+1EA0-1EF9, U+20AB;
+        font-display: fallback;
+        }
+        /* latin-ext */
+        @font-face {
+        font-family: 'Spectral';
+        font-style: normal;
+        font-weight: 400;
+        src: local('Spectral Regular'), local('Spectral-Regular'), url(https://fonts.gstatic.com/s/spectral/v5/rnCr-xNNww_2s0amA9M3knjsS_ulYHs.woff2) format('woff2');
+        unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+        font-display: fallback;
+        }
+        /* latin */
+        @font-face {
+        font-family: 'Spectral';
+        font-style: normal;
+        font-weight: 400;
+        src: local('Spectral Regular'), local('Spectral-Regular'), url(https://fonts.gstatic.com/s/spectral/v5/rnCr-xNNww_2s0amA9M5knjsS_ul.woff2) format('woff2');
+        unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+        font-display: fallback;
+        }
+        /* cyrillic */
+        @font-face {
+        font-family: 'Spectral';
+        font-style: normal;
+        font-weight: 600;
+        src: local('Spectral SemiBold'), local('Spectral-SemiBold'), url(https://fonts.gstatic.com/s/spectral/v5/rnCs-xNNww_2s0amA9vmtm3FafaPWnIIMrY.woff2) format('woff2');
+        unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
+        font-display: fallback;
+        }
+        /* vietnamese */
+        @font-face {
+        font-family: 'Spectral';
+        font-style: normal;
+        font-weight: 600;
+        src: local('Spectral SemiBold'), local('Spectral-SemiBold'), url(https://fonts.gstatic.com/s/spectral/v5/rnCs-xNNww_2s0amA9vmtm3OafaPWnIIMrY.woff2) format('woff2');
+        unicode-range: U+0102-0103, U+0110-0111, U+1EA0-1EF9, U+20AB;
+        font-display: fallback;
+        }
+        /* latin-ext */
+        @font-face {
+        font-family: 'Spectral';
+        font-style: normal;
+        font-weight: 600;
+        src: local('Spectral SemiBold'), local('Spectral-SemiBold'), url(https://fonts.gstatic.com/s/spectral/v5/rnCs-xNNww_2s0amA9vmtm3PafaPWnIIMrY.woff2) format('woff2');
+        unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+        font-display: fallback;
+        }
+        /* latin */
+        @font-face {
+        font-family: 'Spectral';
+        font-style: normal;
+        font-weight: 600;
+        src: local('Spectral SemiBold'), local('Spectral-SemiBold'), url(https://fonts.gstatic.com/s/spectral/v5/rnCs-xNNww_2s0amA9vmtm3BafaPWnII.woff2) format('woff2');
+        unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+        font-display: fallback;
+        }
+        ]]>
+        </style>
+        <style>
+        <![CDATA[
+        :root{--color_theme_bg_pop:#ffe682;--background_pop:#ffe682;--cover_bg_color:#FFFFFF;--background_pop_darken:#ffe168;--print_on_pop:#404040;--color_theme_bg_pop_darken:#ffe168;--color_theme_print_on_pop:#404040;--border_subtle:rgba(204, 204, 204, 0.5);--background_subtle:rgba(255, 251, 236, 0.4);--print_pop:hsl(48, 100%, 40%);--color_theme_accent:hsl(48, 100%, 40%);--cover_print_primary:#404040;--cover_print_secondary:#757575;--cover_border_color:#ffe682;--web_bg_color:#ffffff;--background_contrast_1:#f7f7f7;--color_theme_bg_contrast_1:#f7f7f7;--background_contrast_2:#ebebeb;--color_theme_bg_contrast_2:#ebebeb;--background_contrast_3:#d6d6d6;--color_theme_bg_contrast_3:#d6d6d6;--background_contrast_4:#b8b8b8;--color_theme_bg_contrast_4:#b8b8b8;--background_contrast_5:#9a9a9a;--color_theme_bg_contrast_5:#9a9a9a;--background_contrast_pop:rgba(255, 230, 130, 0.4);--color_theme_bg_contrast_pop:rgba(255, 230, 130, 0.4);--input_background:#ffffff;--cover_input_background:#ffffff;--tooltip_background:#191919;--web_bg_color_h:0;--web_bg_color_s:0%;--web_bg_color_l:100%;--print_on_web_bg_color:#404040;--print_secondary_on_web_bg_color:#8c8c8c;--selected_comment_background_color:#fdf9f3;--background_pop_rgb:255, 230, 130;--color_theme_bg_pop_rgb:255, 230, 130;}
+        ]]>
+        </style>
+        <link rel="stylesheet" href="https://substackcdn.com/theme/main.css?v=9f1f911d6a334a9ce086b54db0877c7e" />
+        <link rel="stylesheet" type="text/css" href="https://substackcdn.com/min/main.css?v=1a455-183edb5c440" />
+        <style type="text/css">
+        /*<![CDATA[*/
+        /*
+        code is extracted from Calendly's embed stylesheet: https://assets.calendly.com/assets/external/widget.css
+        */
+
+        .calendly-inline-widget,
+        .calendly-inline-widget *,
+        .calendly-badge-widget,
+        .calendly-badge-widget *,
+        .calendly-overlay,
+        .calendly-overlay * {
+        font-size:16px;
+        line-height:1.2em
+        }
+
+        .calendly-inline-widget iframe,
+        .calendly-badge-widget iframe,
+        .calendly-overlay iframe {
+        display:inline;
+        width:100%;
+        height:100%
+        }
+
+        .calendly-popup-content {
+        position:relative
+        }
+
+        .calendly-popup-content.calendly-mobile {
+        -webkit-overflow-scrolling:touch;
+        overflow-y:auto
+        }
+
+        .calendly-overlay {
+        position:fixed;
+        top:0;
+        left:0;
+        right:0;
+        bottom:0;
+        overflow:hidden;
+        z-index:9999;
+        background-color:#a5a5a5;
+        background-color:rgba(31,31,31,0.4)
+        }
+
+        .calendly-overlay .calendly-close-overlay {
+        position:absolute;
+        top:0;
+        left:0;
+        right:0;
+        bottom:0
+        }
+
+        .calendly-overlay .calendly-popup {
+        box-sizing:border-box;
+        position:absolute;
+        top:50%;
+        left:50%;
+        -webkit-transform:translateY(-50%) translateX(-50%);
+        transform:translateY(-50%) translateX(-50%);
+        width:80%;
+        min-width:900px;
+        max-width:1000px;
+        height:90%;
+        max-height:680px
+        }
+
+        @media (max-width: 975px) {
+        .calendly-overlay .calendly-popup {
+        position:fixed;
+        top:50px;
+        left:0;
+        right:0;
+        bottom:0;
+        -webkit-transform:none;
+        transform:none;
+        width:100%;
+        height:auto;
+        min-width:0;
+        max-height:none
+        }
+        }
+
+        .calendly-overlay .calendly-popup .calendly-popup-content {
+        height:100%;
+        }
+
+        .calendly-overlay .calendly-popup-close {
+        position:absolute;
+        top:25px;
+        right:25px;
+        color:#fff;
+        width:19px;
+        height:19px;
+        cursor:pointer;
+        background:url(https://assets.calendly.com/assets/external/close-icon.svg) no-repeat;
+        background-size:contain
+        }
+
+        @media (max-width: 975px) {
+        .calendly-overlay .calendly-popup-close {
+        top:15px;
+        right:15px
+        }
+        }
+
+        .calendly-badge-widget {
+        position:fixed;
+        right:20px;
+        bottom:15px;
+        z-index:9998
+        }
+
+        .calendly-badge-widget .calendly-badge-content {
+        display:table-cell;
+        width:auto;
+        height:45px;
+        padding:0 30px;
+        border-radius:25px;
+        box-shadow:rgba(0,0,0,0.25) 0 2px 5px;
+        font-family:sans-serif;
+        text-align:center;
+        vertical-align:middle;
+        font-weight:bold;
+        font-size:14px;
+        color:#fff;
+        cursor:pointer
+        }
+
+        .calendly-badge-widget .calendly-badge-content.calendly-white {
+        color:#666a73
+        }
+
+        .calendly-badge-widget .calendly-badge-content span {
+        display:block;
+        font-size:12px
+        }
+
+        .calendly-spinner {
+        position:absolute;
+        top:50%;
+        left:0;
+        right:0;
+        -webkit-transform:translateY(-50%);
+        transform:translateY(-50%);
+        text-align:center;
+        z-index:-1
+        }
+
+        .calendly-spinner>div {
+        display:inline-block;
+        width:18px;
+        height:18px;
+        background-color:#e1e1e1;
+        border-radius:50%;
+        vertical-align:middle;
+        -webkit-animation:calendly-bouncedelay 1.4s infinite ease-in-out;
+        animation:calendly-bouncedelay 1.4s infinite ease-in-out;
+        -webkit-animation-fill-mode:both;
+        animation-fill-mode:both
+        }
+
+        .calendly-spinner .calendly-bounce1 {
+        -webkit-animation-delay:-0.32s;
+        animation-delay:-0.32s
+        }
+
+        .calendly-spinner .calendly-bounce2 {
+        -webkit-animation-delay:-0.16s;
+        animation-delay:-0.16s
+        }
+
+        @-webkit-keyframes calendly-bouncedelay {
+        0%,80%,100% {
+        -webkit-transform:scale(0);
+        transform:scale(0)
+        } 
+
+        40%{
+        -webkit-transform:scale(1);
+        transform:scale(1)
+        }
+        }
+
+        @keyframes calendly-bouncedelay{ 
+        0%,80%,100% {
+        -webkit-transform:scale(0);
+        transform:scale(0)
+        }
+
+        40% {
+        -webkit-transform:scale(1);
+        transform:scale(1)
+        }
+        }
+        /*]]>*/
+        </style>
+        <meta property="og:type" content="article" data-preact-helmet="true" />
+        <meta name="theme-color" content="#ffffff" data-preact-helmet="true" />
+        <meta name="description" content="With the Omnivore app for iOS, it’s easy to save web pages and articles or archive web content to read later. The Omnivore app uses the iOS Share System, which lets you send items from one app (such as Safari) to another (such as Messages or Mail)." data-preact-helmet="true" />
+        <meta property="og:description" content="With the Omnivore app for iOS, it’s easy to save web pages and articles or archive web content to read later. The Omnivore app uses the iOS Share System, which lets you send items from one app (such as Safari) to another (such as Messages or Mail)." data-preact-helmet="true" />
+        <meta property="twitter:description" content="With the Omnivore app for iOS, it’s easy to save web pages and articles or archive web content to read later. The Omnivore app uses the iOS Share System, which lets you send items from one app (such as Safari) to another (such as Messages or Mail)." data-preact-helmet="true" />
+        <meta property="og:title" content="Saving Links from Your iPhone or iPad" data-preact-helmet="true" />
+        <meta property="twitter:title" content="Saving Links from Your iPhone or iPad" data-preact-helmet="true" />
+        <meta property="og:image" content="https://substackcdn.com/image/youtube/w_728,c_limit/k6RkIqepAig" data-preact-helmet="true" />
+        <meta property="twitter:image" content="https://substackcdn.com/image/youtube/w_728,c_limit/k6RkIqepAig" data-preact-helmet="true" />
+        <meta property="twitter:card" content="summary_large_image" data-preact-helmet="true" />
+        <meta http-equiv="origin-trial" content="A7bG5hJ4XpMV5a3V1wwAR0PalkFSxLOZeL9D/YBYdupYUIgUgGhfVJ1zBFOqGybb7gRhswfJ+AmO7S2rNK2IOwkAAAB7eyJvcmlnaW4iOiJodHRwczovL3d3dy5nb29nbGV0YWdtYW5hZ2VyLmNvbTo0NDMiLCJmZWF0dXJlIjoiUHJpdmFjeVNhbmRib3hBZHNBUElzIiwiZXhwaXJ5IjoxNjY5NzY2Mzk5LCJpc1RoaXJkUGFydHkiOnRydWV9" />
+        <style>
+        <![CDATA[
+
+        #nojs-banner {
+            position: fixed;
+            bottom: 0;
+            left: 0;
+            padding: 16px 16px 16px 32px;
+            width: 100%;
+            box-sizing: border-box;
+            background: red;
+            color: white;
+            font-family: -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+            font-size: 13px;
+            line-height: 13px;
+        }
+        #nojs-banner a {
+            color: inherit;
+            text-decoration: underline;
+        }
+        ]]>
+        </style>
+    </head>
+    <body>
+        <div id="entry">
+            <div id="main" class="main typography use-theme-bg">
+                <iframe src="https://substack.com/channel-frame" class="channel-frame" width="0" height="0"></iframe>
+                <div data-testid="navbar" class="main-menu animated">
+                    <div class="main-menu-content" style="top: -73px; position: fixed;">
+                        <div class="topbar">
+                            <div class="topbar-content">
+                                <div class="navbar-logo-container" style="width: 183.125px;">
+                                    <a href="https://blog.omnivore.app"><img src="https://substackcdn.com/image/fetch/w_96,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fbucketeer-e05bbc84-baa3-437e-9518-adb32be77984.s3.amazonaws.com%2Fpublic%2Fimages%2F052c15c4-ecfd-4d32-87db-13bcac9afad5_512x512.png" class="navbar-logo" /></a>
+                                </div>
+                                <h1 class="navbar-title">
+                                    <a class="navbar-title-link" href="https://blog.omnivore.app">Omnivore</a>
+                                </h1>
+                                <div class="navbar-buttons">
+                                    <button data-testid="noncontributor-cta-button" class="button primary subscribe-cta subscribe-btn" type="button" tabindex="0">Subscribe</button><button native="true" class="button sign-in-link outline-grayscale" type="button" tabindex="0">Sign in</button>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="topbar-spacer"></div>
+                </div>
+                <div>
+                    <script type="application/ld+json">
+                    <![CDATA[
+                    {"@context":"http://schema.org","@type":"NewsArticle","url":"https://blog.omnivore.app/p/saving-links-from-your-iphone-or","mainEntityOfPage":"https://blog.omnivore.app/p/saving-links-from-your-iphone-or","headline":"Saving Links from Your iPhone or iPad ","description":"With the Omnivore app for iOS, it\u2019s easy to save web pages and articles or archive web content to read later. The Omnivore app uses the iOS Share System, which lets you send items from one app (such as Safari) to another (such as Messages or Mail).","image":[{"@type":"ImageObject","url":"https://substackcdn.com/image/youtube/w_728,c_limit/k6RkIqepAig"}],"datePublished":"2022-10-19T15:42:04+08:00","dateModified":"2022-10-19T15:42:04+08:00","isAccessibleForFree":true,"author":[{"@type":"Person","name":"Omnivore","url":"https://substack.com/profile/49669396-omnivore","description":"Omnivore is the home for everything you read; automatically organized and easy to share","identifier":"user:49669396"}],"publisher":{"@type":"Organization","name":"Omnivore","url":"https://blog.omnivore.app","description":"Updates from the Omnivore team","identifier":"pub:509268","logo":{"@type":"ImageObject","url":"https://bucketeer-e05bbc84-baa3-437e-9518-adb32be77984.s3.amazonaws.com/public/images/052c15c4-ecfd-4d32-87db-13bcac9afad5_512x512.png","contentUrl":"https://substackcdn.com/image/fetch/f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fbucketeer-e05bbc84-baa3-437e-9518-adb32be77984.s3.amazonaws.com%2Fpublic%2Fimages%2F052c15c4-ecfd-4d32-87db-13bcac9afad5_512x512.png","thumbnailUrl":"https://substackcdn.com/image/fetch/w_128,h_128,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fbucketeer-e05bbc84-baa3-437e-9518-adb32be77984.s3.amazonaws.com%2Fpublic%2Fimages%2F052c15c4-ecfd-4d32-87db-13bcac9afad5_512x512.png"},"image":{"@type":"ImageObject","url":"https://bucketeer-e05bbc84-baa3-437e-9518-adb32be77984.s3.amazonaws.com/public/images/052c15c4-ecfd-4d32-87db-13bcac9afad5_512x512.png","contentUrl":"https://substackcdn.com/image/fetch/f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fbucketeer-e05bbc84-baa3-437e-9518-adb32be77984.s3.amazonaws.com%2Fpublic%2Fimages%2F052c15c4-ecfd-4d32-87db-13bcac9afad5_512x512.png","thumbnailUrl":"https://substackcdn.com/image/fetch/w_128,h_128,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fbucketeer-e05bbc84-baa3-437e-9518-adb32be77984.s3.amazonaws.com%2Fpublic%2Fimages%2F052c15c4-ecfd-4d32-87db-13bcac9afad5_512x512.png"}}}
+                    ]]>
+                    </script>
+                    <script type="text/javascript" async="async" src="https://www.google.com/pagead/conversion_async.js"></script>
+                    <script type="text/javascript" async="async" src="https://www.googletagmanager.com/gtag/js?id=AW-316245675&amp;l=localGaDataLayer&amp;cx=c"></script>
+                    <script async="async" src="https://www.googletagmanager.com/gtag/js?id=undefined&amp;l=localGaDataLayer"></script>
+                    <div class="single-post-container">
+                        <div class="container">
+                            <div class="single-post">
+                                <article class="typography newsletter-post post">
+                                    <div role="dialog" class="modal typography out gone share-dialog popup">
+                                        <div class="modal-table">
+                                            <div class="modal-row">
+                                                <div class="modal-cell modal-content no-fullscreen">
+                                                    <div class="container">
+                                                        <button data-testid="close-modal" class="button modal-btn modal-exit-btn no-margin" type="button" tabindex="0"><svg role="img" width="20" height="20" viewbox="0 0 20 20" fill="none" stroke-width="1" stroke="#666666" xmlns="http://www.w3.org/2000/svg">
+                                                        <g>
+                                                            <title></title>
+                                                            <path d="M15 5L5 15" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
+                                                            <path d="M5 5L15 15" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
+                                                        </g></svg></button>
+                                                        <div class="share-dialog-title">
+                                                            Share this post
+                                                        </div>
+                                                        <div class="social-preview-box post">
+                                                            <div class="social-image-box">
+                                                                <picture><source type="image/webp" srcset="https://substackcdn.com/image/youtube/w_728,c_limit/k6RkIqepAig" /><img src="https://substackcdn.com/image/youtube/w_728,c_limit/k6RkIqepAig" sizes="100vw" alt="" srcset="" loading="lazy" class="frontend-components-responsive_img-module__img--1l4UG social-image" /></picture>
+                                                            </div>
+                                                            <div class="social-labels">
+                                                                <div class="social-title">
+                                                                    Saving Links from Your iPhone or iPad
+                                                                </div>
+                                                                <div class="social-subtitle">
+                                                                    blog.omnivore.app
+                                                                </div>
+                                                            </div>
+                                                        </div>
+                                                        <div class="share-action-row">
+                                                            <div class="action-icon">
+                                                                <button class="button share-action" type="button" tabindex="0"><svg role="img" width="20" height="16" viewbox="0 0 20 16" fill="none" stroke-width="1" stroke="#000" xmlns="http://www.w3.org/2000/svg">
+                                                                <g>
+                                                                    <title></title>
+                                                                    <path fill-rule="evenodd" clip-rule="evenodd" d="M12.1303 0.000379039C10.9833 -0.00959082 9.87819 0.431464 9.05309 1.22855L9.04556 1.23593L7.79145 2.48303C7.50587 2.767 7.50453 3.22877 7.78844 3.51441C8.07235 3.80004 8.53401 3.80139 8.81959 3.51741L10.0698 2.27423C10.6194 1.74503 11.3546 1.45229 12.1177 1.45892C12.8824 1.46556 13.6139 1.77236 14.1546 2.31323C14.6954 2.8541 15.0021 3.58577 15.0087 4.35065C15.0154 5.11353 14.7229 5.84857 14.1943 6.39829L12.0116 8.58145L12.0115 8.58155C11.7159 8.87739 11.36 9.10617 10.9682 9.25237C10.5764 9.39857 10.1577 9.45878 9.74051 9.42889C9.32337 9.39901 8.91752 9.27975 8.55051 9.07918C8.1835 8.87862 7.8639 8.60146 7.6134 8.26649C7.3722 7.94396 6.91526 7.87807 6.5928 8.11933C6.27034 8.36059 6.20447 8.81763 6.44567 9.14016C6.82142 9.64261 7.30082 10.0584 7.85134 10.3592C8.40186 10.66 9.01062 10.8389 9.63634 10.8838C10.2621 10.9286 10.8901 10.8383 11.4779 10.619C12.0656 10.3997 12.5994 10.0565 13.0429 9.61274L15.2302 7.42494L15.2391 7.4159C16.036 6.59062 16.4769 5.48529 16.467 4.33797C16.457 3.19066 15.9969 2.09316 15.1858 1.28185C14.3746 0.470545 13.2774 0.0103489 12.1303 0.000379039ZM7.29806 5.11625C6.67234 5.07142 6.0443 5.16173 5.45654 5.38103C4.86882 5.60031 4.33502 5.94355 3.89153 6.38727L1.70423 8.57506L1.69534 8.5841C0.898438 9.40939 0.457483 10.5147 0.467451 11.662C0.477418 12.8094 0.937512 13.9069 1.74864 14.7182C2.55976 15.5295 3.65701 15.9897 4.80407 15.9996C5.95113 16.0096 7.05622 15.5685 7.88132 14.7715L7.89035 14.7626L9.13717 13.5155C9.42192 13.2307 9.42192 12.7689 9.13717 12.4841C8.85243 12.1993 8.39077 12.1993 8.10602 12.4841L6.86392 13.7265C6.31432 14.2552 5.57945 14.5477 4.81675 14.5411C4.05204 14.5344 3.32054 14.2276 2.77979 13.6868C2.23904 13.1459 1.93231 12.4142 1.92566 11.6494C1.91904 10.8865 2.21146 10.1514 2.74011 9.60172L4.92287 7.41846C5.21854 7.12262 5.57437 6.89384 5.96621 6.74763C6.35805 6.60143 6.77674 6.54123 7.19389 6.57111C7.61104 6.601 8.01688 6.72026 8.38389 6.92082C8.75091 7.12138 9.0705 7.39855 9.32101 7.73352C9.56221 8.05605 10.0191 8.12194 10.3416 7.88068C10.6641 7.63942 10.7299 7.18238 10.4887 6.85985C10.113 6.3574 9.63359 5.94165 9.08307 5.64081C8.53255 5.33997 7.92378 5.16107 7.29806 5.11625Z"></path>
+                                                                </g></svg></button>
+                                                            </div>
+                                                            <div class="action-label">
+                                                                <button class="button share-action" type="button" tabindex="0">Copy link</button>
+                                                            </div>
+                                                            <div class="action-icon">
+                                                                <button class="button share-action" type="button" tabindex="0"><svg role="img" width="20" height="16" viewbox="0 0 20 16" fill="none" stroke-width="1" stroke="#000" xmlns="http://www.w3.org/2000/svg">
+                                                                <g>
+                                                                    <title></title>
+                                                                    <path fill-rule="evenodd" clip-rule="evenodd" d="M12.1524 0.286815C12.9848 -0.0318829 13.8948 -0.0864749 14.7592 0.130489C15.462 0.306912 16.107 0.655903 16.6376 1.14249C17.3169 0.89658 17.961 0.560161 18.5523 0.141743C18.7998 -0.0334198 19.1301 -0.0365939 19.381 0.133779C19.6318 0.304152 19.7507 0.612306 19.6791 0.907C19.4028 2.04538 18.8458 3.09393 18.0616 3.95753C18.0757 4.09811 18.083 4.23936 18.0835 4.3808L18.0835 4.38319C18.0835 9.29757 15.7264 12.8962 12.3452 14.7015C8.98147 16.4975 4.67843 16.4794 0.840591 14.3406C0.546545 14.1767 0.403384 13.8324 0.49452 13.5084C0.585656 13.1843 0.887269 12.9652 1.22363 12.9786C2.65157 13.0356 4.0647 12.7377 5.34034 12.12C4.06579 11.3575 3.15922 10.4438 2.53674 9.45782C1.73519 8.18825 1.43205 6.84263 1.37719 5.63204C1.32248 4.42456 1.51372 3.33632 1.71513 2.55507C1.81628 2.16276 1.92118 1.84328 2.00191 1.61926C2.04232 1.50714 2.0768 1.41859 2.10191 1.35643C2.11446 1.32534 2.12469 1.30081 2.13215 1.2832L2.14123 1.26201L2.14412 1.25538L2.14514 1.25307L2.14553 1.25217C2.1457 1.25179 2.14586 1.25144 2.81079 1.54604L2.14586 1.25144C2.25213 1.01158 2.47934 0.847546 2.74046 0.822176C3.00157 0.796805 3.25612 0.914031 3.40657 1.12894C4.15428 2.19698 5.15353 3.06271 6.31515 3.64923C7.26519 4.12892 8.2998 4.40971 9.35623 4.47759V4.41217C9.34536 3.52161 9.60685 2.64886 10.1058 1.91153C10.6058 1.17278 11.3201 0.605503 12.1524 0.286815ZM3.09343 3.03841C2.9284 3.71356 2.78659 4.6028 2.83025 5.5662C2.8764 6.58479 3.12882 7.67102 3.76666 8.68131C4.40153 9.68688 5.44569 10.6611 7.14733 11.4198C7.38821 11.5272 7.55207 11.7566 7.57557 12.0192C7.59906 12.2819 7.47851 12.5367 7.26052 12.6852C6.28428 13.3499 5.20629 13.8343 4.07717 14.1236C6.75502 14.8865 9.46059 14.5928 11.6602 13.4184C14.5413 11.8801 16.6285 8.79158 16.6289 4.38467C16.6283 4.20406 16.611 4.0239 16.5772 3.84652C16.5318 3.60859 16.6079 3.3637 16.7801 3.19336C17.0303 2.94581 17.2553 2.67591 17.4527 2.38779C17.1883 2.49441 16.9189 2.58923 16.6453 2.67187C16.3709 2.75477 16.0733 2.6687 15.8855 2.45208C15.4964 2.00326 14.9795 1.68547 14.4051 1.54127C13.8306 1.39708 13.2258 1.43333 12.6725 1.6452C12.1191 1.85707 11.6436 2.23446 11.3105 2.72674C10.9773 3.21904 10.8028 3.80236 10.8107 4.39779L10.8108 4.40751H10.8108V5.21813C10.8108 5.61242 10.4966 5.9349 10.1024 5.94515C8.56202 5.98522 7.03575 5.6425 5.65956 4.94765C4.69805 4.46217 3.83071 3.81535 3.09343 3.03841Z"></path>
+                                                                </g></svg></button>
+                                                            </div>
+                                                            <div class="action-label">
+                                                                <button class="button share-action" type="button" tabindex="0">Twitter</button>
+                                                            </div>
+                                                            <div class="action-icon">
+                                                                <button class="button share-action" type="button" tabindex="0"><svg role="img" width="16" height="17" viewbox="0 0 16 17" fill="none" stroke-width="1" stroke="#000" xmlns="http://www.w3.org/2000/svg">
+                                                                <g>
+                                                                    <title></title>
+                                                                    <path d="M10.6543 1.38723C10.3533 0.960814 9.95383 0.61341 9.48976 0.374567C9.02902 0.137956 8.51908 0.0130716 8.00115 0.0100098C7.86087 0.0101844 7.72354 0.0502687 7.60519 0.125581C7.48684 0.200893 7.39237 0.308324 7.3328 0.435326L5.00368 5.67077H3.029C2.72335 5.66964 2.42059 5.73003 2.13876 5.84833C1.85692 5.96663 1.60177 6.14043 1.38849 6.35938C1.16707 6.57502 0.991841 6.83346 0.873459 7.11897C0.755078 7.40447 0.696022 7.71108 0.699885 8.02014V13.691C0.699885 14.3087 0.945273 14.9012 1.38207 15.338C1.81886 15.7747 2.41128 16.0201 3.029 16.0201H13.348C13.8951 16.021 14.425 15.8283 14.8438 15.4762C15.2626 15.1241 15.5434 14.6352 15.6366 14.0961L16.6493 8.4252C16.7252 8.09192 16.7252 7.74582 16.6493 7.41254C16.566 7.08205 16.4104 6.7742 16.1936 6.51128C15.9746 6.25 15.7017 6.03926 15.3936 5.89355C15.0762 5.7467 14.7306 5.67068 14.3809 5.67077H10.5328L11.0391 4.37457C11.2397 3.88784 11.3162 3.35894 11.2619 2.83533C11.1853 2.30894 10.9763 1.81065 10.6543 1.38723ZM4.75052 14.5518H3.029C2.91049 14.5525 2.79303 14.5296 2.68349 14.4844C2.57394 14.4392 2.47452 14.3726 2.39102 14.2885C2.23609 14.1199 2.14945 13.8997 2.14799 13.6708V8.02014C2.14913 7.901 2.17389 7.78328 2.22082 7.67377C2.26775 7.56427 2.33592 7.46515 2.4214 7.38216C2.50369 7.29576 2.60267 7.22698 2.71233 7.17998C2.822 7.13298 2.94007 7.10874 3.05938 7.10874H4.7809L4.75052 14.5518ZM10.6746 7.05811H14.3809C14.5145 7.05821 14.6462 7.08942 14.7657 7.14925C14.8875 7.20532 14.9948 7.28845 15.0796 7.39229C15.1675 7.49052 15.2301 7.60871 15.2619 7.73659C15.2922 7.8665 15.2922 8.00162 15.2619 8.13153L14.2493 13.8024C14.2087 14.017 14.094 14.2106 13.9252 14.3492C13.7619 14.4812 13.558 14.5528 13.348 14.5518H6.19862V6.45052L8.43659 1.38723H8.52773C8.9042 1.50037 9.23304 1.73413 9.4636 2.05252C9.69416 2.37092 9.81365 2.75627 9.80368 3.14925C9.8181 3.39741 9.78015 3.64583 9.69229 3.87836L9.23659 5.04292C9.15397 5.273 9.12623 5.51921 9.15558 5.76191C9.1877 6.00427 9.27425 6.23623 9.40875 6.44039C9.5535 6.6376 9.74028 6.80017 9.95558 6.91634C10.1774 7.03206 10.4244 7.0912 10.6746 7.08849V7.05811Z"></path>
+                                                                </g></svg></button>
+                                                            </div>
+                                                            <div class="action-label">
+                                                                <button class="button share-action" type="button" tabindex="0">Facebook</button>
+                                                            </div>
+                                                            <div class="action-icon">
+                                                                <button class="button share-action" type="button" tabindex="0"><svg role="img" width="21" height="16" viewbox="0 0 21 16" fill="none" stroke-width="1" stroke="#000" xmlns="http://www.w3.org/2000/svg">
+                                                                <g>
+                                                                    <title></title>
+                                                                    <path fill-rule="evenodd" clip-rule="evenodd" d="M2.22192 2.20503C2.36754 1.77115 2.78269 1.45455 3.26639 1.45455H17.9332C18.4169 1.45455 18.8321 1.77118 18.9777 2.2051L10.5999 8.02107L2.22192 2.20503ZM2.16639 3.94198V13.4545C2.16639 14.0529 2.66307 14.5455 3.26639 14.5455H17.9332C18.5365 14.5455 19.0332 14.0529 19.0332 13.4545V3.94206L11.0204 9.50462C10.7679 9.67991 10.4318 9.67991 10.1793 9.50462L2.16639 3.94198ZM20.4999 2.55809V13.4545C20.4999 14.8562 19.3465 16 17.9332 16H3.26639C1.85304 16 0.699707 14.8562 0.699707 13.4545V2.54545C0.699707 1.14379 1.85304 0 3.26639 0H17.9332C19.3407 0 20.4904 1.13441 20.4998 2.52818C20.5 2.53816 20.5001 2.54813 20.4999 2.55809Z"></path>
+                                                                </g></svg></button>
+                                                            </div>
+                                                            <div class="action-label">
+                                                                <button class="button share-action" type="button" tabindex="0">Email</button>
+                                                            </div>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="subscribe-dialog" style="bottom: 360px; left: 740px;">
+                                        <div class="pub-icon pub-icon-margin subscribe-dialog-publication-icon">
+                                            <a href="https://blog.omnivore.app" native="true"><picture><source type="image/webp" srcset="https://substackcdn.com/image/fetch/w_108,h_108,c_fill,f_webp,q_auto:good,fl_progressive:steep/https%3A%2F%2Fbucketeer-e05bbc84-baa3-437e-9518-adb32be77984.s3.amazonaws.com%2Fpublic%2Fimages%2F052c15c4-ecfd-4d32-87db-13bcac9afad5_512x512.png" /><img class="frontend-components-responsive_img-module__img--1l4UG custom" src="https://substackcdn.com/image/fetch/w_108,h_108,c_fill,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fbucketeer-e05bbc84-baa3-437e-9518-adb32be77984.s3.amazonaws.com%2Fpublic%2Fimages%2F052c15c4-ecfd-4d32-87db-13bcac9afad5_512x512.png" sizes="100vw" alt="Omnivore" srcset="" width="54" height="54" /></picture></a>
+                                        </div>
+                                        <div class="subscribe-dialog-publication-title subscribe-dialog-header-text">
+                                            Omnivore
+                                        </div>
+                                        <div class="subscribe-dialog-publication-subtitle subscribe-dialog-body-text">
+                                            Updates from the Omnivore team
+                                        </div>
+                                        <form>
+                                            <input class="subscribe-dialog-publication-email-input" placeholder="Type your email..." /><button class="subscribe-dialog-submit-button" type="submit">Subscribe</button>
+                                        </form>
+                                        <div class="subscribe-dialog-let-me-read-it subscribe-dialog-body-text">
+                                            <span>Let me read it first</span><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-chevron-right">
+                                            <polyline points="9 18 15 12 9 6"></polyline></svg>
+                                        </div>
+                                        <div class="subscribe-dialog-body-text">
+                                            <span>Already a subscriber?</span> <span class="subscribe-dialog-sign-in-link"><a href="https://substack.com/sign-in?redirect=https%3A%2F%2Fblog.omnivore.app%2Fp%2Fsaving-links-from-your-iphone-or&amp;for_pub=omnivoreapp">Sign in</a></span>
+                                        </div>
+                                    </div>
+                                    <div class="subscribe-dialog-scroll-modal-scroll-capture" style="opacity: 0.6;"></div>
+                                    <div class="post-header">
+                                        <h1 class="post-title short unpublished">
+                                            Saving Links from Your iPhone or iPad
+                                        </h1>
+                                        <div class="post-subheader meta-subheader">
+                                            <div class="left">
+                                                <div class="label-stack">
+                                                    <div class="bylines">
+                                                        <div class="profile-hover-wrapper">
+                                                            <span class="byline-names"><a class="byline-profile-link" href="https://substack.com/profile/49669396-omnivore">Omnivore</a></span>
+                                                        </div>
+                                                    </div>
+                                                    <div class="publish-context">
+                                                        <time datetime="2022-10-19T07:42:04.670Z">31 min ago</time>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                            <div class="right">
+                                                <div class="post-ufi style-button themed">
+                                                    <a role="button" class="post-ufi-button style-button no-label with-border"><svg role="img" width="20" height="20" viewbox="0 0 24 24" fill="#000000" stroke-width="1.5" stroke="#000" xmlns="http://www.w3.org/2000/svg" class="icon" style="height: 20px; width: 20px;">
+                                                    <g>
+                                                        <title></title><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-heart">
+                                                        <path d="M20.42 4.58a5.4 5.4 0 0 0-7.65 0l-.77.78-.77-.78a5.4 5.4 0 0 0-7.65 0C1.46 6.7 1.33 10.28 4 13l8 8 8-8c2.67-2.72 2.54-6.3.42-8.42z"></path></svg>
+                                                    </g></svg></a><a role="button" class="post-ufi-button style-button post-ufi-comment-button no-label with-border" href="https://blog.omnivore.app/p/saving-links-from-your-iphone-or/comments"><svg role="img" width="20" height="20" viewbox="0 0 24 24" fill="#000000" stroke-width="1.5" stroke="#000" xmlns="http://www.w3.org/2000/svg" class="icon" style="height: 20px; width: 20px;">
+                                                    <g>
+                                                        <title></title><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-message-circle">
+                                                        <path d="M21 11.5a8.38 8.38 0 0 1-.9 3.8 8.5 8.5 0 0 1-7.6 4.7 8.38 8.38 0 0 1-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 0 1-.9-3.8 8.5 8.5 0 0 1 4.7-7.6 8.38 8.38 0 0 1 3.8-.9h.5a8.48 8.48 0 0 1 8 8v.5z"></path></svg>
+                                                    </g></svg></a><a role="button" class="post-ufi-button style-button no-label with-border" href="javascript:void(0)"><svg role="img" width="20" height="20" viewbox="0 0 24 24" fill="#000000" stroke-width="1.5" stroke="#000" xmlns="http://www.w3.org/2000/svg" class="icon" style="height: 20px; width: 20px;">
+                                                    <g>
+                                                        <title></title><svg width="24" height="24" viewbox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                                        <path d="M12.4376 15.6C4.77778 15.6 2 20.3999 2 20.3999C2 12.5999 5.88889 8.4 12.4376 8.4V3L22 11.9812L12.4376 21V15.6Z" stroke-width="1.5" class="lucide" stroke-linecap="round" stroke-linejoin="round"></path></svg>
+                                                    </g></svg></a>
+                                                    <div class="modal typography out gone share-dialog popup" role="dialog">
+                                                        <div class="modal-table">
+                                                            <div class="modal-row">
+                                                                <div class="modal-cell modal-content no-fullscreen">
+                                                                    <div class="container">
+                                                                        <button tabindex="0" data-testid="close-modal" class="button modal-btn modal-exit-btn no-margin" type="button"><svg role="img" width="20" height="20" viewbox="0 0 20 20" fill="none" stroke-width="1" stroke="#666666" xmlns="http://www.w3.org/2000/svg">
+                                                                        <g>
+                                                                            <title></title>
+                                                                            <path d="M15 5L5 15" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
+                                                                            <path d="M5 5L15 15" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
+                                                                        </g></svg></button>
+                                                                        <div class="share-dialog-title">
+                                                                            Share this post
+                                                                        </div>
+                                                                        <div class="social-preview-box post">
+                                                                            <div class="social-image-box">
+                                                                                <picture><source type="image/webp" srcset="https://substackcdn.com/image/youtube/w_728,c_limit/k6RkIqepAig" /><img class="frontend-components-responsive_img-module__img--1l4UG social-image" src="https://substackcdn.com/image/youtube/w_728,c_limit/k6RkIqepAig" sizes="100vw" alt="" srcset="" loading="lazy" /></picture>
+                                                                            </div>
+                                                                            <div class="social-labels">
+                                                                                <div class="social-title">
+                                                                                    Saving Links from Your iPhone or iPad
+                                                                                </div>
+                                                                                <div class="social-subtitle">
+                                                                                    blog.omnivore.app
+                                                                                </div>
+                                                                            </div>
+                                                                        </div>
+                                                                        <div class="share-action-row">
+                                                                            <div class="action-icon">
+                                                                                <button tabindex="0" class="button share-action" type="button"><svg role="img" width="20" height="16" viewbox="0 0 20 16" fill="none" stroke-width="1" stroke="#000" xmlns="http://www.w3.org/2000/svg">
+                                                                                <g>
+                                                                                    <title></title>
+                                                                                    <path fill-rule="evenodd" clip-rule="evenodd" d="M12.1303 0.000379039C10.9833 -0.00959082 9.87819 0.431464 9.05309 1.22855L9.04556 1.23593L7.79145 2.48303C7.50587 2.767 7.50453 3.22877 7.78844 3.51441C8.07235 3.80004 8.53401 3.80139 8.81959 3.51741L10.0698 2.27423C10.6194 1.74503 11.3546 1.45229 12.1177 1.45892C12.8824 1.46556 13.6139 1.77236 14.1546 2.31323C14.6954 2.8541 15.0021 3.58577 15.0087 4.35065C15.0154 5.11353 14.7229 5.84857 14.1943 6.39829L12.0116 8.58145L12.0115 8.58155C11.7159 8.87739 11.36 9.10617 10.9682 9.25237C10.5764 9.39857 10.1577 9.45878 9.74051 9.42889C9.32337 9.39901 8.91752 9.27975 8.55051 9.07918C8.1835 8.87862 7.8639 8.60146 7.6134 8.26649C7.3722 7.94396 6.91526 7.87807 6.5928 8.11933C6.27034 8.36059 6.20447 8.81763 6.44567 9.14016C6.82142 9.64261 7.30082 10.0584 7.85134 10.3592C8.40186 10.66 9.01062 10.8389 9.63634 10.8838C10.2621 10.9286 10.8901 10.8383 11.4779 10.619C12.0656 10.3997 12.5994 10.0565 13.0429 9.61274L15.2302 7.42494L15.2391 7.4159C16.036 6.59062 16.4769 5.48529 16.467 4.33797C16.457 3.19066 15.9969 2.09316 15.1858 1.28185C14.3746 0.470545 13.2774 0.0103489 12.1303 0.000379039ZM7.29806 5.11625C6.67234 5.07142 6.0443 5.16173 5.45654 5.38103C4.86882 5.60031 4.33502 5.94355 3.89153 6.38727L1.70423 8.57506L1.69534 8.5841C0.898438 9.40939 0.457483 10.5147 0.467451 11.662C0.477418 12.8094 0.937512 13.9069 1.74864 14.7182C2.55976 15.5295 3.65701 15.9897 4.80407 15.9996C5.95113 16.0096 7.05622 15.5685 7.88132 14.7715L7.89035 14.7626L9.13717 13.5155C9.42192 13.2307 9.42192 12.7689 9.13717 12.4841C8.85243 12.1993 8.39077 12.1993 8.10602 12.4841L6.86392 13.7265C6.31432 14.2552 5.57945 14.5477 4.81675 14.5411C4.05204 14.5344 3.32054 14.2276 2.77979 13.6868C2.23904 13.1459 1.93231 12.4142 1.92566 11.6494C1.91904 10.8865 2.21146 10.1514 2.74011 9.60172L4.92287 7.41846C5.21854 7.12262 5.57437 6.89384 5.96621 6.74763C6.35805 6.60143 6.77674 6.54123 7.19389 6.57111C7.61104 6.601 8.01688 6.72026 8.38389 6.92082C8.75091 7.12138 9.0705 7.39855 9.32101 7.73352C9.56221 8.05605 10.0191 8.12194 10.3416 7.88068C10.6641 7.63942 10.7299 7.18238 10.4887 6.85985C10.113 6.3574 9.63359 5.94165 9.08307 5.64081C8.53255 5.33997 7.92378 5.16107 7.29806 5.11625Z"></path>
+                                                                                </g></svg></button>
+                                                                            </div>
+                                                                            <div class="action-label">
+                                                                                <button tabindex="0" class="button share-action" type="button">Copy link</button>
+                                                                            </div>
+                                                                            <div class="action-icon">
+                                                                                <button tabindex="0" class="button share-action" type="button"><svg role="img" width="20" height="16" viewbox="0 0 20 16" fill="none" stroke-width="1" stroke="#000" xmlns="http://www.w3.org/2000/svg">
+                                                                                <g>
+                                                                                    <title></title>
+                                                                                    <path fill-rule="evenodd" clip-rule="evenodd" d="M12.1524 0.286815C12.9848 -0.0318829 13.8948 -0.0864749 14.7592 0.130489C15.462 0.306912 16.107 0.655903 16.6376 1.14249C17.3169 0.89658 17.961 0.560161 18.5523 0.141743C18.7998 -0.0334198 19.1301 -0.0365939 19.381 0.133779C19.6318 0.304152 19.7507 0.612306 19.6791 0.907C19.4028 2.04538 18.8458 3.09393 18.0616 3.95753C18.0757 4.09811 18.083 4.23936 18.0835 4.3808L18.0835 4.38319C18.0835 9.29757 15.7264 12.8962 12.3452 14.7015C8.98147 16.4975 4.67843 16.4794 0.840591 14.3406C0.546545 14.1767 0.403384 13.8324 0.49452 13.5084C0.585656 13.1843 0.887269 12.9652 1.22363 12.9786C2.65157 13.0356 4.0647 12.7377 5.34034 12.12C4.06579 11.3575 3.15922 10.4438 2.53674 9.45782C1.73519 8.18825 1.43205 6.84263 1.37719 5.63204C1.32248 4.42456 1.51372 3.33632 1.71513 2.55507C1.81628 2.16276 1.92118 1.84328 2.00191 1.61926C2.04232 1.50714 2.0768 1.41859 2.10191 1.35643C2.11446 1.32534 2.12469 1.30081 2.13215 1.2832L2.14123 1.26201L2.14412 1.25538L2.14514 1.25307L2.14553 1.25217C2.1457 1.25179 2.14586 1.25144 2.81079 1.54604L2.14586 1.25144C2.25213 1.01158 2.47934 0.847546 2.74046 0.822176C3.00157 0.796805 3.25612 0.914031 3.40657 1.12894C4.15428 2.19698 5.15353 3.06271 6.31515 3.64923C7.26519 4.12892 8.2998 4.40971 9.35623 4.47759V4.41217C9.34536 3.52161 9.60685 2.64886 10.1058 1.91153C10.6058 1.17278 11.3201 0.605503 12.1524 0.286815ZM3.09343 3.03841C2.9284 3.71356 2.78659 4.6028 2.83025 5.5662C2.8764 6.58479 3.12882 7.67102 3.76666 8.68131C4.40153 9.68688 5.44569 10.6611 7.14733 11.4198C7.38821 11.5272 7.55207 11.7566 7.57557 12.0192C7.59906 12.2819 7.47851 12.5367 7.26052 12.6852C6.28428 13.3499 5.20629 13.8343 4.07717 14.1236C6.75502 14.8865 9.46059 14.5928 11.6602 13.4184C14.5413 11.8801 16.6285 8.79158 16.6289 4.38467C16.6283 4.20406 16.611 4.0239 16.5772 3.84652C16.5318 3.60859 16.6079 3.3637 16.7801 3.19336C17.0303 2.94581 17.2553 2.67591 17.4527 2.38779C17.1883 2.49441 16.9189 2.58923 16.6453 2.67187C16.3709 2.75477 16.0733 2.6687 15.8855 2.45208C15.4964 2.00326 14.9795 1.68547 14.4051 1.54127C13.8306 1.39708 13.2258 1.43333 12.6725 1.6452C12.1191 1.85707 11.6436 2.23446 11.3105 2.72674C10.9773 3.21904 10.8028 3.80236 10.8107 4.39779L10.8108 4.40751H10.8108V5.21813C10.8108 5.61242 10.4966 5.9349 10.1024 5.94515C8.56202 5.98522 7.03575 5.6425 5.65956 4.94765C4.69805 4.46217 3.83071 3.81535 3.09343 3.03841Z"></path>
+                                                                                </g></svg></button>
+                                                                            </div>
+                                                                            <div class="action-label">
+                                                                                <button tabindex="0" class="button share-action" type="button">Twitter</button>
+                                                                            </div>
+                                                                            <div class="action-icon">
+                                                                                <button tabindex="0" class="button share-action" type="button"><svg role="img" width="16" height="17" viewbox="0 0 16 17" fill="none" stroke-width="1" stroke="#000" xmlns="http://www.w3.org/2000/svg">
+                                                                                <g>
+                                                                                    <title></title>
+                                                                                    <path d="M10.6543 1.38723C10.3533 0.960814 9.95383 0.61341 9.48976 0.374567C9.02902 0.137956 8.51908 0.0130716 8.00115 0.0100098C7.86087 0.0101844 7.72354 0.0502687 7.60519 0.125581C7.48684 0.200893 7.39237 0.308324 7.3328 0.435326L5.00368 5.67077H3.029C2.72335 5.66964 2.42059 5.73003 2.13876 5.84833C1.85692 5.96663 1.60177 6.14043 1.38849 6.35938C1.16707 6.57502 0.991841 6.83346 0.873459 7.11897C0.755078 7.40447 0.696022 7.71108 0.699885 8.02014V13.691C0.699885 14.3087 0.945273 14.9012 1.38207 15.338C1.81886 15.7747 2.41128 16.0201 3.029 16.0201H13.348C13.8951 16.021 14.425 15.8283 14.8438 15.4762C15.2626 15.1241 15.5434 14.6352 15.6366 14.0961L16.6493 8.4252C16.7252 8.09192 16.7252 7.74582 16.6493 7.41254C16.566 7.08205 16.4104 6.7742 16.1936 6.51128C15.9746 6.25 15.7017 6.03926 15.3936 5.89355C15.0762 5.7467 14.7306 5.67068 14.3809 5.67077H10.5328L11.0391 4.37457C11.2397 3.88784 11.3162 3.35894 11.2619 2.83533C11.1853 2.30894 10.9763 1.81065 10.6543 1.38723ZM4.75052 14.5518H3.029C2.91049 14.5525 2.79303 14.5296 2.68349 14.4844C2.57394 14.4392 2.47452 14.3726 2.39102 14.2885C2.23609 14.1199 2.14945 13.8997 2.14799 13.6708V8.02014C2.14913 7.901 2.17389 7.78328 2.22082 7.67377C2.26775 7.56427 2.33592 7.46515 2.4214 7.38216C2.50369 7.29576 2.60267 7.22698 2.71233 7.17998C2.822 7.13298 2.94007 7.10874 3.05938 7.10874H4.7809L4.75052 14.5518ZM10.6746 7.05811H14.3809C14.5145 7.05821 14.6462 7.08942 14.7657 7.14925C14.8875 7.20532 14.9948 7.28845 15.0796 7.39229C15.1675 7.49052 15.2301 7.60871 15.2619 7.73659C15.2922 7.8665 15.2922 8.00162 15.2619 8.13153L14.2493 13.8024C14.2087 14.017 14.094 14.2106 13.9252 14.3492C13.7619 14.4812 13.558 14.5528 13.348 14.5518H6.19862V6.45052L8.43659 1.38723H8.52773C8.9042 1.50037 9.23304 1.73413 9.4636 2.05252C9.69416 2.37092 9.81365 2.75627 9.80368 3.14925C9.8181 3.39741 9.78015 3.64583 9.69229 3.87836L9.23659 5.04292C9.15397 5.273 9.12623 5.51921 9.15558 5.76191C9.1877 6.00427 9.27425 6.23623 9.40875 6.44039C9.5535 6.6376 9.74028 6.80017 9.95558 6.91634C10.1774 7.03206 10.4244 7.0912 10.6746 7.08849V7.05811Z"></path>
+                                                                                </g></svg></button>
+                                                                            </div>
+                                                                            <div class="action-label">
+                                                                                <button tabindex="0" class="button share-action" type="button">Facebook</button>
+                                                                            </div>
+                                                                            <div class="action-icon">
+                                                                                <button tabindex="0" class="button share-action" type="button"><svg role="img" width="21" height="16" viewbox="0 0 21 16" fill="none" stroke-width="1" stroke="#000" xmlns="http://www.w3.org/2000/svg">
+                                                                                <g>
+                                                                                    <title></title>
+                                                                                    <path fill-rule="evenodd" clip-rule="evenodd" d="M2.22192 2.20503C2.36754 1.77115 2.78269 1.45455 3.26639 1.45455H17.9332C18.4169 1.45455 18.8321 1.77118 18.9777 2.2051L10.5999 8.02107L2.22192 2.20503ZM2.16639 3.94198V13.4545C2.16639 14.0529 2.66307 14.5455 3.26639 14.5455H17.9332C18.5365 14.5455 19.0332 14.0529 19.0332 13.4545V3.94206L11.0204 9.50462C10.7679 9.67991 10.4318 9.67991 10.1793 9.50462L2.16639 3.94198ZM20.4999 2.55809V13.4545C20.4999 14.8562 19.3465 16 17.9332 16H3.26639C1.85304 16 0.699707 14.8562 0.699707 13.4545V2.54545C0.699707 1.14379 1.85304 0 3.26639 0H17.9332C19.3407 0 20.4904 1.13441 20.4998 2.52818C20.5 2.53816 20.5001 2.54813 20.4999 2.55809Z"></path>
+                                                                                </g></svg></button>
+                                                                            </div>
+                                                                            <div class="action-label">
+                                                                                <button tabindex="0" class="button share-action" type="button">Email</button>
+                                                                            </div>
+                                                                        </div>
+                                                                    </div>
+                                                                </div>
+                                                            </div>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="visibility-check"></div>
+                                    <div class="">
+                                        <div class="available-content">
+                                            <div class="body markup" dir="auto">
+                                                <p>
+                                                    <span>With the</span> <a href="https://omnivore.app/install/ios" rel="">Omnivore app for iOS</a><span>, it’s easy to save web pages and articles or archive web content to read later.</span>
+                                                </p>
+                                                <p>
+                                                    <span>The Omnivore app uses the</span> <em>iOS Share System</em><span>, which lets you send items from one app (such as Safari) to another (such as Messages or Mail).&#160;</span>
+                                                </p>
+                                                <ul>
+                                                    <li>
+                                                        <p>
+                                                            Step 1: Log in to the Omnivore app.
+                                                        </p>
+                                                    </li>
+                                                    <li>
+                                                        <p>
+                                                            Step 2: Add Omnivore to your Share menu favorites.
+                                                        </p>
+                                                    </li>
+                                                    <li>
+                                                        <p>
+                                                            Step 3: Save links to your Omnivore Library.
+                                                        </p>
+                                                    </li>
+                                                </ul>
+                                                <div id="youtube2-k6RkIqepAig" class="youtube-wrap" data-attrs="{&quot;videoId&quot;:&quot;k6RkIqepAig&quot;,&quot;startTime&quot;:null,&quot;endTime&quot;:null}">
+                                                    <div class="youtube-inner">
+                                                        <iframe src="https://www.youtube-nocookie.com/embed/k6RkIqepAig?rel=0&amp;autoplay=0&amp;showinfo=0&amp;enablejsapi=0" frameborder="0" loading="lazy" gesture="media" allow="autoplay; fullscreen" allowautoplay="true" allowfullscreen="true" width="728" height="409"></iframe>
+                                                    </div>
+                                                </div>
+                                                <h2 class="header-with-anchor-widget">
+                                                    <strong>Step 1: Log in to the Omnivore app.</strong>
+                                                </h2>
+                                                <div id="§step-log-in-to-the-omnivore-app" class="header-anchor-widget">
+                                                    <div class="header-anchor-widget-button-container">
+                                                        <div class="header-anchor-widget-button" href="https://blog.omnivore.app/i/79321629/step-log-in-to-the-omnivore-app">
+                                                            <h2 class="header-with-anchor-widget">
+                                                                <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="header-anchor-widget-icon">
+                                                                <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"></path>
+                                                                <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"></path></svg>
+                                                            </h2>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                                <p>
+                                                    You must be logged in before you can save links via the Share menu. If you don’t already have an Omnivore account, you can sign up for free from the login screen.
+                                                </p>
+                                                <p>
+                                                    <em>Note:</em> <span>If you haven’t installed the iOS app, download it here:</span> <a href="https://omnivore.app/install/ios" rel="">https://omnivore.app/install/ios</a>
+                                                </p>
+                                                <h2 class="header-with-anchor-widget">
+                                                    <strong>Step 2: Add Omnivore to your Share menu favorites.</strong>
+                                                </h2>
+                                                <div id="§step-add-omnivore-to-your-share-menu-favorites" class="header-anchor-widget">
+                                                    <div class="header-anchor-widget-button-container">
+                                                        <div class="header-anchor-widget-button" href="https://blog.omnivore.app/i/79321629/step-add-omnivore-to-your-share-menu-favorites">
+                                                            <h2 class="header-with-anchor-widget">
+                                                                <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="header-anchor-widget-icon">
+                                                                <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"></path>
+                                                                <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"></path></svg>
+                                                            </h2>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                                <p>
+                                                    Start by viewing the Share menu from within any supported iOS app (we’ve used Safari for this example).
+                                                </p>
+                                                <ol>
+                                                    <li>
+                                                        <p>
+                                                            <span>Tap the</span> <strong>Share</strong> <span>icon at the bottom of the screen.</span>
+                                                        </p>
+                                                    </li>
+                                                    <li>
+                                                        <p>
+                                                            <span>Swipe left to the end of the list of app icons and tap</span> <strong>More</strong><span>.</span>
+                                                        </p>
+                                                    </li>
+                                                    <li>
+                                                        <p>
+                                                            <span>Tap</span> <strong>Edit</strong> <span>at the top of the screen.</span>
+                                                        </p>
+                                                    </li>
+                                                    <li>
+                                                        <p>
+                                                            <span>Scroll down until you see the</span> <strong>Omnivore</strong> <span>icon and tap the</span> <strong>+</strong> <span>icon next to it.&#160;</span>
+                                                        </p>
+                                                    </li>
+                                                    <li>
+                                                        <p>
+                                                            <span>Press and hold the three-bar icon and drag Omnivore to one of the top positions under Favorites. Tap</span> <strong>Done</strong> <span>to close the menu.</span>
+                                                        </p>
+                                                    </li>
+                                                    <li>
+                                                        <p>
+                                                            <strong>Omnivore</strong> <span>will appear as one of the first options the next time you use the Share feature (you may need to restart Safari).</span>
+                                                        </p>
+                                                    </li>
+                                                </ol>
+                                                <h2 class="header-with-anchor-widget">
+                                                    <strong>Step 3: Save links to your Omnivore Library</strong>
+                                                </h2>
+                                                <div id="§step-save-links-to-your-omnivore-library" class="header-anchor-widget">
+                                                    <div class="header-anchor-widget-button-container">
+                                                        <div class="header-anchor-widget-button" href="https://blog.omnivore.app/i/79321629/step-save-links-to-your-omnivore-library">
+                                                            <h2 class="header-with-anchor-widget">
+                                                                <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="header-anchor-widget-icon">
+                                                                <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"></path>
+                                                                <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"></path></svg>
+                                                            </h2>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                                <p>
+                                                    <span>Start by navigating to the page or article you wish to save. Please note that Omnivore will save the content that appears on your screen (not just a link), so</span> <em>if the page is behind a paywall and you are logged into the paywalled site, you will save the paid content.</em><span>&#160;</span>
+                                                </p>
+                                                <ol>
+                                                    <li>
+                                                        <p>
+                                                            <span>While viewing the page you’d like to save, tap the</span> <strong>Share</strong> <span>icon.</span>
+                                                        </p>
+                                                    </li>
+                                                    <li>
+                                                        <p>
+                                                            <span>Tap the</span> <strong>Omnivore</strong> <span>icon in the Share menu.</span>
+                                                        </p>
+                                                    </li>
+                                                    <li>
+                                                        <p>
+                                                            <span>Tag the article with one or more labels (optional) and tap</span> <strong>Read Now</strong> <span>or</span> <strong>Read Later</strong><span>.&#160;</span>
+                                                        </p>
+                                                    </li>
+                                                    <li>
+                                                        <p>
+                                                            If you choose Read Later, the link will appear in your Library the next time you open the Omnivore app.
+                                                        </p>
+                                                    </li>
+                                                </ol>
+                                            </div>
+                                        </div>
+                                        <div class="visibility-check"></div>
+                                        <div class="post-end-cta-full">
+                                            <div class="visibility-check"></div>
+                                            <h3>
+                                                Subscribe to <b>Omnivore</b>
+                                            </h3>
+                                            <p class="end-cta-author-subs">
+                                                Launched a year ago
+                                            </p>
+                                            <p class="end-cta-hero-text">
+                                                Updates from the Omnivore team
+                                            </p>
+                                            <div class="subscribe-widget">
+                                                <form class="form" action="/api/v1/free?nojs=true" method="post" novalidate="">
+                                                    <input type="hidden" name="first_url" value="https://blog.omnivore.app/p/saving-links-from-your-iphone-or" /><input type="hidden" name="first_referrer" /><input type="hidden" name="current_url" value="https://blog.omnivore.app/p/saving-links-from-your-iphone-or" /><input type="hidden" name="current_referrer" /><input type="hidden" name="referral_code" /><input type="hidden" name="source" value="post-end-cta" /><input type="hidden" name="referring_pub_id" /><input type="hidden" name="additional_referring_pub_ids" />
+                                                    <div class="sideBySideWrap">
+                                                        <input type="email" name="email" placeholder="Type your email…" /><button tabindex="0" class="button rightButton primary subscribe-btn" type="submit"><b class="button-text">Subscribe</b></button>
+                                                    </div>
+                                                    <div id="error-container"></div>
+                                                    <div class="subtle-help-text below-input"></div>
+                                                </form>
+                                                <div class="frontend-login-typo_handler-EmailTypoHandler-module__animationWrapper--1W2AP"></div>
+                                            </div>
+                                        </div>
+                                        <div class="post-footer use-separators">
+                                            <div class="add-icon">
+                                                <button class="no-likes-cta"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="20" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="plus-icon">
+                                                <line x1="12" y1="5" x2="12" y2="19"></line>
+                                                <line x1="5" y1="12" x2="19" y2="12"></line></svg></button>
+                                            </div>
+                                            <div class="add-label">
+                                                <button class="no-likes-cta">Like this post</button>
+                                            </div>
+                                            <div class="post-ufi style-button themed">
+                                                <a role="button" class="post-ufi-button style-button no-label with-border"><svg role="img" width="20" height="20" viewbox="0 0 24 24" fill="#000000" stroke-width="1.5" stroke="#000" xmlns="http://www.w3.org/2000/svg" class="icon" style="height: 20px; width: 20px;">
+                                                <g>
+                                                    <title></title><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-heart">
+                                                    <path d="M20.42 4.58a5.4 5.4 0 0 0-7.65 0l-.77.78-.77-.78a5.4 5.4 0 0 0-7.65 0C1.46 6.7 1.33 10.28 4 13l8 8 8-8c2.67-2.72 2.54-6.3.42-8.42z"></path></svg>
+                                                </g></svg></a><a role="button" class="post-ufi-button style-button post-ufi-comment-button no-label with-border" href="https://blog.omnivore.app/p/saving-links-from-your-iphone-or/comments"><svg role="img" width="20" height="20" viewbox="0 0 24 24" fill="#000000" stroke-width="1.5" stroke="#000" xmlns="http://www.w3.org/2000/svg" class="icon" style="height: 20px; width: 20px;">
+                                                <g>
+                                                    <title></title><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-message-circle">
+                                                    <path d="M21 11.5a8.38 8.38 0 0 1-.9 3.8 8.5 8.5 0 0 1-7.6 4.7 8.38 8.38 0 0 1-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 0 1-.9-3.8 8.5 8.5 0 0 1 4.7-7.6 8.38 8.38 0 0 1 3.8-.9h.5a8.48 8.48 0 0 1 8 8v.5z"></path></svg>
+                                                </g></svg></a><a role="button" class="post-ufi-button style-button no-label with-border" href="javascript:void(0)"><svg role="img" width="20" height="20" viewbox="0 0 24 24" fill="#000000" stroke-width="1.5" stroke="#000" xmlns="http://www.w3.org/2000/svg" class="icon" style="height: 20px; width: 20px;">
+                                                <g>
+                                                    <title></title><svg width="24" height="24" viewbox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                                    <path d="M12.4376 15.6C4.77778 15.6 2 20.3999 2 20.3999C2 12.5999 5.88889 8.4 12.4376 8.4V3L22 11.9812L12.4376 21V15.6Z" stroke-width="1.5" class="lucide" stroke-linecap="round" stroke-linejoin="round"></path></svg>
+                                                </g></svg></a>
+                                                <div class="modal typography out gone share-dialog popup" role="dialog">
+                                                    <div class="modal-table">
+                                                        <div class="modal-row">
+                                                            <div class="modal-cell modal-content no-fullscreen">
+                                                                <div class="container">
+                                                                    <button tabindex="0" data-testid="close-modal" class="button modal-btn modal-exit-btn no-margin" type="button"><svg role="img" width="20" height="20" viewbox="0 0 20 20" fill="none" stroke-width="1" stroke="#666666" xmlns="http://www.w3.org/2000/svg">
+                                                                    <g>
+                                                                        <title></title>
+                                                                        <path d="M15 5L5 15" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
+                                                                        <path d="M5 5L15 15" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
+                                                                    </g></svg></button>
+                                                                    <div class="share-dialog-title">
+                                                                        Share this post
+                                                                    </div>
+                                                                    <div class="social-preview-box post">
+                                                                        <div class="social-image-box">
+                                                                            <picture><source type="image/webp" srcset="https://substackcdn.com/image/youtube/w_728,c_limit/k6RkIqepAig" /><img class="frontend-components-responsive_img-module__img--1l4UG social-image" src="https://substackcdn.com/image/youtube/w_728,c_limit/k6RkIqepAig" sizes="100vw" alt="" srcset="" loading="lazy" /></picture>
+                                                                        </div>
+                                                                        <div class="social-labels">
+                                                                            <div class="social-title">
+                                                                                Saving Links from Your iPhone or iPad
+                                                                            </div>
+                                                                            <div class="social-subtitle">
+                                                                                blog.omnivore.app
+                                                                            </div>
+                                                                        </div>
+                                                                    </div>
+                                                                    <div class="share-action-row">
+                                                                        <div class="action-icon">
+                                                                            <button tabindex="0" class="button share-action" type="button"><svg role="img" width="20" height="16" viewbox="0 0 20 16" fill="none" stroke-width="1" stroke="#000" xmlns="http://www.w3.org/2000/svg">
+                                                                            <g>
+                                                                                <title></title>
+                                                                                <path fill-rule="evenodd" clip-rule="evenodd" d="M12.1303 0.000379039C10.9833 -0.00959082 9.87819 0.431464 9.05309 1.22855L9.04556 1.23593L7.79145 2.48303C7.50587 2.767 7.50453 3.22877 7.78844 3.51441C8.07235 3.80004 8.53401 3.80139 8.81959 3.51741L10.0698 2.27423C10.6194 1.74503 11.3546 1.45229 12.1177 1.45892C12.8824 1.46556 13.6139 1.77236 14.1546 2.31323C14.6954 2.8541 15.0021 3.58577 15.0087 4.35065C15.0154 5.11353 14.7229 5.84857 14.1943 6.39829L12.0116 8.58145L12.0115 8.58155C11.7159 8.87739 11.36 9.10617 10.9682 9.25237C10.5764 9.39857 10.1577 9.45878 9.74051 9.42889C9.32337 9.39901 8.91752 9.27975 8.55051 9.07918C8.1835 8.87862 7.8639 8.60146 7.6134 8.26649C7.3722 7.94396 6.91526 7.87807 6.5928 8.11933C6.27034 8.36059 6.20447 8.81763 6.44567 9.14016C6.82142 9.64261 7.30082 10.0584 7.85134 10.3592C8.40186 10.66 9.01062 10.8389 9.63634 10.8838C10.2621 10.9286 10.8901 10.8383 11.4779 10.619C12.0656 10.3997 12.5994 10.0565 13.0429 9.61274L15.2302 7.42494L15.2391 7.4159C16.036 6.59062 16.4769 5.48529 16.467 4.33797C16.457 3.19066 15.9969 2.09316 15.1858 1.28185C14.3746 0.470545 13.2774 0.0103489 12.1303 0.000379039ZM7.29806 5.11625C6.67234 5.07142 6.0443 5.16173 5.45654 5.38103C4.86882 5.60031 4.33502 5.94355 3.89153 6.38727L1.70423 8.57506L1.69534 8.5841C0.898438 9.40939 0.457483 10.5147 0.467451 11.662C0.477418 12.8094 0.937512 13.9069 1.74864 14.7182C2.55976 15.5295 3.65701 15.9897 4.80407 15.9996C5.95113 16.0096 7.05622 15.5685 7.88132 14.7715L7.89035 14.7626L9.13717 13.5155C9.42192 13.2307 9.42192 12.7689 9.13717 12.4841C8.85243 12.1993 8.39077 12.1993 8.10602 12.4841L6.86392 13.7265C6.31432 14.2552 5.57945 14.5477 4.81675 14.5411C4.05204 14.5344 3.32054 14.2276 2.77979 13.6868C2.23904 13.1459 1.93231 12.4142 1.92566 11.6494C1.91904 10.8865 2.21146 10.1514 2.74011 9.60172L4.92287 7.41846C5.21854 7.12262 5.57437 6.89384 5.96621 6.74763C6.35805 6.60143 6.77674 6.54123 7.19389 6.57111C7.61104 6.601 8.01688 6.72026 8.38389 6.92082C8.75091 7.12138 9.0705 7.39855 9.32101 7.73352C9.56221 8.05605 10.0191 8.12194 10.3416 7.88068C10.6641 7.63942 10.7299 7.18238 10.4887 6.85985C10.113 6.3574 9.63359 5.94165 9.08307 5.64081C8.53255 5.33997 7.92378 5.16107 7.29806 5.11625Z"></path>
+                                                                            </g></svg></button>
+                                                                        </div>
+                                                                        <div class="action-label">
+                                                                            <button tabindex="0" class="button share-action" type="button">Copy link</button>
+                                                                        </div>
+                                                                        <div class="action-icon">
+                                                                            <button tabindex="0" class="button share-action" type="button"><svg role="img" width="20" height="16" viewbox="0 0 20 16" fill="none" stroke-width="1" stroke="#000" xmlns="http://www.w3.org/2000/svg">
+                                                                            <g>
+                                                                                <title></title>
+                                                                                <path fill-rule="evenodd" clip-rule="evenodd" d="M12.1524 0.286815C12.9848 -0.0318829 13.8948 -0.0864749 14.7592 0.130489C15.462 0.306912 16.107 0.655903 16.6376 1.14249C17.3169 0.89658 17.961 0.560161 18.5523 0.141743C18.7998 -0.0334198 19.1301 -0.0365939 19.381 0.133779C19.6318 0.304152 19.7507 0.612306 19.6791 0.907C19.4028 2.04538 18.8458 3.09393 18.0616 3.95753C18.0757 4.09811 18.083 4.23936 18.0835 4.3808L18.0835 4.38319C18.0835 9.29757 15.7264 12.8962 12.3452 14.7015C8.98147 16.4975 4.67843 16.4794 0.840591 14.3406C0.546545 14.1767 0.403384 13.8324 0.49452 13.5084C0.585656 13.1843 0.887269 12.9652 1.22363 12.9786C2.65157 13.0356 4.0647 12.7377 5.34034 12.12C4.06579 11.3575 3.15922 10.4438 2.53674 9.45782C1.73519 8.18825 1.43205 6.84263 1.37719 5.63204C1.32248 4.42456 1.51372 3.33632 1.71513 2.55507C1.81628 2.16276 1.92118 1.84328 2.00191 1.61926C2.04232 1.50714 2.0768 1.41859 2.10191 1.35643C2.11446 1.32534 2.12469 1.30081 2.13215 1.2832L2.14123 1.26201L2.14412 1.25538L2.14514 1.25307L2.14553 1.25217C2.1457 1.25179 2.14586 1.25144 2.81079 1.54604L2.14586 1.25144C2.25213 1.01158 2.47934 0.847546 2.74046 0.822176C3.00157 0.796805 3.25612 0.914031 3.40657 1.12894C4.15428 2.19698 5.15353 3.06271 6.31515 3.64923C7.26519 4.12892 8.2998 4.40971 9.35623 4.47759V4.41217C9.34536 3.52161 9.60685 2.64886 10.1058 1.91153C10.6058 1.17278 11.3201 0.605503 12.1524 0.286815ZM3.09343 3.03841C2.9284 3.71356 2.78659 4.6028 2.83025 5.5662C2.8764 6.58479 3.12882 7.67102 3.76666 8.68131C4.40153 9.68688 5.44569 10.6611 7.14733 11.4198C7.38821 11.5272 7.55207 11.7566 7.57557 12.0192C7.59906 12.2819 7.47851 12.5367 7.26052 12.6852C6.28428 13.3499 5.20629 13.8343 4.07717 14.1236C6.75502 14.8865 9.46059 14.5928 11.6602 13.4184C14.5413 11.8801 16.6285 8.79158 16.6289 4.38467C16.6283 4.20406 16.611 4.0239 16.5772 3.84652C16.5318 3.60859 16.6079 3.3637 16.7801 3.19336C17.0303 2.94581 17.2553 2.67591 17.4527 2.38779C17.1883 2.49441 16.9189 2.58923 16.6453 2.67187C16.3709 2.75477 16.0733 2.6687 15.8855 2.45208C15.4964 2.00326 14.9795 1.68547 14.4051 1.54127C13.8306 1.39708 13.2258 1.43333 12.6725 1.6452C12.1191 1.85707 11.6436 2.23446 11.3105 2.72674C10.9773 3.21904 10.8028 3.80236 10.8107 4.39779L10.8108 4.40751H10.8108V5.21813C10.8108 5.61242 10.4966 5.9349 10.1024 5.94515C8.56202 5.98522 7.03575 5.6425 5.65956 4.94765C4.69805 4.46217 3.83071 3.81535 3.09343 3.03841Z"></path>
+                                                                            </g></svg></button>
+                                                                        </div>
+                                                                        <div class="action-label">
+                                                                            <button tabindex="0" class="button share-action" type="button">Twitter</button>
+                                                                        </div>
+                                                                        <div class="action-icon">
+                                                                            <button tabindex="0" class="button share-action" type="button"><svg role="img" width="16" height="17" viewbox="0 0 16 17" fill="none" stroke-width="1" stroke="#000" xmlns="http://www.w3.org/2000/svg">
+                                                                            <g>
+                                                                                <title></title>
+                                                                                <path d="M10.6543 1.38723C10.3533 0.960814 9.95383 0.61341 9.48976 0.374567C9.02902 0.137956 8.51908 0.0130716 8.00115 0.0100098C7.86087 0.0101844 7.72354 0.0502687 7.60519 0.125581C7.48684 0.200893 7.39237 0.308324 7.3328 0.435326L5.00368 5.67077H3.029C2.72335 5.66964 2.42059 5.73003 2.13876 5.84833C1.85692 5.96663 1.60177 6.14043 1.38849 6.35938C1.16707 6.57502 0.991841 6.83346 0.873459 7.11897C0.755078 7.40447 0.696022 7.71108 0.699885 8.02014V13.691C0.699885 14.3087 0.945273 14.9012 1.38207 15.338C1.81886 15.7747 2.41128 16.0201 3.029 16.0201H13.348C13.8951 16.021 14.425 15.8283 14.8438 15.4762C15.2626 15.1241 15.5434 14.6352 15.6366 14.0961L16.6493 8.4252C16.7252 8.09192 16.7252 7.74582 16.6493 7.41254C16.566 7.08205 16.4104 6.7742 16.1936 6.51128C15.9746 6.25 15.7017 6.03926 15.3936 5.89355C15.0762 5.7467 14.7306 5.67068 14.3809 5.67077H10.5328L11.0391 4.37457C11.2397 3.88784 11.3162 3.35894 11.2619 2.83533C11.1853 2.30894 10.9763 1.81065 10.6543 1.38723ZM4.75052 14.5518H3.029C2.91049 14.5525 2.79303 14.5296 2.68349 14.4844C2.57394 14.4392 2.47452 14.3726 2.39102 14.2885C2.23609 14.1199 2.14945 13.8997 2.14799 13.6708V8.02014C2.14913 7.901 2.17389 7.78328 2.22082 7.67377C2.26775 7.56427 2.33592 7.46515 2.4214 7.38216C2.50369 7.29576 2.60267 7.22698 2.71233 7.17998C2.822 7.13298 2.94007 7.10874 3.05938 7.10874H4.7809L4.75052 14.5518ZM10.6746 7.05811H14.3809C14.5145 7.05821 14.6462 7.08942 14.7657 7.14925C14.8875 7.20532 14.9948 7.28845 15.0796 7.39229C15.1675 7.49052 15.2301 7.60871 15.2619 7.73659C15.2922 7.8665 15.2922 8.00162 15.2619 8.13153L14.2493 13.8024C14.2087 14.017 14.094 14.2106 13.9252 14.3492C13.7619 14.4812 13.558 14.5528 13.348 14.5518H6.19862V6.45052L8.43659 1.38723H8.52773C8.9042 1.50037 9.23304 1.73413 9.4636 2.05252C9.69416 2.37092 9.81365 2.75627 9.80368 3.14925C9.8181 3.39741 9.78015 3.64583 9.69229 3.87836L9.23659 5.04292C9.15397 5.273 9.12623 5.51921 9.15558 5.76191C9.1877 6.00427 9.27425 6.23623 9.40875 6.44039C9.5535 6.6376 9.74028 6.80017 9.95558 6.91634C10.1774 7.03206 10.4244 7.0912 10.6746 7.08849V7.05811Z"></path>
+                                                                            </g></svg></button>
+                                                                        </div>
+                                                                        <div class="action-label">
+                                                                            <button tabindex="0" class="button share-action" type="button">Facebook</button>
+                                                                        </div>
+                                                                        <div class="action-icon">
+                                                                            <button tabindex="0" class="button share-action" type="button"><svg role="img" width="21" height="16" viewbox="0 0 21 16" fill="none" stroke-width="1" stroke="#000" xmlns="http://www.w3.org/2000/svg">
+                                                                            <g>
+                                                                                <title></title>
+                                                                                <path fill-rule="evenodd" clip-rule="evenodd" d="M2.22192 2.20503C2.36754 1.77115 2.78269 1.45455 3.26639 1.45455H17.9332C18.4169 1.45455 18.8321 1.77118 18.9777 2.2051L10.5999 8.02107L2.22192 2.20503ZM2.16639 3.94198V13.4545C2.16639 14.0529 2.66307 14.5455 3.26639 14.5455H17.9332C18.5365 14.5455 19.0332 14.0529 19.0332 13.4545V3.94206L11.0204 9.50462C10.7679 9.67991 10.4318 9.67991 10.1793 9.50462L2.16639 3.94198ZM20.4999 2.55809V13.4545C20.4999 14.8562 19.3465 16 17.9332 16H3.26639C1.85304 16 0.699707 14.8562 0.699707 13.4545V2.54545C0.699707 1.14379 1.85304 0 3.26639 0H17.9332C19.3407 0 20.4904 1.13441 20.4998 2.52818C20.5 2.53816 20.5001 2.54813 20.4999 2.55809Z"></path>
+                                                                            </g></svg></button>
+                                                                        </div>
+                                                                        <div class="action-label">
+                                                                            <button tabindex="0" class="button share-action" type="button">Email</button>
+                                                                        </div>
+                                                                    </div>
+                                                                </div>
+                                                            </div>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </article>
+                            </div>
+                        </div>
+                        <div class="single-post-section comments-section">
+                            <div class="full-container-border"></div>
+                            <div class="container">
+                                <div class="comments-section-title">
+                                    Comments
+                                </div>
+                                <div class="visibility-check"></div>
+                                <div class="comment-input-wrap">
+                                    <form method="post" class="form comment-input" novalidate="">
+                                        <div class="comment-input-head">
+                                            <div class="user-head">
+                                                <a>
+                                                <div class="profile-img-wrap">
+                                                    <picture><source type="image/webp" srcset="https://substackcdn.com/image/fetch/w_66,h_66,c_fill,f_webp,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack.com%2Fimg%2Favatars%2Flogged-out.png" /><img src="https://substackcdn.com/image/fetch/w_66,h_66,c_fill,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack.com%2Fimg%2Favatars%2Flogged-out.png" sizes="100vw" alt="" srcset="" class="frontend-components-responsive_img-module__img--1l4UG" /></picture>
+                                                </div></a>
+                                            </div>
+                                        </div>
+                                        <div class="comment-input-right">
+                                            <textarea data-gramm="false" data-gramm_editor="false" data-enable-grammarly="false" name="body" placeholder="Write a comment…" style="height: 104px;"></textarea>
+                                            <div id="error-container"></div>
+                                            <div class="comment-button-container"></div>
+                                        </div>
+                                    </form>
+                                    <div role="dialog" class="modal typography out gone popup">
+                                        <div class="modal-table">
+                                            <div class="modal-row">
+                                                <div class="modal-cell modal-content">
+                                                    <div class="container">
+                                                        <button data-testid="close-modal" class="button modal-btn modal-exit-btn no-margin" type="button" tabindex="0"><svg role="img" width="20" height="20" viewbox="0 0 20 20" fill="none" stroke-width="1" stroke="#666666" xmlns="http://www.w3.org/2000/svg">
+                                                        <g>
+                                                            <title></title>
+                                                            <path d="M15 5L5 15" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
+                                                            <path d="M5 5L15 15" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
+                                                        </g></svg></button>
+                                                        <div class="profile-updater-modal">
+                                                            <div class="profile-updater">
+                                                                <h2 class="page-title profile-updater-title">
+                                                                    Create your profile
+                                                                </h2>
+                                                                <div class="profile-photo-wrap">
+                                                                    <img src="https://substackcdn.com/image/fetch/w_144,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack.com%2Fimg%2Favatars%2Flogged-out.png" /><button type="button" class="button" tabindex="0"><input type="file" name="photo" accept="image/*" /></button>
+                                                                    <div class="add-photo-fab">
+                                                                        <div class="add-photo-fab-inner">
+                                                                            <button type="button" class="button" tabindex="0"><svg role="img" style="height: 12px; width: 12px;" width="12" height="12" viewbox="0 0 14 14" fill="#fff" stroke-width="1" stroke="#fff" xmlns="http://www.w3.org/2000/svg">
+                                                                            <g>
+                                                                                <title></title>
+                                                                                <path d="M7 0V7M7 14V7M7 7H14H0"></path>
+                                                                            </g></svg></button>
+                                                                        </div>
+                                                                    </div>
+                                                                </div>
+                                                                <form action="/api/v1/user/profile" method="post" class="form" novalidate="">
+                                                                    <label for="name">Your name</label><input type="text" placeholder="Your name…" name="name" value="" class="profile-name" /><label for="bio">Your bio</label>
+                                                                    <textarea placeholder="Say something about yourself…" name="bio" class="profile-bio"></textarea><input type="email" placeholder="Your email…" name="email" class="profile-email" /><label class="profile-signup-checkbox"><input type="checkbox" name="free_signup" checked="checked" /> Subscribe to the newsletter</label><input type="hidden" name="photo_url" /><input type="hidden" name="user_id" value="" /><input type="hidden" name="needs_photo" value="false" /><input type="hidden" name="token" />
+                                                                    <div id="error-container"></div>
+                                                                    <p class="left hidden">
+                                                                        0 subscriptions will be displayed on your profile (<a>edit</a>)
+                                                                    </p>
+                                                                    <div class="modal-ctas">
+                                                                        <p class="skip hidden">
+                                                                            <a class="small">Skip for now</a>
+                                                                        </p><button class="button primary" type="submit" tabindex="0">Save &amp; Post Comment</button>
+                                                                    </div>
+                                                                </form>
+                                                            </div>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div role="dialog" class="modal typography out gone popup">
+                                        <div class="modal-table">
+                                            <div class="modal-row">
+                                                <div class="modal-cell modal-content">
+                                                    <div class="container">
+                                                        <button data-testid="close-modal" class="button modal-btn modal-exit-btn no-margin" type="button" tabindex="0"><svg role="img" width="20" height="20" viewbox="0 0 20 20" fill="none" stroke-width="1" stroke="#666666" xmlns="http://www.w3.org/2000/svg">
+                                                        <g>
+                                                            <title></title>
+                                                            <path d="M15 5L5 15" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
+                                                            <path d="M5 5L15 15" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
+                                                        </g></svg></button>
+                                                        <div data-testid="paywall" class="paywall modal-paywall">
+                                                            <h2 class="paywall-title">
+                                                                Only paid subscribers can comment on this post
+                                                            </h2>
+                                                            <div class="paywall-login">
+                                                                <a href="https://substack.com/sign-in?redirect=%2Fp%2Fsaving-links-from-your-iphone-or&amp;for_pub=omnivoreapp&amp;change_user=false" native="true">Already a paid subscriber? <b>Sign in</b></a>
+                                                            </div>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div role="dialog" class="modal typography out gone finish-magic-login-modal popup">
+                                        <div class="modal-table">
+                                            <div class="modal-row">
+                                                <div class="modal-cell modal-content">
+                                                    <div class="container">
+                                                        <button data-testid="close-modal" class="button modal-btn modal-exit-btn no-margin" type="button" tabindex="0"><svg role="img" width="20" height="20" viewbox="0 0 20 20" fill="none" stroke-width="1" stroke="#666666" xmlns="http://www.w3.org/2000/svg">
+                                                        <g>
+                                                            <title></title>
+                                                            <path d="M15 5L5 15" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
+                                                            <path d="M5 5L15 15" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
+                                                        </g></svg></button>
+                                                        <h4>
+                                                            Check your email
+                                                        </h4>
+                                                        <p>
+                                                            For your security, we need to re-authenticate you.
+                                                        </p>
+                                                        <p>
+                                                            Click the link we sent to , or <a href="https://substack.com/sign-in?redirect=%2Fp%2Fsaving-links-from-your-iphone-or&amp;for_pub=omnivoreapp&amp;with_password=true" native="true">click here to sign in</a>.
+                                                        </p>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="single-post-section">
+                            <div class="full-container-border"></div>
+                            <div class="container">
+                                <div class="visibility-check"></div>
+                                <div class="portable-archive">
+                                    <div class="portable-archive-tabs">
+                                        <a class="portable-archive-tab top-tab active"><span class="portable-archive-tab-content">Top</span></a><a class="portable-archive-tab new-tab"><span class="portable-archive-tab-content">New</span></a><a href="javascript:void(0)" class="portable-archive-tab search-tab"><svg role="img" width="24" height="24" viewbox="0 0 24 24" fill="none" stroke-width="1" stroke="#000" xmlns="http://www.w3.org/2000/svg">
+                                        <g>
+                                            <title></title>
+                                            <path d="M11 19C15.4183 19 19 15.4183 19 11C19 6.58172 15.4183 3 11 3C6.58172 3 3 6.58172 3 11C3 15.4183 6.58172 19 11 19Z" stroke="#555555" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
+                                            <path d="M21.0004 21.0004L16.6504 16.6504" stroke="#555555" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
+                                        </g></svg></a>
+                                    </div>
+                                    <div class="portable-archive-list">
+                                        <div class="post-preview portable-archive-post has-image">
+                                            <div class="post-preview-image">
+                                                <picture><source type="image/webp" srcset="https://substackcdn.com/image/fetch/w_336,h_255,c_limit,f_webp,q_auto:good,fl_progressive:steep/https%3A%2F%2Fbucketeer-e05bbc84-baa3-437e-9518-adb32be77984.s3.amazonaws.com%2Fpublic%2Fimages%2F658efff4-341a-4720-8cf6-9b2bdbedfaa7_800x668.gif" /><img class="frontend-components-responsive_img-module__img--1l4UG post-preview-inner-image" src="https://substackcdn.com/image/fetch/w_336,h_255,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fbucketeer-e05bbc84-baa3-437e-9518-adb32be77984.s3.amazonaws.com%2Fpublic%2Fimages%2F658efff4-341a-4720-8cf6-9b2bdbedfaa7_800x668.gif" sizes="100vw" alt="" srcset="" loading="lazy" /></picture>
+                                            </div>
+                                            <div class="post-preview-content">
+                                                <a href="https://blog.omnivore.app/p/getting-started-with-omnivore" class="post-preview-title newsletter">Getting Started with Omnivore</a><a href="https://blog.omnivore.app/p/getting-started-with-omnivore" class="post-preview-description">Learn the best ways to save links with Omnivore</a>
+                                                <div class="post-ufi style-compressed themed">
+                                                    <div class="ufi-preamble themed">
+                                                        <div class="ufi-preamble-label author">
+                                                            <div class="profile-hover-wrapper">
+                                                                <a href="https://substack.com/profile/49669396-omnivore">Omnivore</a>
+                                                            </div>
+                                                        </div>
+                                                        <div class="ufi-preamble-label post-date" title="2021-10-13T19:39:10.254Z">
+                                                            <time datetime="2021-10-13T19:39:10.254Z">Oct 14, 2021</time>
+                                                        </div>
+                                                    </div><a role="button" class="post-ufi-button style-compressed has-label with-border"><svg role="img" width="16" height="16" viewbox="0 0 24 24" fill="#000000" stroke-width="1.5" stroke="#000" xmlns="http://www.w3.org/2000/svg" class="icon" style="height: 16px; width: 16px;">
+                                                    <g>
+                                                        <title></title><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-heart">
+                                                        <path d="M20.42 4.58a5.4 5.4 0 0 0-7.65 0l-.77.78-.77-.78a5.4 5.4 0 0 0-7.65 0C1.46 6.7 1.33 10.28 4 13l8 8 8-8c2.67-2.72 2.54-6.3.42-8.42z"></path></svg>
+                                                    </g></svg>
+                                                    <div class="label">
+                                                        2
+                                                    </div></a><a role="button" class="post-ufi-button style-compressed no-label with-border" href="javascript:void(0)"><svg role="img" width="16" height="16" viewbox="0 0 24 24" fill="#000000" stroke-width="1.5" stroke="#000" xmlns="http://www.w3.org/2000/svg" class="icon" style="height: 16px; width: 16px;">
+                                                    <g>
+                                                        <title></title><svg width="24" height="24" viewbox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                                        <path d="M12.4376 15.6C4.77778 15.6 2 20.3999 2 20.3999C2 12.5999 5.88889 8.4 12.4376 8.4V3L22 11.9812L12.4376 21V15.6Z" stroke-width="1.5" class="lucide" stroke-linecap="round" stroke-linejoin="round"></path></svg>
+                                                    </g></svg></a>
+                                                    <div class="modal typography out gone share-dialog popup" role="dialog">
+                                                        <div class="modal-table">
+                                                            <div class="modal-row">
+                                                                <div class="modal-cell modal-content no-fullscreen">
+                                                                    <div class="container">
+                                                                        <button tabindex="0" data-testid="close-modal" class="button modal-btn modal-exit-btn no-margin" type="button"><svg role="img" width="20" height="20" viewbox="0 0 20 20" fill="none" stroke-width="1" stroke="#666666" xmlns="http://www.w3.org/2000/svg">
+                                                                        <g>
+                                                                            <title></title>
+                                                                            <path d="M15 5L5 15" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
+                                                                            <path d="M5 5L15 15" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
+                                                                        </g></svg></button>
+                                                                        <div class="share-dialog-title">
+                                                                            Share this post
+                                                                        </div>
+                                                                        <div class="social-preview-box post">
+                                                                            <div class="social-image-box">
+                                                                                <picture><source type="image/webp" srcset="https://substackcdn.com/image/fetch/w_120,c_limit,f_webp,q_auto:good,fl_progressive:steep/https%3A%2F%2Fbucketeer-e05bbc84-baa3-437e-9518-adb32be77984.s3.amazonaws.com%2Fpublic%2Fimages%2F658efff4-341a-4720-8cf6-9b2bdbedfaa7_800x668.gif" /><img class="frontend-components-responsive_img-module__img--1l4UG social-image" src="https://substackcdn.com/image/fetch/w_120,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fbucketeer-e05bbc84-baa3-437e-9518-adb32be77984.s3.amazonaws.com%2Fpublic%2Fimages%2F658efff4-341a-4720-8cf6-9b2bdbedfaa7_800x668.gif" sizes="100vw" alt="" srcset="" loading="lazy" /></picture>
+                                                                            </div>
+                                                                            <div class="social-labels">
+                                                                                <div class="social-title">
+                                                                                    Getting Started with Omnivore
+                                                                                </div>
+                                                                                <div class="social-subtitle">
+                                                                                    blog.omnivore.app
+                                                                                </div>
+                                                                            </div>
+                                                                        </div>
+                                                                        <div class="share-action-row">
+                                                                            <div class="action-icon">
+                                                                                <button tabindex="0" class="button share-action" type="button"><svg role="img" width="20" height="16" viewbox="0 0 20 16" fill="none" stroke-width="1" stroke="#000" xmlns="http://www.w3.org/2000/svg">
+                                                                                <g>
+                                                                                    <title></title>
+                                                                                    <path fill-rule="evenodd" clip-rule="evenodd" d="M12.1303 0.000379039C10.9833 -0.00959082 9.87819 0.431464 9.05309 1.22855L9.04556 1.23593L7.79145 2.48303C7.50587 2.767 7.50453 3.22877 7.78844 3.51441C8.07235 3.80004 8.53401 3.80139 8.81959 3.51741L10.0698 2.27423C10.6194 1.74503 11.3546 1.45229 12.1177 1.45892C12.8824 1.46556 13.6139 1.77236 14.1546 2.31323C14.6954 2.8541 15.0021 3.58577 15.0087 4.35065C15.0154 5.11353 14.7229 5.84857 14.1943 6.39829L12.0116 8.58145L12.0115 8.58155C11.7159 8.87739 11.36 9.10617 10.9682 9.25237C10.5764 9.39857 10.1577 9.45878 9.74051 9.42889C9.32337 9.39901 8.91752 9.27975 8.55051 9.07918C8.1835 8.87862 7.8639 8.60146 7.6134 8.26649C7.3722 7.94396 6.91526 7.87807 6.5928 8.11933C6.27034 8.36059 6.20447 8.81763 6.44567 9.14016C6.82142 9.64261 7.30082 10.0584 7.85134 10.3592C8.40186 10.66 9.01062 10.8389 9.63634 10.8838C10.2621 10.9286 10.8901 10.8383 11.4779 10.619C12.0656 10.3997 12.5994 10.0565 13.0429 9.61274L15.2302 7.42494L15.2391 7.4159C16.036 6.59062 16.4769 5.48529 16.467 4.33797C16.457 3.19066 15.9969 2.09316 15.1858 1.28185C14.3746 0.470545 13.2774 0.0103489 12.1303 0.000379039ZM7.29806 5.11625C6.67234 5.07142 6.0443 5.16173 5.45654 5.38103C4.86882 5.60031 4.33502 5.94355 3.89153 6.38727L1.70423 8.57506L1.69534 8.5841C0.898438 9.40939 0.457483 10.5147 0.467451 11.662C0.477418 12.8094 0.937512 13.9069 1.74864 14.7182C2.55976 15.5295 3.65701 15.9897 4.80407 15.9996C5.95113 16.0096 7.05622 15.5685 7.88132 14.7715L7.89035 14.7626L9.13717 13.5155C9.42192 13.2307 9.42192 12.7689 9.13717 12.4841C8.85243 12.1993 8.39077 12.1993 8.10602 12.4841L6.86392 13.7265C6.31432 14.2552 5.57945 14.5477 4.81675 14.5411C4.05204 14.5344 3.32054 14.2276 2.77979 13.6868C2.23904 13.1459 1.93231 12.4142 1.92566 11.6494C1.91904 10.8865 2.21146 10.1514 2.74011 9.60172L4.92287 7.41846C5.21854 7.12262 5.57437 6.89384 5.96621 6.74763C6.35805 6.60143 6.77674 6.54123 7.19389 6.57111C7.61104 6.601 8.01688 6.72026 8.38389 6.92082C8.75091 7.12138 9.0705 7.39855 9.32101 7.73352C9.56221 8.05605 10.0191 8.12194 10.3416 7.88068C10.6641 7.63942 10.7299 7.18238 10.4887 6.85985C10.113 6.3574 9.63359 5.94165 9.08307 5.64081C8.53255 5.33997 7.92378 5.16107 7.29806 5.11625Z"></path>
+                                                                                </g></svg></button>
+                                                                            </div>
+                                                                            <div class="action-label">
+                                                                                <button tabindex="0" class="button share-action" type="button">Copy link</button>
+                                                                            </div>
+                                                                            <div class="action-icon">
+                                                                                <button tabindex="0" class="button share-action" type="button"><svg role="img" width="20" height="16" viewbox="0 0 20 16" fill="none" stroke-width="1" stroke="#000" xmlns="http://www.w3.org/2000/svg">
+                                                                                <g>
+                                                                                    <title></title>
+                                                                                    <path fill-rule="evenodd" clip-rule="evenodd" d="M12.1524 0.286815C12.9848 -0.0318829 13.8948 -0.0864749 14.7592 0.130489C15.462 0.306912 16.107 0.655903 16.6376 1.14249C17.3169 0.89658 17.961 0.560161 18.5523 0.141743C18.7998 -0.0334198 19.1301 -0.0365939 19.381 0.133779C19.6318 0.304152 19.7507 0.612306 19.6791 0.907C19.4028 2.04538 18.8458 3.09393 18.0616 3.95753C18.0757 4.09811 18.083 4.23936 18.0835 4.3808L18.0835 4.38319C18.0835 9.29757 15.7264 12.8962 12.3452 14.7015C8.98147 16.4975 4.67843 16.4794 0.840591 14.3406C0.546545 14.1767 0.403384 13.8324 0.49452 13.5084C0.585656 13.1843 0.887269 12.9652 1.22363 12.9786C2.65157 13.0356 4.0647 12.7377 5.34034 12.12C4.06579 11.3575 3.15922 10.4438 2.53674 9.45782C1.73519 8.18825 1.43205 6.84263 1.37719 5.63204C1.32248 4.42456 1.51372 3.33632 1.71513 2.55507C1.81628 2.16276 1.92118 1.84328 2.00191 1.61926C2.04232 1.50714 2.0768 1.41859 2.10191 1.35643C2.11446 1.32534 2.12469 1.30081 2.13215 1.2832L2.14123 1.26201L2.14412 1.25538L2.14514 1.25307L2.14553 1.25217C2.1457 1.25179 2.14586 1.25144 2.81079 1.54604L2.14586 1.25144C2.25213 1.01158 2.47934 0.847546 2.74046 0.822176C3.00157 0.796805 3.25612 0.914031 3.40657 1.12894C4.15428 2.19698 5.15353 3.06271 6.31515 3.64923C7.26519 4.12892 8.2998 4.40971 9.35623 4.47759V4.41217C9.34536 3.52161 9.60685 2.64886 10.1058 1.91153C10.6058 1.17278 11.3201 0.605503 12.1524 0.286815ZM3.09343 3.03841C2.9284 3.71356 2.78659 4.6028 2.83025 5.5662C2.8764 6.58479 3.12882 7.67102 3.76666 8.68131C4.40153 9.68688 5.44569 10.6611 7.14733 11.4198C7.38821 11.5272 7.55207 11.7566 7.57557 12.0192C7.59906 12.2819 7.47851 12.5367 7.26052 12.6852C6.28428 13.3499 5.20629 13.8343 4.07717 14.1236C6.75502 14.8865 9.46059 14.5928 11.6602 13.4184C14.5413 11.8801 16.6285 8.79158 16.6289 4.38467C16.6283 4.20406 16.611 4.0239 16.5772 3.84652C16.5318 3.60859 16.6079 3.3637 16.7801 3.19336C17.0303 2.94581 17.2553 2.67591 17.4527 2.38779C17.1883 2.49441 16.9189 2.58923 16.6453 2.67187C16.3709 2.75477 16.0733 2.6687 15.8855 2.45208C15.4964 2.00326 14.9795 1.68547 14.4051 1.54127C13.8306 1.39708 13.2258 1.43333 12.6725 1.6452C12.1191 1.85707 11.6436 2.23446 11.3105 2.72674C10.9773 3.21904 10.8028 3.80236 10.8107 4.39779L10.8108 4.40751H10.8108V5.21813C10.8108 5.61242 10.4966 5.9349 10.1024 5.94515C8.56202 5.98522 7.03575 5.6425 5.65956 4.94765C4.69805 4.46217 3.83071 3.81535 3.09343 3.03841Z"></path>
+                                                                                </g></svg></button>
+                                                                            </div>
+                                                                            <div class="action-label">
+                                                                                <button tabindex="0" class="button share-action" type="button">Twitter</button>
+                                                                            </div>
+                                                                            <div class="action-icon">
+                                                                                <button tabindex="0" class="button share-action" type="button"><svg role="img" width="16" height="17" viewbox="0 0 16 17" fill="none" stroke-width="1" stroke="#000" xmlns="http://www.w3.org/2000/svg">
+                                                                                <g>
+                                                                                    <title></title>
+                                                                                    <path d="M10.6543 1.38723C10.3533 0.960814 9.95383 0.61341 9.48976 0.374567C9.02902 0.137956 8.51908 0.0130716 8.00115 0.0100098C7.86087 0.0101844 7.72354 0.0502687 7.60519 0.125581C7.48684 0.200893 7.39237 0.308324 7.3328 0.435326L5.00368 5.67077H3.029C2.72335 5.66964 2.42059 5.73003 2.13876 5.84833C1.85692 5.96663 1.60177 6.14043 1.38849 6.35938C1.16707 6.57502 0.991841 6.83346 0.873459 7.11897C0.755078 7.40447 0.696022 7.71108 0.699885 8.02014V13.691C0.699885 14.3087 0.945273 14.9012 1.38207 15.338C1.81886 15.7747 2.41128 16.0201 3.029 16.0201H13.348C13.8951 16.021 14.425 15.8283 14.8438 15.4762C15.2626 15.1241 15.5434 14.6352 15.6366 14.0961L16.6493 8.4252C16.7252 8.09192 16.7252 7.74582 16.6493 7.41254C16.566 7.08205 16.4104 6.7742 16.1936 6.51128C15.9746 6.25 15.7017 6.03926 15.3936 5.89355C15.0762 5.7467 14.7306 5.67068 14.3809 5.67077H10.5328L11.0391 4.37457C11.2397 3.88784 11.3162 3.35894 11.2619 2.83533C11.1853 2.30894 10.9763 1.81065 10.6543 1.38723ZM4.75052 14.5518H3.029C2.91049 14.5525 2.79303 14.5296 2.68349 14.4844C2.57394 14.4392 2.47452 14.3726 2.39102 14.2885C2.23609 14.1199 2.14945 13.8997 2.14799 13.6708V8.02014C2.14913 7.901 2.17389 7.78328 2.22082 7.67377C2.26775 7.56427 2.33592 7.46515 2.4214 7.38216C2.50369 7.29576 2.60267 7.22698 2.71233 7.17998C2.822 7.13298 2.94007 7.10874 3.05938 7.10874H4.7809L4.75052 14.5518ZM10.6746 7.05811H14.3809C14.5145 7.05821 14.6462 7.08942 14.7657 7.14925C14.8875 7.20532 14.9948 7.28845 15.0796 7.39229C15.1675 7.49052 15.2301 7.60871 15.2619 7.73659C15.2922 7.8665 15.2922 8.00162 15.2619 8.13153L14.2493 13.8024C14.2087 14.017 14.094 14.2106 13.9252 14.3492C13.7619 14.4812 13.558 14.5528 13.348 14.5518H6.19862V6.45052L8.43659 1.38723H8.52773C8.9042 1.50037 9.23304 1.73413 9.4636 2.05252C9.69416 2.37092 9.81365 2.75627 9.80368 3.14925C9.8181 3.39741 9.78015 3.64583 9.69229 3.87836L9.23659 5.04292C9.15397 5.273 9.12623 5.51921 9.15558 5.76191C9.1877 6.00427 9.27425 6.23623 9.40875 6.44039C9.5535 6.6376 9.74028 6.80017 9.95558 6.91634C10.1774 7.03206 10.4244 7.0912 10.6746 7.08849V7.05811Z"></path>
+                                                                                </g></svg></button>
+                                                                            </div>
+                                                                            <div class="action-label">
+                                                                                <button tabindex="0" class="button share-action" type="button">Facebook</button>
+                                                                            </div>
+                                                                            <div class="action-icon">
+                                                                                <button tabindex="0" class="button share-action" type="button"><svg role="img" width="21" height="16" viewbox="0 0 21 16" fill="none" stroke-width="1" stroke="#000" xmlns="http://www.w3.org/2000/svg">
+                                                                                <g>
+                                                                                    <title></title>
+                                                                                    <path fill-rule="evenodd" clip-rule="evenodd" d="M2.22192 2.20503C2.36754 1.77115 2.78269 1.45455 3.26639 1.45455H17.9332C18.4169 1.45455 18.8321 1.77118 18.9777 2.2051L10.5999 8.02107L2.22192 2.20503ZM2.16639 3.94198V13.4545C2.16639 14.0529 2.66307 14.5455 3.26639 14.5455H17.9332C18.5365 14.5455 19.0332 14.0529 19.0332 13.4545V3.94206L11.0204 9.50462C10.7679 9.67991 10.4318 9.67991 10.1793 9.50462L2.16639 3.94198ZM20.4999 2.55809V13.4545C20.4999 14.8562 19.3465 16 17.9332 16H3.26639C1.85304 16 0.699707 14.8562 0.699707 13.4545V2.54545C0.699707 1.14379 1.85304 0 3.26639 0H17.9332C19.3407 0 20.4904 1.13441 20.4998 2.52818C20.5 2.53816 20.5001 2.54813 20.4999 2.55809Z"></path>
+                                                                                </g></svg></button>
+                                                                            </div>
+                                                                            <div class="action-label">
+                                                                                <button tabindex="0" class="button share-action" type="button">Email</button>
+                                                                            </div>
+                                                                        </div>
+                                                                    </div>
+                                                                </div>
+                                                            </div>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                        <div class="post-preview portable-archive-post has-image">
+                                            <div class="post-preview-image">
+                                                <picture><source type="image/webp" srcset="https://substackcdn.com/image/fetch/w_336,h_255,c_fill,f_webp,q_auto:good,fl_progressive:steep,g_auto/https%3A%2F%2Fbucketeer-e05bbc84-baa3-437e-9518-adb32be77984.s3.amazonaws.com%2Fpublic%2Fimages%2F2ab1f7e8-2ca7-4011-8ccb-43d0b3bd244f_1490x2020.png" /><img class="frontend-components-responsive_img-module__img--1l4UG post-preview-inner-image" src="https://substackcdn.com/image/fetch/w_336,h_255,c_fill,f_auto,q_auto:good,fl_progressive:steep,g_auto/https%3A%2F%2Fbucketeer-e05bbc84-baa3-437e-9518-adb32be77984.s3.amazonaws.com%2Fpublic%2Fimages%2F2ab1f7e8-2ca7-4011-8ccb-43d0b3bd244f_1490x2020.png" sizes="100vw" alt="" srcset="" loading="lazy" /></picture>
+                                            </div>
+                                            <div class="post-preview-content">
+                                                <a href="https://blog.omnivore.app/p/code-block-syntax-highlighting" class="post-preview-title newsletter">Code Block Syntax Highlighting</a><a href="https://blog.omnivore.app/p/code-block-syntax-highlighting" class="post-preview-description">Highlighted &lt;code&gt; in Omnivore</a>
+                                                <div class="post-ufi style-compressed themed">
+                                                    <div class="ufi-preamble themed">
+                                                        <div class="ufi-preamble-label author">
+                                                            <div class="profile-hover-wrapper">
+                                                                <a href="https://substack.com/profile/49669396-omnivore">Omnivore</a>
+                                                            </div>
+                                                        </div>
+                                                        <div class="ufi-preamble-label post-date" title="2022-02-28T19:40:04.793Z">
+                                                            <time datetime="2022-02-28T19:40:04.793Z">Mar 1</time>
+                                                        </div>
+                                                    </div><a role="button" class="post-ufi-button style-compressed has-label with-border"><svg role="img" width="16" height="16" viewbox="0 0 24 24" fill="#000000" stroke-width="1.5" stroke="#000" xmlns="http://www.w3.org/2000/svg" class="icon" style="height: 16px; width: 16px;">
+                                                    <g>
+                                                        <title></title><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-heart">
+                                                        <path d="M20.42 4.58a5.4 5.4 0 0 0-7.65 0l-.77.78-.77-.78a5.4 5.4 0 0 0-7.65 0C1.46 6.7 1.33 10.28 4 13l8 8 8-8c2.67-2.72 2.54-6.3.42-8.42z"></path></svg>
+                                                    </g></svg>
+                                                    <div class="label">
+                                                        1
+                                                    </div></a><a role="button" class="post-ufi-button style-compressed no-label with-border" href="javascript:void(0)"><svg role="img" width="16" height="16" viewbox="0 0 24 24" fill="#000000" stroke-width="1.5" stroke="#000" xmlns="http://www.w3.org/2000/svg" class="icon" style="height: 16px; width: 16px;">
+                                                    <g>
+                                                        <title></title><svg width="24" height="24" viewbox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                                        <path d="M12.4376 15.6C4.77778 15.6 2 20.3999 2 20.3999C2 12.5999 5.88889 8.4 12.4376 8.4V3L22 11.9812L12.4376 21V15.6Z" stroke-width="1.5" class="lucide" stroke-linecap="round" stroke-linejoin="round"></path></svg>
+                                                    </g></svg></a>
+                                                    <div class="modal typography out gone share-dialog popup" role="dialog">
+                                                        <div class="modal-table">
+                                                            <div class="modal-row">
+                                                                <div class="modal-cell modal-content no-fullscreen">
+                                                                    <div class="container">
+                                                                        <button tabindex="0" data-testid="close-modal" class="button modal-btn modal-exit-btn no-margin" type="button"><svg role="img" width="20" height="20" viewbox="0 0 20 20" fill="none" stroke-width="1" stroke="#666666" xmlns="http://www.w3.org/2000/svg">
+                                                                        <g>
+                                                                            <title></title>
+                                                                            <path d="M15 5L5 15" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
+                                                                            <path d="M5 5L15 15" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
+                                                                        </g></svg></button>
+                                                                        <div class="share-dialog-title">
+                                                                            Share this post
+                                                                        </div>
+                                                                        <div class="social-preview-box post">
+                                                                            <div class="social-image-box">
+                                                                                <picture><source type="image/webp" srcset="https://substackcdn.com/image/fetch/w_120,c_limit,f_webp,q_auto:good,fl_progressive:steep/https%3A%2F%2Fbucketeer-e05bbc84-baa3-437e-9518-adb32be77984.s3.amazonaws.com%2Fpublic%2Fimages%2F2ab1f7e8-2ca7-4011-8ccb-43d0b3bd244f_1490x2020.png" /><img class="frontend-components-responsive_img-module__img--1l4UG social-image" src="https://substackcdn.com/image/fetch/w_120,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fbucketeer-e05bbc84-baa3-437e-9518-adb32be77984.s3.amazonaws.com%2Fpublic%2Fimages%2F2ab1f7e8-2ca7-4011-8ccb-43d0b3bd244f_1490x2020.png" sizes="100vw" alt="" srcset="" loading="lazy" /></picture>
+                                                                            </div>
+                                                                            <div class="social-labels">
+                                                                                <div class="social-title">
+                                                                                    Code Block Syntax Highlighting
+                                                                                </div>
+                                                                                <div class="social-subtitle">
+                                                                                    blog.omnivore.app
+                                                                                </div>
+                                                                            </div>
+                                                                        </div>
+                                                                        <div class="share-action-row">
+                                                                            <div class="action-icon">
+                                                                                <button tabindex="0" class="button share-action" type="button"><svg role="img" width="20" height="16" viewbox="0 0 20 16" fill="none" stroke-width="1" stroke="#000" xmlns="http://www.w3.org/2000/svg">
+                                                                                <g>
+                                                                                    <title></title>
+                                                                                    <path fill-rule="evenodd" clip-rule="evenodd" d="M12.1303 0.000379039C10.9833 -0.00959082 9.87819 0.431464 9.05309 1.22855L9.04556 1.23593L7.79145 2.48303C7.50587 2.767 7.50453 3.22877 7.78844 3.51441C8.07235 3.80004 8.53401 3.80139 8.81959 3.51741L10.0698 2.27423C10.6194 1.74503 11.3546 1.45229 12.1177 1.45892C12.8824 1.46556 13.6139 1.77236 14.1546 2.31323C14.6954 2.8541 15.0021 3.58577 15.0087 4.35065C15.0154 5.11353 14.7229 5.84857 14.1943 6.39829L12.0116 8.58145L12.0115 8.58155C11.7159 8.87739 11.36 9.10617 10.9682 9.25237C10.5764 9.39857 10.1577 9.45878 9.74051 9.42889C9.32337 9.39901 8.91752 9.27975 8.55051 9.07918C8.1835 8.87862 7.8639 8.60146 7.6134 8.26649C7.3722 7.94396 6.91526 7.87807 6.5928 8.11933C6.27034 8.36059 6.20447 8.81763 6.44567 9.14016C6.82142 9.64261 7.30082 10.0584 7.85134 10.3592C8.40186 10.66 9.01062 10.8389 9.63634 10.8838C10.2621 10.9286 10.8901 10.8383 11.4779 10.619C12.0656 10.3997 12.5994 10.0565 13.0429 9.61274L15.2302 7.42494L15.2391 7.4159C16.036 6.59062 16.4769 5.48529 16.467 4.33797C16.457 3.19066 15.9969 2.09316 15.1858 1.28185C14.3746 0.470545 13.2774 0.0103489 12.1303 0.000379039ZM7.29806 5.11625C6.67234 5.07142 6.0443 5.16173 5.45654 5.38103C4.86882 5.60031 4.33502 5.94355 3.89153 6.38727L1.70423 8.57506L1.69534 8.5841C0.898438 9.40939 0.457483 10.5147 0.467451 11.662C0.477418 12.8094 0.937512 13.9069 1.74864 14.7182C2.55976 15.5295 3.65701 15.9897 4.80407 15.9996C5.95113 16.0096 7.05622 15.5685 7.88132 14.7715L7.89035 14.7626L9.13717 13.5155C9.42192 13.2307 9.42192 12.7689 9.13717 12.4841C8.85243 12.1993 8.39077 12.1993 8.10602 12.4841L6.86392 13.7265C6.31432 14.2552 5.57945 14.5477 4.81675 14.5411C4.05204 14.5344 3.32054 14.2276 2.77979 13.6868C2.23904 13.1459 1.93231 12.4142 1.92566 11.6494C1.91904 10.8865 2.21146 10.1514 2.74011 9.60172L4.92287 7.41846C5.21854 7.12262 5.57437 6.89384 5.96621 6.74763C6.35805 6.60143 6.77674 6.54123 7.19389 6.57111C7.61104 6.601 8.01688 6.72026 8.38389 6.92082C8.75091 7.12138 9.0705 7.39855 9.32101 7.73352C9.56221 8.05605 10.0191 8.12194 10.3416 7.88068C10.6641 7.63942 10.7299 7.18238 10.4887 6.85985C10.113 6.3574 9.63359 5.94165 9.08307 5.64081C8.53255 5.33997 7.92378 5.16107 7.29806 5.11625Z"></path>
+                                                                                </g></svg></button>
+                                                                            </div>
+                                                                            <div class="action-label">
+                                                                                <button tabindex="0" class="button share-action" type="button">Copy link</button>
+                                                                            </div>
+                                                                            <div class="action-icon">
+                                                                                <button tabindex="0" class="button share-action" type="button"><svg role="img" width="20" height="16" viewbox="0 0 20 16" fill="none" stroke-width="1" stroke="#000" xmlns="http://www.w3.org/2000/svg">
+                                                                                <g>
+                                                                                    <title></title>
+                                                                                    <path fill-rule="evenodd" clip-rule="evenodd" d="M12.1524 0.286815C12.9848 -0.0318829 13.8948 -0.0864749 14.7592 0.130489C15.462 0.306912 16.107 0.655903 16.6376 1.14249C17.3169 0.89658 17.961 0.560161 18.5523 0.141743C18.7998 -0.0334198 19.1301 -0.0365939 19.381 0.133779C19.6318 0.304152 19.7507 0.612306 19.6791 0.907C19.4028 2.04538 18.8458 3.09393 18.0616 3.95753C18.0757 4.09811 18.083 4.23936 18.0835 4.3808L18.0835 4.38319C18.0835 9.29757 15.7264 12.8962 12.3452 14.7015C8.98147 16.4975 4.67843 16.4794 0.840591 14.3406C0.546545 14.1767 0.403384 13.8324 0.49452 13.5084C0.585656 13.1843 0.887269 12.9652 1.22363 12.9786C2.65157 13.0356 4.0647 12.7377 5.34034 12.12C4.06579 11.3575 3.15922 10.4438 2.53674 9.45782C1.73519 8.18825 1.43205 6.84263 1.37719 5.63204C1.32248 4.42456 1.51372 3.33632 1.71513 2.55507C1.81628 2.16276 1.92118 1.84328 2.00191 1.61926C2.04232 1.50714 2.0768 1.41859 2.10191 1.35643C2.11446 1.32534 2.12469 1.30081 2.13215 1.2832L2.14123 1.26201L2.14412 1.25538L2.14514 1.25307L2.14553 1.25217C2.1457 1.25179 2.14586 1.25144 2.81079 1.54604L2.14586 1.25144C2.25213 1.01158 2.47934 0.847546 2.74046 0.822176C3.00157 0.796805 3.25612 0.914031 3.40657 1.12894C4.15428 2.19698 5.15353 3.06271 6.31515 3.64923C7.26519 4.12892 8.2998 4.40971 9.35623 4.47759V4.41217C9.34536 3.52161 9.60685 2.64886 10.1058 1.91153C10.6058 1.17278 11.3201 0.605503 12.1524 0.286815ZM3.09343 3.03841C2.9284 3.71356 2.78659 4.6028 2.83025 5.5662C2.8764 6.58479 3.12882 7.67102 3.76666 8.68131C4.40153 9.68688 5.44569 10.6611 7.14733 11.4198C7.38821 11.5272 7.55207 11.7566 7.57557 12.0192C7.59906 12.2819 7.47851 12.5367 7.26052 12.6852C6.28428 13.3499 5.20629 13.8343 4.07717 14.1236C6.75502 14.8865 9.46059 14.5928 11.6602 13.4184C14.5413 11.8801 16.6285 8.79158 16.6289 4.38467C16.6283 4.20406 16.611 4.0239 16.5772 3.84652C16.5318 3.60859 16.6079 3.3637 16.7801 3.19336C17.0303 2.94581 17.2553 2.67591 17.4527 2.38779C17.1883 2.49441 16.9189 2.58923 16.6453 2.67187C16.3709 2.75477 16.0733 2.6687 15.8855 2.45208C15.4964 2.00326 14.9795 1.68547 14.4051 1.54127C13.8306 1.39708 13.2258 1.43333 12.6725 1.6452C12.1191 1.85707 11.6436 2.23446 11.3105 2.72674C10.9773 3.21904 10.8028 3.80236 10.8107 4.39779L10.8108 4.40751H10.8108V5.21813C10.8108 5.61242 10.4966 5.9349 10.1024 5.94515C8.56202 5.98522 7.03575 5.6425 5.65956 4.94765C4.69805 4.46217 3.83071 3.81535 3.09343 3.03841Z"></path>
+                                                                                </g></svg></button>
+                                                                            </div>
+                                                                            <div class="action-label">
+                                                                                <button tabindex="0" class="button share-action" type="button">Twitter</button>
+                                                                            </div>
+                                                                            <div class="action-icon">
+                                                                                <button tabindex="0" class="button share-action" type="button"><svg role="img" width="16" height="17" viewbox="0 0 16 17" fill="none" stroke-width="1" stroke="#000" xmlns="http://www.w3.org/2000/svg">
+                                                                                <g>
+                                                                                    <title></title>
+                                                                                    <path d="M10.6543 1.38723C10.3533 0.960814 9.95383 0.61341 9.48976 0.374567C9.02902 0.137956 8.51908 0.0130716 8.00115 0.0100098C7.86087 0.0101844 7.72354 0.0502687 7.60519 0.125581C7.48684 0.200893 7.39237 0.308324 7.3328 0.435326L5.00368 5.67077H3.029C2.72335 5.66964 2.42059 5.73003 2.13876 5.84833C1.85692 5.96663 1.60177 6.14043 1.38849 6.35938C1.16707 6.57502 0.991841 6.83346 0.873459 7.11897C0.755078 7.40447 0.696022 7.71108 0.699885 8.02014V13.691C0.699885 14.3087 0.945273 14.9012 1.38207 15.338C1.81886 15.7747 2.41128 16.0201 3.029 16.0201H13.348C13.8951 16.021 14.425 15.8283 14.8438 15.4762C15.2626 15.1241 15.5434 14.6352 15.6366 14.0961L16.6493 8.4252C16.7252 8.09192 16.7252 7.74582 16.6493 7.41254C16.566 7.08205 16.4104 6.7742 16.1936 6.51128C15.9746 6.25 15.7017 6.03926 15.3936 5.89355C15.0762 5.7467 14.7306 5.67068 14.3809 5.67077H10.5328L11.0391 4.37457C11.2397 3.88784 11.3162 3.35894 11.2619 2.83533C11.1853 2.30894 10.9763 1.81065 10.6543 1.38723ZM4.75052 14.5518H3.029C2.91049 14.5525 2.79303 14.5296 2.68349 14.4844C2.57394 14.4392 2.47452 14.3726 2.39102 14.2885C2.23609 14.1199 2.14945 13.8997 2.14799 13.6708V8.02014C2.14913 7.901 2.17389 7.78328 2.22082 7.67377C2.26775 7.56427 2.33592 7.46515 2.4214 7.38216C2.50369 7.29576 2.60267 7.22698 2.71233 7.17998C2.822 7.13298 2.94007 7.10874 3.05938 7.10874H4.7809L4.75052 14.5518ZM10.6746 7.05811H14.3809C14.5145 7.05821 14.6462 7.08942 14.7657 7.14925C14.8875 7.20532 14.9948 7.28845 15.0796 7.39229C15.1675 7.49052 15.2301 7.60871 15.2619 7.73659C15.2922 7.8665 15.2922 8.00162 15.2619 8.13153L14.2493 13.8024C14.2087 14.017 14.094 14.2106 13.9252 14.3492C13.7619 14.4812 13.558 14.5528 13.348 14.5518H6.19862V6.45052L8.43659 1.38723H8.52773C8.9042 1.50037 9.23304 1.73413 9.4636 2.05252C9.69416 2.37092 9.81365 2.75627 9.80368 3.14925C9.8181 3.39741 9.78015 3.64583 9.69229 3.87836L9.23659 5.04292C9.15397 5.273 9.12623 5.51921 9.15558 5.76191C9.1877 6.00427 9.27425 6.23623 9.40875 6.44039C9.5535 6.6376 9.74028 6.80017 9.95558 6.91634C10.1774 7.03206 10.4244 7.0912 10.6746 7.08849V7.05811Z"></path>
+                                                                                </g></svg></button>
+                                                                            </div>
+                                                                            <div class="action-label">
+                                                                                <button tabindex="0" class="button share-action" type="button">Facebook</button>
+                                                                            </div>
+                                                                            <div class="action-icon">
+                                                                                <button tabindex="0" class="button share-action" type="button"><svg role="img" width="21" height="16" viewbox="0 0 21 16" fill="none" stroke-width="1" stroke="#000" xmlns="http://www.w3.org/2000/svg">
+                                                                                <g>
+                                                                                    <title></title>
+                                                                                    <path fill-rule="evenodd" clip-rule="evenodd" d="M2.22192 2.20503C2.36754 1.77115 2.78269 1.45455 3.26639 1.45455H17.9332C18.4169 1.45455 18.8321 1.77118 18.9777 2.2051L10.5999 8.02107L2.22192 2.20503ZM2.16639 3.94198V13.4545C2.16639 14.0529 2.66307 14.5455 3.26639 14.5455H17.9332C18.5365 14.5455 19.0332 14.0529 19.0332 13.4545V3.94206L11.0204 9.50462C10.7679 9.67991 10.4318 9.67991 10.1793 9.50462L2.16639 3.94198ZM20.4999 2.55809V13.4545C20.4999 14.8562 19.3465 16 17.9332 16H3.26639C1.85304 16 0.699707 14.8562 0.699707 13.4545V2.54545C0.699707 1.14379 1.85304 0 3.26639 0H17.9332C19.3407 0 20.4904 1.13441 20.4998 2.52818C20.5 2.53816 20.5001 2.54813 20.4999 2.55809Z"></path>
+                                                                                </g></svg></button>
+                                                                            </div>
+                                                                            <div class="action-label">
+                                                                                <button tabindex="0" class="button share-action" type="button">Email</button>
+                                                                            </div>
+                                                                        </div>
+                                                                    </div>
+                                                                </div>
+                                                            </div>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                        <div class="post-preview portable-archive-post has-image">
+                                            <div class="post-preview-image">
+                                                <picture><source type="image/webp" srcset="https://substackcdn.com/image/fetch/w_336,h_255,c_limit,f_webp,q_auto:good,fl_progressive:steep/https%3A%2F%2Fbucketeer-e05bbc84-baa3-437e-9518-adb32be77984.s3.amazonaws.com%2Fpublic%2Fimages%2Ffd4b0ce7-fe29-4055-b5c6-8ff1cbbfda6b_800x537.gif" /><img class="frontend-components-responsive_img-module__img--1l4UG post-preview-inner-image" src="https://substackcdn.com/image/fetch/w_336,h_255,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fbucketeer-e05bbc84-baa3-437e-9518-adb32be77984.s3.amazonaws.com%2Fpublic%2Fimages%2Ffd4b0ce7-fe29-4055-b5c6-8ff1cbbfda6b_800x537.gif" sizes="100vw" alt="" srcset="" loading="lazy" /></picture>
+                                            </div>
+                                            <div class="post-preview-content">
+                                                <a href="https://blog.omnivore.app/p/send-pdfs-and-subscribe-to-newsletters" class="post-preview-title newsletter">Send PDFs and subscribe to newsletters with your Omnivore email address</a><a href="https://blog.omnivore.app/p/send-pdfs-and-subscribe-to-newsletters" class="post-preview-description">Add to your library with your Omnivore email address</a>
+                                                <div class="post-ufi style-compressed themed">
+                                                    <div class="ufi-preamble themed">
+                                                        <div class="ufi-preamble-label author">
+                                                            <div class="profile-hover-wrapper">
+                                                                <a href="https://substack.com/profile/49669396-omnivore">Omnivore</a>
+                                                            </div>
+                                                        </div>
+                                                        <div class="ufi-preamble-label post-date" title="2022-04-04T21:18:47.694Z">
+                                                            <time datetime="2022-04-04T21:18:47.694Z">Apr 5</time>
+                                                        </div>
+                                                    </div><a role="button" class="post-ufi-button style-compressed has-label with-border"><svg role="img" width="16" height="16" viewbox="0 0 24 24" fill="#000000" stroke-width="1.5" stroke="#000" xmlns="http://www.w3.org/2000/svg" class="icon" style="height: 16px; width: 16px;">
+                                                    <g>
+                                                        <title></title><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-heart">
+                                                        <path d="M20.42 4.58a5.4 5.4 0 0 0-7.65 0l-.77.78-.77-.78a5.4 5.4 0 0 0-7.65 0C1.46 6.7 1.33 10.28 4 13l8 8 8-8c2.67-2.72 2.54-6.3.42-8.42z"></path></svg>
+                                                    </g></svg>
+                                                    <div class="label">
+                                                        1
+                                                    </div></a><a role="button" class="post-ufi-button style-compressed no-label with-border" href="javascript:void(0)"><svg role="img" width="16" height="16" viewbox="0 0 24 24" fill="#000000" stroke-width="1.5" stroke="#000" xmlns="http://www.w3.org/2000/svg" class="icon" style="height: 16px; width: 16px;">
+                                                    <g>
+                                                        <title></title><svg width="24" height="24" viewbox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                                        <path d="M12.4376 15.6C4.77778 15.6 2 20.3999 2 20.3999C2 12.5999 5.88889 8.4 12.4376 8.4V3L22 11.9812L12.4376 21V15.6Z" stroke-width="1.5" class="lucide" stroke-linecap="round" stroke-linejoin="round"></path></svg>
+                                                    </g></svg></a>
+                                                    <div class="modal typography out gone share-dialog popup" role="dialog">
+                                                        <div class="modal-table">
+                                                            <div class="modal-row">
+                                                                <div class="modal-cell modal-content no-fullscreen">
+                                                                    <div class="container">
+                                                                        <button tabindex="0" data-testid="close-modal" class="button modal-btn modal-exit-btn no-margin" type="button"><svg role="img" width="20" height="20" viewbox="0 0 20 20" fill="none" stroke-width="1" stroke="#666666" xmlns="http://www.w3.org/2000/svg">
+                                                                        <g>
+                                                                            <title></title>
+                                                                            <path d="M15 5L5 15" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
+                                                                            <path d="M5 5L15 15" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
+                                                                        </g></svg></button>
+                                                                        <div class="share-dialog-title">
+                                                                            Share this post
+                                                                        </div>
+                                                                        <div class="social-preview-box post">
+                                                                            <div class="social-image-box">
+                                                                                <picture><source type="image/webp" srcset="https://substackcdn.com/image/fetch/w_120,c_limit,f_webp,q_auto:good,fl_progressive:steep/https%3A%2F%2Fbucketeer-e05bbc84-baa3-437e-9518-adb32be77984.s3.amazonaws.com%2Fpublic%2Fimages%2Ffd4b0ce7-fe29-4055-b5c6-8ff1cbbfda6b_800x537.gif" /><img class="frontend-components-responsive_img-module__img--1l4UG social-image" src="https://substackcdn.com/image/fetch/w_120,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fbucketeer-e05bbc84-baa3-437e-9518-adb32be77984.s3.amazonaws.com%2Fpublic%2Fimages%2Ffd4b0ce7-fe29-4055-b5c6-8ff1cbbfda6b_800x537.gif" sizes="100vw" alt="" srcset="" loading="lazy" /></picture>
+                                                                            </div>
+                                                                            <div class="social-labels">
+                                                                                <div class="social-title">
+                                                                                    Send PDFs and subscribe to newsletters with your Omnivore email address
+                                                                                </div>
+                                                                                <div class="social-subtitle">
+                                                                                    blog.omnivore.app
+                                                                                </div>
+                                                                            </div>
+                                                                        </div>
+                                                                        <div class="share-action-row">
+                                                                            <div class="action-icon">
+                                                                                <button tabindex="0" class="button share-action" type="button"><svg role="img" width="20" height="16" viewbox="0 0 20 16" fill="none" stroke-width="1" stroke="#000" xmlns="http://www.w3.org/2000/svg">
+                                                                                <g>
+                                                                                    <title></title>
+                                                                                    <path fill-rule="evenodd" clip-rule="evenodd" d="M12.1303 0.000379039C10.9833 -0.00959082 9.87819 0.431464 9.05309 1.22855L9.04556 1.23593L7.79145 2.48303C7.50587 2.767 7.50453 3.22877 7.78844 3.51441C8.07235 3.80004 8.53401 3.80139 8.81959 3.51741L10.0698 2.27423C10.6194 1.74503 11.3546 1.45229 12.1177 1.45892C12.8824 1.46556 13.6139 1.77236 14.1546 2.31323C14.6954 2.8541 15.0021 3.58577 15.0087 4.35065C15.0154 5.11353 14.7229 5.84857 14.1943 6.39829L12.0116 8.58145L12.0115 8.58155C11.7159 8.87739 11.36 9.10617 10.9682 9.25237C10.5764 9.39857 10.1577 9.45878 9.74051 9.42889C9.32337 9.39901 8.91752 9.27975 8.55051 9.07918C8.1835 8.87862 7.8639 8.60146 7.6134 8.26649C7.3722 7.94396 6.91526 7.87807 6.5928 8.11933C6.27034 8.36059 6.20447 8.81763 6.44567 9.14016C6.82142 9.64261 7.30082 10.0584 7.85134 10.3592C8.40186 10.66 9.01062 10.8389 9.63634 10.8838C10.2621 10.9286 10.8901 10.8383 11.4779 10.619C12.0656 10.3997 12.5994 10.0565 13.0429 9.61274L15.2302 7.42494L15.2391 7.4159C16.036 6.59062 16.4769 5.48529 16.467 4.33797C16.457 3.19066 15.9969 2.09316 15.1858 1.28185C14.3746 0.470545 13.2774 0.0103489 12.1303 0.000379039ZM7.29806 5.11625C6.67234 5.07142 6.0443 5.16173 5.45654 5.38103C4.86882 5.60031 4.33502 5.94355 3.89153 6.38727L1.70423 8.57506L1.69534 8.5841C0.898438 9.40939 0.457483 10.5147 0.467451 11.662C0.477418 12.8094 0.937512 13.9069 1.74864 14.7182C2.55976 15.5295 3.65701 15.9897 4.80407 15.9996C5.95113 16.0096 7.05622 15.5685 7.88132 14.7715L7.89035 14.7626L9.13717 13.5155C9.42192 13.2307 9.42192 12.7689 9.13717 12.4841C8.85243 12.1993 8.39077 12.1993 8.10602 12.4841L6.86392 13.7265C6.31432 14.2552 5.57945 14.5477 4.81675 14.5411C4.05204 14.5344 3.32054 14.2276 2.77979 13.6868C2.23904 13.1459 1.93231 12.4142 1.92566 11.6494C1.91904 10.8865 2.21146 10.1514 2.74011 9.60172L4.92287 7.41846C5.21854 7.12262 5.57437 6.89384 5.96621 6.74763C6.35805 6.60143 6.77674 6.54123 7.19389 6.57111C7.61104 6.601 8.01688 6.72026 8.38389 6.92082C8.75091 7.12138 9.0705 7.39855 9.32101 7.73352C9.56221 8.05605 10.0191 8.12194 10.3416 7.88068C10.6641 7.63942 10.7299 7.18238 10.4887 6.85985C10.113 6.3574 9.63359 5.94165 9.08307 5.64081C8.53255 5.33997 7.92378 5.16107 7.29806 5.11625Z"></path>
+                                                                                </g></svg></button>
+                                                                            </div>
+                                                                            <div class="action-label">
+                                                                                <button tabindex="0" class="button share-action" type="button">Copy link</button>
+                                                                            </div>
+                                                                            <div class="action-icon">
+                                                                                <button tabindex="0" class="button share-action" type="button"><svg role="img" width="20" height="16" viewbox="0 0 20 16" fill="none" stroke-width="1" stroke="#000" xmlns="http://www.w3.org/2000/svg">
+                                                                                <g>
+                                                                                    <title></title>
+                                                                                    <path fill-rule="evenodd" clip-rule="evenodd" d="M12.1524 0.286815C12.9848 -0.0318829 13.8948 -0.0864749 14.7592 0.130489C15.462 0.306912 16.107 0.655903 16.6376 1.14249C17.3169 0.89658 17.961 0.560161 18.5523 0.141743C18.7998 -0.0334198 19.1301 -0.0365939 19.381 0.133779C19.6318 0.304152 19.7507 0.612306 19.6791 0.907C19.4028 2.04538 18.8458 3.09393 18.0616 3.95753C18.0757 4.09811 18.083 4.23936 18.0835 4.3808L18.0835 4.38319C18.0835 9.29757 15.7264 12.8962 12.3452 14.7015C8.98147 16.4975 4.67843 16.4794 0.840591 14.3406C0.546545 14.1767 0.403384 13.8324 0.49452 13.5084C0.585656 13.1843 0.887269 12.9652 1.22363 12.9786C2.65157 13.0356 4.0647 12.7377 5.34034 12.12C4.06579 11.3575 3.15922 10.4438 2.53674 9.45782C1.73519 8.18825 1.43205 6.84263 1.37719 5.63204C1.32248 4.42456 1.51372 3.33632 1.71513 2.55507C1.81628 2.16276 1.92118 1.84328 2.00191 1.61926C2.04232 1.50714 2.0768 1.41859 2.10191 1.35643C2.11446 1.32534 2.12469 1.30081 2.13215 1.2832L2.14123 1.26201L2.14412 1.25538L2.14514 1.25307L2.14553 1.25217C2.1457 1.25179 2.14586 1.25144 2.81079 1.54604L2.14586 1.25144C2.25213 1.01158 2.47934 0.847546 2.74046 0.822176C3.00157 0.796805 3.25612 0.914031 3.40657 1.12894C4.15428 2.19698 5.15353 3.06271 6.31515 3.64923C7.26519 4.12892 8.2998 4.40971 9.35623 4.47759V4.41217C9.34536 3.52161 9.60685 2.64886 10.1058 1.91153C10.6058 1.17278 11.3201 0.605503 12.1524 0.286815ZM3.09343 3.03841C2.9284 3.71356 2.78659 4.6028 2.83025 5.5662C2.8764 6.58479 3.12882 7.67102 3.76666 8.68131C4.40153 9.68688 5.44569 10.6611 7.14733 11.4198C7.38821 11.5272 7.55207 11.7566 7.57557 12.0192C7.59906 12.2819 7.47851 12.5367 7.26052 12.6852C6.28428 13.3499 5.20629 13.8343 4.07717 14.1236C6.75502 14.8865 9.46059 14.5928 11.6602 13.4184C14.5413 11.8801 16.6285 8.79158 16.6289 4.38467C16.6283 4.20406 16.611 4.0239 16.5772 3.84652C16.5318 3.60859 16.6079 3.3637 16.7801 3.19336C17.0303 2.94581 17.2553 2.67591 17.4527 2.38779C17.1883 2.49441 16.9189 2.58923 16.6453 2.67187C16.3709 2.75477 16.0733 2.6687 15.8855 2.45208C15.4964 2.00326 14.9795 1.68547 14.4051 1.54127C13.8306 1.39708 13.2258 1.43333 12.6725 1.6452C12.1191 1.85707 11.6436 2.23446 11.3105 2.72674C10.9773 3.21904 10.8028 3.80236 10.8107 4.39779L10.8108 4.40751H10.8108V5.21813C10.8108 5.61242 10.4966 5.9349 10.1024 5.94515C8.56202 5.98522 7.03575 5.6425 5.65956 4.94765C4.69805 4.46217 3.83071 3.81535 3.09343 3.03841Z"></path>
+                                                                                </g></svg></button>
+                                                                            </div>
+                                                                            <div class="action-label">
+                                                                                <button tabindex="0" class="button share-action" type="button">Twitter</button>
+                                                                            </div>
+                                                                            <div class="action-icon">
+                                                                                <button tabindex="0" class="button share-action" type="button"><svg role="img" width="16" height="17" viewbox="0 0 16 17" fill="none" stroke-width="1" stroke="#000" xmlns="http://www.w3.org/2000/svg">
+                                                                                <g>
+                                                                                    <title></title>
+                                                                                    <path d="M10.6543 1.38723C10.3533 0.960814 9.95383 0.61341 9.48976 0.374567C9.02902 0.137956 8.51908 0.0130716 8.00115 0.0100098C7.86087 0.0101844 7.72354 0.0502687 7.60519 0.125581C7.48684 0.200893 7.39237 0.308324 7.3328 0.435326L5.00368 5.67077H3.029C2.72335 5.66964 2.42059 5.73003 2.13876 5.84833C1.85692 5.96663 1.60177 6.14043 1.38849 6.35938C1.16707 6.57502 0.991841 6.83346 0.873459 7.11897C0.755078 7.40447 0.696022 7.71108 0.699885 8.02014V13.691C0.699885 14.3087 0.945273 14.9012 1.38207 15.338C1.81886 15.7747 2.41128 16.0201 3.029 16.0201H13.348C13.8951 16.021 14.425 15.8283 14.8438 15.4762C15.2626 15.1241 15.5434 14.6352 15.6366 14.0961L16.6493 8.4252C16.7252 8.09192 16.7252 7.74582 16.6493 7.41254C16.566 7.08205 16.4104 6.7742 16.1936 6.51128C15.9746 6.25 15.7017 6.03926 15.3936 5.89355C15.0762 5.7467 14.7306 5.67068 14.3809 5.67077H10.5328L11.0391 4.37457C11.2397 3.88784 11.3162 3.35894 11.2619 2.83533C11.1853 2.30894 10.9763 1.81065 10.6543 1.38723ZM4.75052 14.5518H3.029C2.91049 14.5525 2.79303 14.5296 2.68349 14.4844C2.57394 14.4392 2.47452 14.3726 2.39102 14.2885C2.23609 14.1199 2.14945 13.8997 2.14799 13.6708V8.02014C2.14913 7.901 2.17389 7.78328 2.22082 7.67377C2.26775 7.56427 2.33592 7.46515 2.4214 7.38216C2.50369 7.29576 2.60267 7.22698 2.71233 7.17998C2.822 7.13298 2.94007 7.10874 3.05938 7.10874H4.7809L4.75052 14.5518ZM10.6746 7.05811H14.3809C14.5145 7.05821 14.6462 7.08942 14.7657 7.14925C14.8875 7.20532 14.9948 7.28845 15.0796 7.39229C15.1675 7.49052 15.2301 7.60871 15.2619 7.73659C15.2922 7.8665 15.2922 8.00162 15.2619 8.13153L14.2493 13.8024C14.2087 14.017 14.094 14.2106 13.9252 14.3492C13.7619 14.4812 13.558 14.5528 13.348 14.5518H6.19862V6.45052L8.43659 1.38723H8.52773C8.9042 1.50037 9.23304 1.73413 9.4636 2.05252C9.69416 2.37092 9.81365 2.75627 9.80368 3.14925C9.8181 3.39741 9.78015 3.64583 9.69229 3.87836L9.23659 5.04292C9.15397 5.273 9.12623 5.51921 9.15558 5.76191C9.1877 6.00427 9.27425 6.23623 9.40875 6.44039C9.5535 6.6376 9.74028 6.80017 9.95558 6.91634C10.1774 7.03206 10.4244 7.0912 10.6746 7.08849V7.05811Z"></path>
+                                                                                </g></svg></button>
+                                                                            </div>
+                                                                            <div class="action-label">
+                                                                                <button tabindex="0" class="button share-action" type="button">Facebook</button>
+                                                                            </div>
+                                                                            <div class="action-icon">
+                                                                                <button tabindex="0" class="button share-action" type="button"><svg role="img" width="21" height="16" viewbox="0 0 21 16" fill="none" stroke-width="1" stroke="#000" xmlns="http://www.w3.org/2000/svg">
+                                                                                <g>
+                                                                                    <title></title>
+                                                                                    <path fill-rule="evenodd" clip-rule="evenodd" d="M2.22192 2.20503C2.36754 1.77115 2.78269 1.45455 3.26639 1.45455H17.9332C18.4169 1.45455 18.8321 1.77118 18.9777 2.2051L10.5999 8.02107L2.22192 2.20503ZM2.16639 3.94198V13.4545C2.16639 14.0529 2.66307 14.5455 3.26639 14.5455H17.9332C18.5365 14.5455 19.0332 14.0529 19.0332 13.4545V3.94206L11.0204 9.50462C10.7679 9.67991 10.4318 9.67991 10.1793 9.50462L2.16639 3.94198ZM20.4999 2.55809V13.4545C20.4999 14.8562 19.3465 16 17.9332 16H3.26639C1.85304 16 0.699707 14.8562 0.699707 13.4545V2.54545C0.699707 1.14379 1.85304 0 3.26639 0H17.9332C19.3407 0 20.4904 1.13441 20.4998 2.52818C20.5 2.53816 20.5001 2.54813 20.4999 2.55809Z"></path>
+                                                                                </g></svg></button>
+                                                                            </div>
+                                                                            <div class="action-label">
+                                                                                <button tabindex="0" class="button share-action" type="button">Email</button>
+                                                                            </div>
+                                                                        </div>
+                                                                    </div>
+                                                                </div>
+                                                            </div>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div><a class="portable-archive-all" href="/archive?sort=top">See all <svg role="img" width="12" height="12" viewbox="0 0 20 20" fill="none" stroke-width="1" stroke="#000" xmlns="http://www.w3.org/2000/svg" style="height: 12px; width: 12px;">
+                                        <g>
+                                            <title></title>
+                                            <path d="M7.5 15L12.5 10L7.5 5" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
+                                        </g></svg></a>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="visibility-check"></div>
+                        <div class="subscribe-footer">
+                            <div class="container">
+                                <h1>
+                                    Ready for more?
+                                </h1>
+                                <form action="/api/v1/free?nojs=true" method="post" class="form" novalidate="">
+                                    <input type="hidden" name="first_url" value="https://blog.omnivore.app/p/saving-links-from-your-iphone-or" /><input type="hidden" name="first_referrer" /><input type="hidden" name="current_url" value="https://blog.omnivore.app/p/saving-links-from-your-iphone-or" /><input type="hidden" name="current_referrer" /><input type="hidden" name="referral_code" /><input type="hidden" name="source" value="subscribe_footer" /><input type="hidden" name="referring_pub_id" /><input type="hidden" name="additional_referring_pub_ids" />
+                                    <div class="sideBySideWrap">
+                                        <input type="email" name="email" placeholder="Type your email…" /><button class="button rightButton primary subscribe-btn" type="submit" tabindex="0"><b class="button-text">Subscribe</b></button>
+                                    </div>
+                                    <div id="error-container"></div>
+                                    <div class="subtle-help-text below-input"></div>
+                                </form>
+                                <div class="frontend-login-typo_handler-EmailTypoHandler-module__animationWrapper--1W2AP"></div>
+                            </div>
+                        </div>
+                    </div>
+                    <script type="text/javascript" async="async" src="https://googleads.g.doubleclick.net/pagead/viewthroughconversion/316245675/?random=1666167209386&amp;cv=9&amp;fst=1666167209386&amp;num=1&amp;bg=ffffff&amp;guid=ON&amp;resp=GooglemKTybQhCsO&amp;u_h=1117&amp;u_w=1728&amp;u_ah=1117&amp;u_aw=1728&amp;u_cd=30&amp;u_his=2&amp;u_tz=480&amp;u_java=false&amp;u_nplug=0&amp;u_nmime=0&amp;gtm=2oaah0&amp;sendb=1&amp;ig=0&amp;data=event%3Dgtag.config&amp;frm=0&amp;url=https%3A%2F%2Fblog.omnivore.app%2Fp%2Fsaving-links-from-your-iphone-or&amp;tiba=Saving%20Links%20from%20Your%20iPhone%20or%20iPad%20-%20Omnivore&amp;auid=801928459.1666167209&amp;hn=www.google.com&amp;async=1&amp;rfmt=3&amp;fmt=4"></script>
+                </div>
+                <div class="footer-wrap publication-footer">
+                    <div class="footer themed-background">
+                        <div class="container">
+                            <div class="footer-blurbs">
+                                <div class="footer-copyright-blurb">
+                                    © 2022 Omnivore
+                                </div>
+                                <div class="footer-terms-blurb">
+                                    <a href="https://blog.omnivore.app/privacy" native="true">Privacy</a> ∙ <a href="/tos" native="true">Terms</a> ∙ <a href="https://substack.com/ccpa#personal-data-collected" native="true">Collection notice</a>
+                                </div>
+                            </div>
+                            <div class="footer-buttons">
+                                <a native="true" href="https://substack.com/signup?utm_source=substack&amp;utm_medium=web&amp;utm_content=footer" class="footer-substack-cta start-publishing"><svg role="img" width="1000" height="1000" viewbox="0 0 1000 1000" fill="#FF6719" stroke-width="1" stroke="none" xmlns="http://www.w3.org/2000/svg">
+                                <g>
+                                    <title></title>
+                                    <path d="M764.166 348.371H236.319V419.402H764.166V348.371Z"></path>
+                                    <path d="M236.319 483.752V813.999L500.231 666.512L764.19 813.999V483.752H236.319Z"></path>
+                                    <path d="M764.166 213H236.319V284.019H764.166V213Z"></path>
+                                </g></svg> Publish on Substack</a><a native="true" href="https://substack.com/app/app-store-redirect?utm_campaign=app-marketing&amp;utm_content=web-footer-button" class="footer-substack-cta get-the-app"><svg role="img" width="24" height="24" viewbox="0 0 24 24" fill="#000" stroke-width="1" stroke="none" xmlns="http://www.w3.org/2000/svg">
+                                <g>
+                                    <title></title>
+                                    <path d="M17.851 11.9011C17.861 11.125 18.0671 10.364 18.4502 9.68899C18.8334 9.01396 19.381 8.44682 20.0422 8.04031C19.6222 7.44042 19.068 6.94672 18.4238 6.59845C17.7796 6.25018 17.063 6.05691 16.3311 6.03401C14.7696 5.87011 13.2559 6.96835 12.4602 6.96835C11.6491 6.96835 10.4241 6.05028 9.10485 6.07742C8.25156 6.10499 7.41996 6.35312 6.69107 6.79764C5.96219 7.24216 5.36088 7.86791 4.94574 8.61392C3.14746 11.7274 4.48882 16.3032 6.21144 18.82C7.07331 20.0523 8.08059 21.4289 9.3986 21.3801C10.6884 21.3266 11.1701 20.5577 12.7269 20.5577C14.2693 20.5577 14.7212 21.3801 16.066 21.3491C17.4499 21.3266 18.3219 20.1112 19.1535 18.8672C19.7728 17.9891 20.2493 17.0186 20.5654 15.9916C19.7614 15.6516 19.0752 15.0823 18.5925 14.3549C18.1098 13.6275 17.8519 12.7741 17.851 11.9011Z"></path>
+                                    <path d="M15.3113 4.3788C16.0659 3.47293 16.4376 2.3086 16.3476 1.13306C15.1948 1.25414 14.1298 1.80513 13.3651 2.67623C12.9911 3.10179 12.7047 3.59687 12.5223 4.13318C12.3398 4.66949 12.2648 5.2365 12.3016 5.8018C12.8782 5.80774 13.4487 5.68276 13.97 5.43627C14.4913 5.18978 14.9499 4.82821 15.3113 4.3788Z"></path>
+                                </g></svg> Get the app</a>
+                            </div>
+                            <div class="footer-slogan-blurb">
+                                <a href="https://substack.com" native="true">Substack</a>&#160;is the home for great writing
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div style="transform: translateY(0px);" class="tw-fixed tw-bottom-2.5 tw-right-2.5 tw-left-2.5 md:tw-left-auto md:tw-bottom-4 md:tw-right-4 md:tw-pl-4 tw-z-10"></div>
+        </div>
+        <script src="https://js.sentry-cdn.com/c41771aeccbb43fbbffbc4755e65c9be.min.js" crossorigin="anonymous"></script> 
+        <script>
+        <![CDATA[
+        window._preloads        = {"isEU":false,"language":"en","country":"SG","base_url":"https://blog.omnivore.app","stripe_publishable_key":"pk_live_vNnuGHOFnt4mM7V9PuCAAPJz","captcha_site_key":"6LdYbsYZAAAAAIFIRh8X_16GoFRLIReh-e-q6qSa","pub":{"apple_pay_disabled":false,"author_id":49669396,"byline_images_enabled":true,"bylines_enabled":true,"chartable_token":null,"community_enabled":true,"copyright":"Omnivore","cover_photo_url":null,"created_at":"2021-10-01T02:49:41.829Z","custom_domain_optional":false,"custom_domain":"blog.omnivore.app","default_comment_sort":"best_first","default_coupon":null,"default_group_coupon":null,"default_show_guest_bios":true,"email_banner_url":null,"email_from_name":"Omnivore","email_from":null,"embed_tracking_disabled":false,"explicit":false,"expose_paywall_content_to_search_engines":true,"fb_pixel_id":null,"fb_site_verification_token":null,"flagged_as_spam":false,"founding_subscription_benefits":null,"free_subscription_benefits":null,"ga_pixel_id":null,"google_site_verification_token":null,"google_tag_manager_token":null,"hero_image":null,"hero_text":"Updates from the Omnivore team","hide_intro_subtitle":null,"hide_intro_title":null,"hide_podcast_feed_link":false,"homepage_type":"newspaper","id":509268,"image_thumbnails_always_enabled":false,"invite_only":false,"keywee_pixel_id":null,"language":"en","logo_url_wide":null,"logo_url":"https://bucketeer-e05bbc84-baa3-437e-9518-adb32be77984.s3.amazonaws.com/public/images/052c15c4-ecfd-4d32-87db-13bcac9afad5_512x512.png","minimum_group_size":4,"moderation_enabled":true,"name":"Omnivore","paid_subscription_benefits":null,"parent_about_page_enabled":true,"parent_publication_id":null,"parsely_pixel_id":null,"payments_state":"disabled","paywall_free_trial_enabled":false,"podcast_art_url":null,"paid_podcast_episode_art_url":null,"podcast_byline":null,"podcast_description":null,"podcast_enabled":false,"podcast_feed_url":null,"podcast_title":null,"post_preview_limit":null,"require_clickthrough":false,"rss_feed_url":null,"rss_website_url":null,"show_pub_podcast_tab":false,"show_recs_on_homepage":true,"sibling_rank":null,"subdomain":"omnivoreapp","subscriber_invites":0,"support_email":null,"theme_var_background_pop":"#FF9900","theme_var_color_links":false,"theme_var_cover_bg_color":null,"trial_end_override":null,"twitter_pixel_id":null,"type":"newsletter","post_reaction_faces_enabled":true,"theme":{"publication_id":509268,"background_pop_color":"#ffe682","cover_bg_color":null,"web_bg_color":"#ffffff","color_links":null,"font_preset_heading":null,"font_preset_body":null,"font_family_headings":null,"font_family_body":null,"font_family_ui":null,"font_size_body_desktop":null,"print_secondary":null,"custom_css_web":null,"custom_css_email":null},"plans":null,"stripe_user_id":null,"stripe_country":null,"stripe_publishable_key":null,"author_name":"Omnivore","author_photo_url":null,"author_bio":"Omnivore is the home for everything you read; automatically organized and easy to share","default_group_coupon_percent_off":null,"has_child_publications":false,"has_posts":true,"has_recommendations":false,"first_post_date":"2021-10-13T19:39:10.254Z","has_podcast":false,"has_free_podcast":false,"has_subscriber_only_podcast":false,"has_community_content":false,"twitter_share_on_publish_opt_in":null,"twitter_permissions":"none","rankingDetail":"Launched a year ago","rankingDetailFreeIncluded":"Launched a year ago","navigationBarItems":[],"contributors":[{"name":"Omnivore","role":"admin","owner":true,"user_id":49669396,"photo_url":null}],"threads_v2_enabled":false,"threads_v2_settings":null,"tier":2,"no_follow":false,"no_index":false,"can_set_google_site_verification":true,"can_have_sitemap":true,"hide_intro_popup_for_crawlers":false,"can_have_sitemap_page":false,"bitcoin_plan":null,"draft_plans":null,"base_url":"https://blog.omnivore.app","hostname":"blog.omnivore.app","is_on_substack":false,"parent_publication":null,"child_publications":[],"sibling_publications":[],"sections":[],"subscribeCardVersionHash":"e03aaf5cd51e4035f38f2aa621f6a29c","section":null},"user":null,"confirmedLogin":false,"freeSignupUserId":null,"freeSignupEmail":null,"freeSignup":null,"token":null,"staffContactId":null,"inviteOnly":null,"referralCode":null,"referralCoupon":null,"hide_intro_popup":false,"block_auto_login":false,"referralCampaign":null,"twitterEmail":null,"twitterToken":null,"domainInfo":{"isSubstack":false,"customDomain":"blog.omnivore.app"},"experimentFeatures":{"email_typo_corrections":"control","translate_choose_subscription_plan":"treatment","paywall_the_archives":null,"precancellation_free_month":null,"bundles_v2":"control","twitter_graph_activity_email":null,"disable_monthly_subscriptions":"control","use_new_subscribe_page_new_styles":"treatment","subscribe_flow_blurb_adoption":null,"subscribe_pledge_screen":"control"},"experimentExposures":{},"siteConfigs":{"score_upsell_email":"control","free_signup_confirmation_behavior":"with_email_validation","reader-onboarding-promoted-pub":737237,"pub_creation_captcha_behavior":"risky_pubs","continue_support_cta_emails_15d_after_expiry":false,"pub_update_opennode_api_key":false,"selection_sharing":"NONE","guest_posts_revamp":"NONE","trending_posts_enabled":false,"activity_emails_v3":false,"cashtags_enabled":true,"reader_post_viewer_enabled":true,"thread_photo_replies":false,"no_contest_charge_disputes":false,"use_new_homepage":true,"recommendations_announcement_url":"https://on.substack.com/p/recommendations","comp_expiry_email_new_copy":"NONE","free_unlock_required":false,"traffic_rule_check_enabled":false,"amp_emails_enabled":false,"minimum_ios_version":null,"image_deep_link_enabled":false,"bitcoin_enabled":false,"public_podcast_rss_feed_only_free_visible":false,"show_entire_square_image":false,"hide_subscriber_count":false,"publication_author_display_override":"","reader_onboarding_after_subscription_flow":"NONE","generate_pdf_tax_report":false,"threads_v2_visible":false,"enable_restacking":false,"include_pdf_invoice":false,"hide_pub_from_subscription_recommendation":false,"enable_prev_next_post_link":true,"tax_integration_enabled":false,"meetings_v1":false,"custom_target_origin":"","exempt_from_gtm_filter":false,"syndicate_voiceover_to_rss":true,"boost_optin_modal_enabled":true,"pub_tts_override":"default","disable_monthly_subscriptions":false,"skip_welcome_email":false,"group_subscriptions_crm":false,"scheduled_pinned_posts":false,"disable_redirect_outbound_utm_params":false,"reader_gift_referrals_enabled":true,"ios_pause_email_default":false,"auto_paywall_archives":true,"dont_show_guest_byline":false,"like_comments_enabled":true,"video_posts_enabled":true,"extended_podcast_episode_metadata":false,"use_richer_html_for_editing_podcast_description":false,"email_ufi_enabled":true,"activity_feed_enabled":false,"enable_new_discover_page":false,"no_auto_renewal_notice":false,"minimum_android_version":null,"welcome_screen_blurb_override":"","show_email_app_install_button":true,"like_posts_enabled":true,"email_header_footer":"original_flow","history_bucket_unit":"month","twitter_player_card_enabled":true,"audio_edu_modal":false,"history_max_iterations":10,"history_paging_enabled":true,"generated_database_maintenance_mode":false,"max_image_upload_mb":32,"extract_stripe_receipt_url":false,"post_recipients_batch_limit":5000,"bulk_subscribe_upsell_email":"experiment","trending_sidebar":false,"threads_suggested_ios_version":null,"precancellation_free_month":"control","threads_minimum_ios_version":812,"hide_podcast_email_setup_link":false,"subscribe_captcha_behavior":"default","publication_ban_sample_rate":0,"allow_moderation_sampling_mode":false,"allow_filtering_moderation_reasons":false,"photo_dna_enabled":false,"round_square_images":false,"reader_referrals_feature_enabled":false,"continue_support_cta_in_newsletter_emails":false,"end_of_post_publication_recommendation":"control","bundles_v2":"NONE","publisher_banner":"","allow_document_freeze":false,"chat_marketing_launched":false,"podcast_main_feed_is_firehose":false,"zendesk_automation_cancellations":false,"pub_launch_checklist":false,"subscribe_flow_blurb_adoption":"experiment","chat_beta_access":false,"should_send_payment_pledge_emails":true,"subscribe_pledge_screen":"NONE"},"publicationSettings":{"enable_prev_next_nav":false,"enable_restacking":true,"seen_coming_soon_explainer":false,"enable_post_page_conversion":true,"enable_meetings":false},"subscriberCountDetails":null,"noIndex":false,"post":{"id":79321629,"publication_id":509268,"type":"newsletter","title":"Saving Links from Your iPhone or iPad ","social_title":null,"section_id":null,"search_engine_title":null,"search_engine_description":null,"subtitle":"","slug":"saving-links-from-your-iphone-or","post_date":"2022-10-19T07:42:04.670Z","podcast_url":"","podcast_art_url":null,"podcast_duration":null,"video_upload_id":null,"podcast_upload_id":null,"podcast_preview_upload_id":null,"audience":"everyone","should_send_free_preview":false,"write_comment_permissions":"everyone","show_guest_bios":true,"free_unlock_required":false,"default_comment_sort":null,"canonical_url":"https://blog.omnivore.app/p/saving-links-from-your-iphone-or","audience_before_archived":null,"reactions":{"\u2764":0},"top_exclusions":[],"pins":[],"section_pins":[],"previous_post_slug":"getting-started-with-omnivore-382","next_post_slug":null,"cover_image":"https://substackcdn.com/image/youtube/w_728,c_limit/k6RkIqepAig","cover_image_is_square":false,"videoUpload":null,"podcastUpload":null,"podcastPreviewUpload":null,"voiceover_upload_id":null,"voiceoverUpload":null,"has_voiceover":false,"description":"With the Omnivore app for iOS, it\u2019s easy to save web pages and articles or archive web content to read later. The Omnivore app uses the iOS Share System, which lets you send items from one app (such as Safari) to another (such as Messages or Mail).","body_html":"<p>With the <a href=\"https://omnivore.app/install/ios\">Omnivore app for iOS<\/a>, it\u2019s easy to save web pages and articles or archive web content to read later.<\/p><p>The Omnivore app uses the<em> iOS Share System<\/em>, which lets you send items from one app (such as Safari) to another (such as Messages or Mail).&nbsp;<\/p><ul><li><p>Step 1: Log in to the Omnivore app.<\/p><\/li><li><p>Step 2: Add Omnivore to your Share menu favorites.<\/p><\/li><li><p>Step 3: Save links to your Omnivore Library.<\/p><\/li><\/ul><div id=\"youtube2-k6RkIqepAig\" class=\"youtube-wrap\" data-attrs=\"{&quot;videoId&quot;:&quot;k6RkIqepAig&quot;,&quot;startTime&quot;:null,&quot;endTime&quot;:null}\"><div class=\"youtube-inner\"><iframe src=\"https://www.youtube-nocookie.com/embed/k6RkIqepAig?rel=0&amp;autoplay=0&amp;showinfo=0&amp;enablejsapi=0\" frameborder=\"0\" loading=\"lazy\" gesture=\"media\" allow=\"autoplay; fullscreen\" allowautoplay=\"true\" allowfullscreen=\"true\" width=\"728\" height=\"409\"><\/iframe><\/div><\/div><p><\/p><h2><strong>Step 1: Log in to the Omnivore app.<\/strong><\/h2><p>You must be logged in before you can save links via the Share menu. If you don\u2019t already have an Omnivore account, you can sign up for free from the login screen.<\/p><p><em>Note: <\/em>If you haven\u2019t installed the iOS app, download it here: <a href=\"https://omnivore.app/install/ios\">https://omnivore.app/install/ios<\/a><\/p><h2><strong>Step 2: Add Omnivore to your Share menu favorites.<\/strong><\/h2><p>Start by viewing the Share menu from within any supported iOS app (we\u2019ve used Safari for this example).<\/p><ol><li><p>Tap the <strong>Share <\/strong>icon at the bottom of the screen.<\/p><\/li><li><p>Swipe left to the end of the list of app icons and tap <strong>More<\/strong>.<\/p><\/li><li><p>Tap <strong>Edit <\/strong>at the top of the screen.<\/p><\/li><li><p>Scroll down until you see the <strong>Omnivore <\/strong>icon and tap the <strong>+ <\/strong>icon next to it.&nbsp;<\/p><\/li><li><p>Press and hold the three-bar icon and drag Omnivore to one of the top positions under Favorites. Tap <strong>Done <\/strong>to close the menu.<\/p><\/li><li><p><strong>Omnivore <\/strong>will appear as one of the first options the next time you use the Share feature (you may need to restart Safari).<\/p><\/li><\/ol><h2><strong>Step 3: Save links to your Omnivore Library<\/strong><\/h2><p>Start by navigating to the page or article you wish to save. Please note that Omnivore will save the content that appears on your screen (not just a link), so <em>if the page is behind a paywall and you are logged into the paywalled site, you will save the paid content.<\/em>&nbsp;<\/p><ol><li><p>While viewing the page you\u2019d like to save, tap the <strong>Share<\/strong> icon.<\/p><\/li><li><p>Tap the <strong>Omnivore<\/strong> icon in the Share menu.<\/p><\/li><li><p>Tag the article with one or more labels (optional) and tap <strong>Read Now<\/strong> or <strong>Read Later<\/strong>.&nbsp;<\/p><\/li><li><p>If you choose Read Later, the link will appear in your Library the next time you open the Omnivore app.<\/p><\/li><\/ol>","longer_truncated_body_json":null,"longer_truncated_body_html":null,"truncated_body_text":"With the Omnivore app for iOS, it\u2019s easy to save web pages and articles or archive web content to read later. The Omnivore app uses the iOS Share System, which lets you send items from one app (such as Safari) to another (such as Messages or Mail).","wordcount":360,"comment_count":0,"publishedBylines":[{"id":49669396,"name":"Omnivore","previous_name":null,"photo_url":null,"bio":"Omnivore is the home for everything you read; automatically organized and easy to share","email":"welcome@omnivore.app","profile_set_up_at":null,"publicationUsers":[{"id":437707,"user_id":49669396,"publication_id":509268,"role":"admin","public":true,"is_primary":false,"publication":{"id":509268,"name":"Omnivore","subdomain":"omnivoreapp","custom_domain":"blog.omnivore.app","custom_domain_optional":false,"hero_text":"Updates from the Omnivore team","logo_url":"https://bucketeer-e05bbc84-baa3-437e-9518-adb32be77984.s3.amazonaws.com/public/images/052c15c4-ecfd-4d32-87db-13bcac9afad5_512x512.png","author_id":49669396,"theme_var_background_pop":"#FF9900","created_at":"2021-10-01T02:49:41.829Z","rss_website_url":null,"email_from_name":"Omnivore","copyright":"Omnivore","founding_plan_name":null,"community_enabled":true,"invite_only":false,"payments_state":"disabled"}}],"is_guest":false}],"reaction":null,"audio_items":null,"truncated_description":null,"hasCashtag":false,"truncated_body_html":null,"post_paywall_content_for_google":null},"truncatedPost":null,"comments":[],"post_reaction_token":null,"canonicalUrl":"https://blog.omnivore.app/p/saving-links-from-your-iphone-or","inlineComments":false,"readerIsSearchCrawler":false,"selectionFromQuery":null,"embeddedPublications":null,"ogUrl":"https://blog.omnivore.app/p/saving-links-from-your-iphone-or","freeTrialCoupon":null,"isChatActive":false,"features":{}}
+        ]]>
+        </script> 
+        <script>
+        <![CDATA[
+        window._analyticsConfig = {"user":null,"properties":{"subdomain":"omnivoreapp","publication_id":509268,"has_plans":false,"pub_community_enabled":true,"parent_publication_id":null,"parent_publication_subdomain":null,"is_parent_publication":false,"section_name":null,"section_slug":null,"section_id":null,"section_is_podcast":null,"is_subscribed":false,"is_free_subscribed":false,"is_author":false,"is_contributor":false,"is_admin":false,"is_founding":false},"adwordsAccountId":"AW-316245675","adwordsEventSendTo":"Tf76CKqcyL4DEKuN5pYB"}
+        ]]>
+        </script> 
+        <script src="https://substackcdn.com/min/main.bundle.js?v=1c7d20-183edb5c440" charset="utf-8"></script> <!-- Fallback tracking pixels -->
+         <noscript>
+        <div id="nojs-banner">
+            This site requires JavaScript to run correctly. Please <a href="https://enable-javascript.com/" target="_blank">turn on JavaScript</a> or unblock scripts
+        </div></noscript>
+    </body>
+</html>

--- a/packages/api/test/routers/auth.test.ts
+++ b/packages/api/test/routers/auth.test.ts
@@ -626,8 +626,7 @@ describe('auth router', () => {
           0,
         ]
 
-        // TODO: update this when we have more iOS popular reads
-        expect(count).to.eql(3)
+        expect(count).to.eql(4)
       })
     })
   })


### PR DESCRIPTION
This also re-orders things a bit, making sure the getting started
guide is always the topmost in a user's library.
