### PR TITLE
Fixing the Link - Here text

### DIFF
--- a/packages/web/components/templates/integrations/Readwise.tsx
+++ b/packages/web/components/templates/integrations/Readwise.tsx
@@ -3,7 +3,7 @@ import { styled } from '@stitches/react'
 import Link from 'next/link'
 import Image from 'next/image'
 
-import { Box, HStack, VStack } from '../../elements/LayoutPrimitives'
+import { Box, HStack, SpanBox, VStack } from '../../elements/LayoutPrimitives'
 import { Button } from '../../elements/Button'
 import { StyledText } from '../../elements/StyledText'
 import { FormInput } from '../../elements/FormElements'
@@ -77,13 +77,13 @@ export function Readwise(): JSX.Element {
           whiteSpace: 'pre-wrap'
         }}
       >
-        Enter your API key from Readwise below. You can get your token{' '}
+        <SpanBox>Enter your API key from Readwise below. You can get your token{' '}
         <Link
           style={{ color: '$utilityTextDefault' }}
           href="https://readwise.io/access_token"
         >
           here
-        </Link>.
+        </Link>.</SpanBox>
       </HStack>
 
       <FormInput


### PR DESCRIPTION
This PR fixes the issue related to "here" text which is a link not being aligned with the rest of the text on smaller screens

### Fix
<img width="370" alt="Screen Shot 2022-10-27 at 7 31 40 PM" src="https://user-images.githubusercontent.com/107437442/198422052-99bc3f7c-5c13-463f-9a03-ab406d14868d.png">
