### PR TITLE
Use order instead of page to indicate highlight location in Readwise

### DIFF
--- a/packages/api/src/services/integrations.ts
+++ b/packages/api/src/services/integrations.ts
@@ -3,7 +3,7 @@ import { env } from '../env'
 import axios from 'axios'
 import { wait } from '../utils/helpers'
 import { Page } from '../elastic/types'
-import { getHighlightLocation, getHighlightUrl } from './highlights'
+import { getHighlightUrl } from './highlights'
 import { Integration } from '../entity/integration'
 import { getRepository } from '../entity/utils'
 
@@ -66,7 +66,6 @@ const validateReadwiseToken = async (token: string): Promise<boolean> => {
 const pageToReadwiseHighlight = (page: Page): ReadwiseHighlight[] => {
   if (!page.highlights) return []
   return page.highlights.map((highlight) => {
-    const location = getHighlightLocation(highlight.patch)
     return {
       text: highlight.quote,
       title: page.title,
@@ -75,8 +74,8 @@ const pageToReadwiseHighlight = (page: Page): ReadwiseHighlight[] => {
       highlighted_at: new Date(highlight.createdAt).toISOString(),
       category: 'articles',
       image_url: page.image,
-      location,
-      location_type: location ? 'page' : 'order',
+      location: highlight.highlightPositionPercent || undefined,
+      location_type: 'order',
       note: highlight.annotation || undefined,
       source_type: 'omnivore',
       source_url: page.url,

--- a/packages/api/test/routers/integrations.test.ts
+++ b/packages/api/test/routers/integrations.test.ts
@@ -132,23 +132,16 @@ describe('Integrations routers', () => {
               refresh: true,
             }
             // create highlight
-            const location = 109
-            const patch = `@@ -${location + 1},16 +${location + 1},36 @@
- . We're
-+%3Comnivore_highlight%3E
- humbled
-@@ -254,16 +254,37 @@
- h in the
-+%3C/omnivore_highlight%3E
-  coming`
+            const highlightPositionPercent = 25
             highlight = {
               createdAt: new Date(),
               id: 'test id',
-              patch,
+              patch: 'test patch',
               quote: 'test quote',
               shortId: 'test shortId',
               updatedAt: new Date(),
               userId: user.id,
+              highlightPositionPercent,
             }
             await addHighlightToPage(page.id, highlight, ctx)
             // create highlights data for integration request
@@ -162,8 +155,8 @@ describe('Integrations routers', () => {
                   highlighted_at: highlight.createdAt.toISOString(),
                   category: 'articles',
                   image_url: page.image,
-                  location,
-                  location_type: 'page',
+                  location: highlightPositionPercent,
+                  location_type: 'order',
                   note: highlight.annotation,
                   source_type: 'omnivore',
                   source_url: page.url,


### PR DESCRIPTION
<img width="740" alt="Screenshot 2022-10-28 at 5 45 36 PM" src="https://user-images.githubusercontent.com/12963965/198558158-9e8cddb9-e3a4-40b1-948b-28727937e3fd.png">

We should not display the page number here because this is not a book