### PR TITLE
Fix not correctly set confirmation code from Gmail in Spanish

### DIFF
--- a/packages/inbound-email-handler/src/newsletter.ts
+++ b/packages/inbound-email-handler/src/newsletter.ts
@@ -10,7 +10,7 @@ interface Unsubscribe {
 const EMAIL_CONFIRMATION_CODE_RECEIVED_TOPIC = 'emailConfirmationCodeReceived'
 const CONFIRMATION_EMAIL_SENDER_ADDRESS = 'forwarding-noreply@google.com'
 // check unicode parentheses too
-const CONFIRMATION_CODE_PATTERN = /^[(（]#\d+[)）]/u
+const CONFIRMATION_CODE_PATTERN = /\d+/u
 const UNSUBSCRIBE_HTTP_URL_PATTERN = /<(https?:\/\/[^>]*)>/
 const UNSUBSCRIBE_MAIL_TO_PATTERN = /<mailto:([^>]*)>/
 
@@ -55,7 +55,7 @@ export const getConfirmationCode = (subject: string): string | undefined => {
   if (matches) {
     // get the number code only
     // e.g. (#123456) => 123456
-    return matches[0].slice(2, -1)
+    return matches[0]
   }
   return undefined
 }

--- a/packages/inbound-email-handler/test/newsletter.test.ts
+++ b/packages/inbound-email-handler/test/newsletter.test.ts
@@ -25,6 +25,14 @@ describe('Confirmation email test', () => {
 
       expect(isConfirmationEmail(from, subject)).to.be.true
     })
+
+    it('returns true when email is in Spanish', () => {
+      from = 'Equipo de Gmail <forwarding-noreply@google.com>'
+      subject =
+        'Confirmación de reenvío de 123456789 (n.º Gmail) - Recibir correo de test@omnivore.app'
+
+      expect(isConfirmationEmail(from, subject)).to.be.true
+    })
   })
 
   describe('#getConfirmationCode()', () => {
@@ -41,6 +49,13 @@ describe('Confirmation email test', () => {
     it('returns the confirmation code from the Google Japan email', () => {
       code = '123456789'
       subject = `（#${code}）SWG の転送の確認 - test@omnivore.app からメールを受信`
+
+      expect(getConfirmationCode(subject)).to.equal(code)
+    })
+
+    it('returns the confirmation code from the Spanish email', () => {
+      code = '123456789'
+      subject = `Confirmación de reenvío de ${code} (n.º Gmail) - Recibir correo de test@omnivore.app`
 
       expect(getConfirmationCode(subject)).to.equal(code)
     })


### PR DESCRIPTION
* Forward text if html is not found in the email
* Fix not correctly set confirmation code from Gmail in Spanish