### PR TITLE
Fix bug causing quotes to appear around notes on iOS

### DIFF
--- a/apple/OmnivoreKit/Sources/Views/Article/OmnivoreWebView.swift
+++ b/apple/OmnivoreKit/Sources/Views/Article/OmnivoreWebView.swift
@@ -429,7 +429,7 @@ public enum WebViewDispatchEvent {
         let encoder = JSONEncoder()
         if let encoded = try? encoder.encode(annotation) {
           let str = String(decoding: encoded, as: UTF8.self)
-          return "event.annotation = '\(str)';"
+          return "event.annotation = \(str);"
         } else {
           throw BasicError.message(messageText: "Unable to serialize highlight note.")
         }


### PR DESCRIPTION
When serialized to a JSON string quotes are added, so we were
double quoting our strings.
