### PR TITLE
Use greedy matching on the GitHub title regex

### DIFF
--- a/packages/content-handler/src/websites/github-handler.ts
+++ b/packages/content-handler/src/websites/github-handler.ts
@@ -35,7 +35,7 @@ export class GitHubHandler extends ContentHandler {
     if (twitterTitle && twitterTitleContent) {
       twitterTitle.setAttribute(
         'content',
-        twitterTitleContent.replace(/GitHub - .*\//, '')
+        twitterTitleContent.replace(/GitHub - (.*?)\//, '')
       )
     }
 

--- a/packages/content-handler/test/github-handler.test.ts
+++ b/packages/content-handler/test/github-handler.test.ts
@@ -1,0 +1,32 @@
+import { GitHubHandler } from '../src/websites/github-handler'
+import 'mocha'
+import { expect } from 'chai'
+import { parseHTML } from 'linkedom'
+
+describe('preParse', () => {
+  it('should update the title on the page', async () => {
+    const dom = parseHTML(
+      `
+      <html>
+        <head>
+          <meta name="twitter:title"
+                content="GitHub - owner/repo: This is a title with a / char"
+          />
+        </head>
+        <body>
+          <article>this is the content of the article</article>
+        </body>
+      </html>
+      `
+    )
+    const result = await new GitHubHandler().preParse(
+      'https://github.com/siyuan-note/siyuan',
+      dom.document
+    )
+    const title = result
+      .querySelector(`meta[name='twitter:title']`)
+      ?.getAttribute('content')
+
+    expect(title).to.eq(`repo: This is a title with a / char`)
+  })
+})


### PR DESCRIPTION
This fixes issues with titles that have slashes (/) in their title
as the regex match would look for the last possible matching
slash.
