### PR TITLE
Save listen position independent of read position when listening to articles

### DIFF
--- a/apple/OmnivoreKit/Sources/Models/CoreData/CoreDataModel.xcdatamodeld/CoreDataModel.xcdatamodel/contents
+++ b/apple/OmnivoreKit/Sources/Models/CoreData/CoreDataModel.xcdatamodeld/CoreDataModel.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="21279" systemVersion="21G115" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="21512" systemVersion="21G115" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="Highlight" representedClassName="Highlight" syncable="YES" codeGenerationType="class">
         <attribute name="annotation" optional="YES" attributeType="String"/>
         <attribute name="createdAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
@@ -31,6 +31,9 @@
         <attribute name="imageURLString" optional="YES" attributeType="String"/>
         <attribute name="isArchived" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="language" optional="YES" attributeType="String"/>
+        <attribute name="listenPositionIndex" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="listenPositionOffset" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <attribute name="listenPositionTime" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
         <attribute name="localPDF" optional="YES" attributeType="String"/>
         <attribute name="onDeviceImageURLString" optional="YES" attributeType="String"/>
         <attribute name="originalHtml" optional="YES" attributeType="String"/>

--- a/apple/OmnivoreKit/Sources/Models/DataModels/FeedItem.swift
+++ b/apple/OmnivoreKit/Sources/Models/DataModels/FeedItem.swift
@@ -29,6 +29,8 @@ public struct LinkedItemAudioProperties {
   public let byline: String?
   public let imageURL: URL?
   public let language: String?
+  public let startIndex: Int
+  public let startOffset: Double
 }
 
 // Internal model used for parsing a push notification object only
@@ -149,7 +151,9 @@ public extension LinkedItem {
       title: unwrappedTitle,
       byline: formattedByline,
       imageURL: imageURL,
-      language: language
+      language: language,
+      startIndex: Int(listenPositionIndex),
+      startOffset: listenPositionOffset
     )
   }
 
@@ -174,7 +178,10 @@ public extension LinkedItem {
     newAnchorIndex: Int? = nil,
     newIsArchivedValue: Bool? = nil,
     newTitle: String? = nil,
-    newDescription: String? = nil
+    newDescription: String? = nil,
+    listenPositionIndex: Int? = nil,
+    listenPositionOffset: Double? = nil,
+    listenPositionTime: Double? = nil
   ) {
     context.perform {
       if let newReadingProgress = newReadingProgress {
@@ -195,6 +202,18 @@ public extension LinkedItem {
 
       if let newDescription = newDescription {
         self.descriptionText = newDescription
+      }
+
+      if let listenPositionIndex = listenPositionIndex {
+        self.listenPositionIndex = Int64(listenPositionIndex)
+      }
+
+      if let listenPositionOffset = listenPositionOffset {
+        self.listenPositionOffset = listenPositionOffset
+      }
+
+      if let listenPositionTime = listenPositionTime {
+        self.listenPositionTime = listenPositionTime
       }
 
       guard context.hasChanges else { return }

--- a/apple/OmnivoreKit/Sources/Services/DataService/Mutations/UpdateArticleListenProgressPublisher.swift
+++ b/apple/OmnivoreKit/Sources/Services/DataService/Mutations/UpdateArticleListenProgressPublisher.swift
@@ -1,0 +1,20 @@
+import CoreData
+import Foundation
+import Models
+import SwiftGraphQL
+
+public extension DataService {
+  func updateLinkListeningProgress(itemID: String, listenIndex: Int, listenOffset: Double, listenTime: Double) {
+    backgroundContext.perform { [weak self] in
+      guard let self = self else { return }
+      guard let linkedItem = LinkedItem.lookup(byID: itemID, inContext: self.backgroundContext) else { return }
+
+      linkedItem.update(
+        inContext: self.backgroundContext,
+        listenPositionIndex: listenIndex,
+        listenPositionOffset: listenOffset,
+        listenPositionTime: listenTime
+      )
+    }
+  }
+}


### PR DESCRIPTION
When you restart an audio session it will start at the previous
listen position.
