### PR TITLE
Save PDF configuration changes

### DIFF
--- a/apple/Omnivore.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/apple/Omnivore.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -158,8 +158,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/PSPDFKit/PSPDFKit-SP",
       "state" : {
-        "branch" : "master",
-        "revision" : "e9757beadad1b30de84073d3c33c1cd0f7a94b80"
+        "revision" : "f4ba9790488b8f11c29cff35943e430efcdb8003",
+        "version" : "12.0.1"
       }
     },
     {

--- a/apple/OmnivoreKit/Package.swift
+++ b/apple/OmnivoreKit/Package.swift
@@ -69,6 +69,6 @@ var dependencies: [Package.Dependency] {
     .package(url: "https://github.com/google/GoogleSignIn-iOS", from: "6.2.2")
   ]
   // Comment out following line for macOS build
-  deps.append(.package(url: "https://github.com/PSPDFKit/PSPDFKit-SP", branch: "master"))
+  deps.append(.package(url: "https://github.com/PSPDFKit/PSPDFKit-SP", from: "12.0.1"))
   return deps
 }

--- a/apple/OmnivoreKit/Sources/App/PDFSupport/PDFViewer.swift
+++ b/apple/OmnivoreKit/Sources/App/PDFSupport/PDFViewer.swift
@@ -85,11 +85,10 @@ import Utils
             builder.shouldAskForAnnotationUsername = false
           }
           .updateControllerConfiguration { controller in
-            // Store config state so we only run this update closure once
             saveSettings(configuration: controller.configuration)
 
+            // Store config state so we only run this update closure once
             guard pdfStateObject.controllerNeedsConfig else { return }
-            print("document is valid", document.isValid)
             coordinator.setController(controller: controller, dataService: dataService)
 
             // Disable the Document Editor

--- a/apple/OmnivoreKit/Sources/App/PDFSupport/PDFViewer.swift
+++ b/apple/OmnivoreKit/Sources/App/PDFSupport/PDFViewer.swift
@@ -9,6 +9,17 @@ import Utils
   import Services
 
   struct PDFViewer: View {
+    enum SettingsKeys: String {
+      case pageTransitionKey = "PDFViewer.pageTransition"
+      case pageModeKey = "PDFViewer.pageModeKey"
+      case scrollDirectionKey = "PDFViewer.scrollDirectionKey"
+      case spreadFittingKey = "PDFViewer.spreadFittingKey"
+
+      func storedValue() -> UInt {
+        UInt(UserDefaults.standard.integer(forKey: rawValue))
+      }
+    }
+
     final class PDFStateObject: ObservableObject {
       @Published var document: Document?
       @Published var coordinator: PDFViewCoordinator?
@@ -33,16 +44,50 @@ import Utils
       self.viewModel = viewModel
     }
 
+    func saveSettings(configuration: PDFConfiguration) {
+      let defaults = UserDefaults.standard
+      defaults.set(configuration.pageTransition.rawValue, forKey: SettingsKeys.pageTransitionKey.rawValue)
+      defaults.set(configuration.pageMode.rawValue, forKey: SettingsKeys.pageModeKey.rawValue)
+      defaults.set(configuration.scrollDirection.rawValue, forKey: SettingsKeys.scrollDirectionKey.rawValue)
+      defaults.set(configuration.spreadFitting.rawValue, forKey: SettingsKeys.spreadFittingKey.rawValue)
+    }
+
+    func restoreSettings(builder: PDFConfigurationBuilder) {
+      if let pageTransition = PageTransition(rawValue: SettingsKeys.pageTransitionKey.storedValue()) {
+        builder.pageTransition = pageTransition
+      }
+
+      if let pageMode = PageMode(rawValue: SettingsKeys.pageModeKey.storedValue()) {
+        builder.pageMode = pageMode
+      }
+
+      if let scrollDirection = ScrollDirection(rawValue: SettingsKeys.scrollDirectionKey.storedValue()) {
+        builder.scrollDirection = scrollDirection
+      }
+
+      if let spreadFitting = PDFConfiguration.SpreadFitting(
+        rawValue: Int(SettingsKeys.spreadFittingKey.storedValue())
+      ) {
+        builder.spreadFitting = spreadFitting
+      }
+    }
+
     var body: some View {
       if let document = pdfStateObject.document, let coordinator = pdfStateObject.coordinator {
         PDFView(document: document)
           .useParentNavigationBar(true)
           .updateConfiguration { builder in
+            builder.settingsOptions = [.pageTransition, .pageMode, .scrollDirection, .spreadFitting, .appearance]
+
+            restoreSettings(builder: builder)
+
             builder.textSelectionShouldSnapToWord = true
             builder.shouldAskForAnnotationUsername = false
           }
           .updateControllerConfiguration { controller in
             // Store config state so we only run this update closure once
+            saveSettings(configuration: controller.configuration)
+
             guard pdfStateObject.controllerNeedsConfig else { return }
             print("document is valid", document.isValid)
             coordinator.setController(controller: controller, dataService: dataService)


### PR DESCRIPTION
These get reloaded after change, so if we don't save them, they
wont be applied to the document. The appearance setting doesn't
get reloaded so that one does not need to be saved (and we don't
have access to it).
