### PR TITLE
Fix NYTimes first few paragraph missing

### DIFF
--- a/packages/readabilityjs/Readability.js
+++ b/packages/readabilityjs/Readability.js
@@ -2785,7 +2785,7 @@ Readability.prototype = {
           return false;
         }
 
-        var parentClasses = node.parentNode.classList;
+        var parentClasses = node.parentNode?.classList || [];
         var haveToRemove =
           !this._isOmnivoreNode(node) && (
           (img > 1 && p / img < 0.5 && !this._hasAncestorTag(node, "figure")) ||

--- a/packages/readabilityjs/Readability.js
+++ b/packages/readabilityjs/Readability.js
@@ -244,6 +244,9 @@ Readability.prototype = {
     "apos": "'",
   },
 
+  // These are the classes that we skip when cleaning a tag
+  CLASSES_TO_SKIP: ["post-body", "StoryBodyCompanionColumn"],
+
   /**
    * Run any post-process modifications to article content as necessary.
    *
@@ -2782,6 +2785,7 @@ Readability.prototype = {
           return false;
         }
 
+        var parentClasses = node.parentNode.classList;
         var haveToRemove =
           !this._isOmnivoreNode(node) && (
           (img > 1 && p / img < 0.5 && !this._hasAncestorTag(node, "figure")) ||
@@ -2789,7 +2793,7 @@ Readability.prototype = {
           (input > Math.floor(p/3)) ||
           (!isList && headingDensity < 0.9 && contentLength < 25 && (img === 0 || img > 2) && !this._hasAncestorTag(node, "figure")) ||
           // ignores link density for the links inside the .post-body div (the main content)
-          (!isList && weight < 25 && linkDensity > 0.2 && !(node.parentElement.className.includes("post-body") && linkDensity === 1)) ||
+          (!isList && weight < 25 && linkDensity > 0.2 && !(this.CLASSES_TO_SKIP.some((c) => parentClasses.contains(c))) )||
           // some website like https://substack.com might have their custom styling of tweets
           // we should omit ignoring their particular case by checking against "tweet" classname
           (weight >= 25 && linkDensity > 0.5 && !(node.className === "tweet" && linkDensity === 1)) ||

--- a/packages/readabilityjs/test/test-pages/electrek/expected-metadata.json
+++ b/packages/readabilityjs/test/test-pages/electrek/expected-metadata.json
@@ -4,7 +4,7 @@
   "dir": null,
   "excerpt": "Solar-cell manufacturing giant Q Cells today announced that it's opening a new solar panel manufacturing facility in Dalton, Georgia.",
   "siteName": "Electrek",
-  "siteIcon": "/favicon.ico",
+  "siteIcon": "http://fakehost/favicon.ico",
   "previewImage": "https://i0.wp.com/electrek.co/wp-content/uploads/sites/3/2022/05/georgia-solar-manufacturing.jpg?resize=1200%2C628&quality=82&strip=all&ssl=1",
   "publishedDate": "2022-05-26T15:57:59.000Z",
   "language": "English",

--- a/packages/readabilityjs/test/test-pages/electrek/expected.html
+++ b/packages/readabilityjs/test/test-pages/electrek/expected.html
@@ -35,6 +35,9 @@
         <p>
             <em>UnderstandSolar is a free service that links you to top-rated solar installers in your region for personalized solar estimates. Tesla now offers price matching, so it’s important to shop for the best quotes.&nbsp;<a href="https://understandsolarenergy.com/form/?lsid=511&s1=%7Bs1%7D#step1" target="_blank" rel="noreferrer noopener">Click here to learn more and get your quotes</a>. — *ad</em>.
         </p>
+        <div id="after_disclaimer_placement">
+            <p> You’re reading Electrek— experts who break news about <a href="https://electrek.co/guides/tesla/">Tesla</a>, <a href="https://electrek.co/best-electric-vehicle-prices/">electric vehicles,</a> and <a href="https://electrek.co/guides/egeb/">green energy</a>, day after day. Be sure to check out our <a href="https://electrek.co/">homepage</a> for all the latest news, and follow Electrek on <a href="http://twitter.com/electrekco">Twitter</a>, <a href="https://www.facebook.com/electrekco/">Facebook</a>, and <a href="https://www.linkedin.com/company/electrek">LinkedIn</a> to stay in the loop. Don’t know where to start? Check out our <a href="https://youtube.com/c/electrekco">YouTube channel</a>&nbsp;for the latest reviews. </p>
+        </div>
         <hr>
         <p>
             <a href="https://www.youtube.com/channel/UCcOIZzJgLCyMPILY7-1Vsdg?sub_confirmation=1">Subscribe to Electrek on YouTube for exclusive videos</a> and subscribe to the <a href="https://www.electrek.co/guides/electrek-podcast">podcast</a>.

--- a/packages/readabilityjs/test/test-pages/nytimes.com/expected-metadata.json
+++ b/packages/readabilityjs/test/test-pages/nytimes.com/expected-metadata.json
@@ -1,0 +1,12 @@
+{
+  "title": "How Twitter Will Change as a Private Company",
+  "byline": "Kate Conger",
+  "dir": null,
+  "excerpt": "The social media company went public in 2013. But Elon Musk is taking it private as part of his acquisition of the firm. Here’s what that means.",
+  "siteName": null,
+  "siteIcon": "http://fakehost/vi-assets/static-assets/favicon-d2483f10ef688e6f89e23806b9700298.ico",
+  "previewImage": "https://static01.nyt.com/images/2022/10/29/business/00jpTWITTER-PRIVATE2-print/00MUSK-TWITTER-facebookJumbo.jpg",
+  "publishedDate": "2022-10-28T09:00:25.000Z",
+  "language": "English",
+  "readerable": true
+}

--- a/packages/readabilityjs/test/test-pages/nytimes.com/expected.html
+++ b/packages/readabilityjs/test/test-pages/nytimes.com/expected.html
@@ -35,6 +35,15 @@
                     </header>
                     <section name="articleBody">
                         <div>
+                            <p>
+                                <em>Elon Musk closes his purchase of Twitter and fires several top executives. </em><a href="https://www.nytimes.com/live/2022/10/28/business/elon-musk-twitter" title=""><em>Follow for the latest news updates</em></a><em>.</em>
+                            </p>
+                            <p> SAN FRANCISCO — In August 2018, Elon Musk called <a href="https://www.nytimes.com/topic/person/michael-s-dell" title="">Michael Dell</a> for advice. </p>
+                            <p> Mr. Musk, who was <a href="https://www.nytimes.com/2018/08/07/business/tesla-stock-elon-musk-private.html" title="">trying to take Tesla, his electric car company, private</a>, quizzed Mr. Dell, who had done that very thing with <a href="https://archive.nytimes.com/dealbook.nytimes.com/2013/02/05/dell-sets-23-8-billion-deal-to-go-private/" title="">his eponymous computer company in 2013</a>, about the process and the best lawyers to use for the complicated transaction. </p>
+                            <p> “I was really asking him about — did he find being private was good?” Mr. Musk recalled in a <a href="https://storage.courtlistener.com/recap/gov.uscourts.cand.330489/gov.uscourts.cand.330489.403.0.pdf" title="" rel="noopener noreferrer" target="_blank">deposition</a> about the Tesla effort. “Did he regret going private?” </p>
+                            <p> Mr. Dell warned Mr. Musk that it was “a very difficult process” but that he was glad to have done it, according to court filings. </p>
+                        </div>
+                        <div>
                             <p> Now, Mr. Musk, who did not end up taking Tesla private, is doing so with Twitter. As part of his $44 billion acquisition of the social media service, which closed on Thursday, he is delisting the company’s stock and taking it out of the hands of public shareholders. </p>
                             <p> Making Twitter a private company gives Mr. Musk some advantages. Unlike publicly traded companies, privately held firms do not have to make quarterly public disclosures about their performance. They are also subject to less regulatory scrutiny and can be more tightly controlled by an owner. That means Mr. Musk can make over Twitter — including tweaking the platform’s content rules, its finances and its priorities — without having to consider the worries of the investing public. </p>
                             <p> “It’s hard to run a public company if you think you should be the one running it and you’re not open to other views from people, like stockholders,” said Brian J.M. Quinn, a professor at Boston College Law School. “By taking it private, you feel like you have a lot more flexibility.” </p>

--- a/packages/readabilityjs/test/test-pages/nytimes.com/expected.html
+++ b/packages/readabilityjs/test/test-pages/nytimes.com/expected.html
@@ -1,0 +1,103 @@
+<DIV class="page" id="readability-page-1">
+    <div aria-hidden="false">
+        <main id="site-content">
+            <div>
+                <article id="story">
+                    <header>
+                        <p id="article-summary"> The social media company went public in 2013. But Elon Musk is taking it private as part of his acquisition of the firm. Here’s what that means. </p>
+                        <div data-testid="photoviewer-wrapper">
+                            <figure aria-label="media" role="group">
+                                <div>
+                                    <picture>
+                                        <source media="(max-width: 599px) and (min-device-pixel-ratio: 3),(max-width: 599px) and (-webkit-min-device-pixel-ratio: 3),(max-width: 599px) and (min-resolution: 3dppx),(max-width: 599px) and (min-resolution: 288dpi)" srcset="
+                                  https://static01.nyt.com/images/2022/10/29/business/00jpTWITTER-PRIVATE2-print/merlin_214496130_63f02e73-7e2f-47ef-9597-f0b9fc9d20c3-mobileMasterAt3x.jpg?quality=75&auto=webp&disable=upscale&width=600
+                                ">
+                                        <source media="(max-width: 599px) and (min-device-pixel-ratio: 2),(max-width: 599px) and (-webkit-min-device-pixel-ratio: 2),(max-width: 599px) and (min-resolution: 2dppx),(max-width: 599px) and (min-resolution: 192dpi)" srcset="
+                                  https://static01.nyt.com/images/2022/10/29/business/00jpTWITTER-PRIVATE2-print/merlin_214496130_63f02e73-7e2f-47ef-9597-f0b9fc9d20c3-mobileMasterAt3x.jpg?quality=75&auto=webp&disable=upscale&width=1200
+                                ">
+                                        <source media="(max-width: 599px) and (min-device-pixel-ratio: 1),(max-width: 599px) and (-webkit-min-device-pixel-ratio: 1),(max-width: 599px) and (min-resolution: 1dppx),(max-width: 599px) and (min-resolution: 96dpi)" srcset="
+                                  https://static01.nyt.com/images/2022/10/29/business/00jpTWITTER-PRIVATE2-print/merlin_214496130_63f02e73-7e2f-47ef-9597-f0b9fc9d20c3-mobileMasterAt3x.jpg?quality=75&auto=webp&disable=upscale&width=1800
+                                ">
+                                        <img alt="Elon Musk plans to change Twitter from a public to a privately held company." src="https://static01.nyt.com/images/2022/10/29/business/00jpTWITTER-PRIVATE2-print/merlin_214496130_63f02e73-7e2f-47ef-9597-f0b9fc9d20c3-articleLarge.jpg?quality=75&auto=webp&disable=upscale" srcset="
+                                  https://static01.nyt.com/images/2022/10/29/business/00jpTWITTER-PRIVATE2-print/merlin_214496130_63f02e73-7e2f-47ef-9597-f0b9fc9d20c3-articleLarge.jpg?quality=75&auto=webp  600w,
+                                  https://static01.nyt.com/images/2022/10/29/business/00jpTWITTER-PRIVATE2-print/merlin_214496130_63f02e73-7e2f-47ef-9597-f0b9fc9d20c3-jumbo.jpg?quality=75&auto=webp        1024w,
+                                  https://static01.nyt.com/images/2022/10/29/business/00jpTWITTER-PRIVATE2-print/merlin_214496130_63f02e73-7e2f-47ef-9597-f0b9fc9d20c3-superJumbo.jpg?quality=75&auto=webp   2048w
+                                " sizes="((min-width: 600px) and (max-width: 1004px)) 84vw, (min-width: 1005px) 60vw, 100vw" decoding="async" width="600" height="400">
+                                    </picture>
+                                </div>
+                                <figcaption>
+                                    <span aria-hidden="true">Elon Musk plans to change Twitter from a public to a privately held company.</span><span><span>Credit...</span><span><span aria-hidden="false">Jason Henry for The New York Times</span></span></span>
+                                </figcaption>
+                            </figure>
+                        </div>
+                        <p><time datetime="2022-10-28T05:00:25-04:00"><span>Oct. 28, 2022</span></time>
+                        </p>
+                    </header>
+                    <section name="articleBody">
+                        <div>
+                            <p> Now, Mr. Musk, who did not end up taking Tesla private, is doing so with Twitter. As part of his $44 billion acquisition of the social media service, which closed on Thursday, he is delisting the company’s stock and taking it out of the hands of public shareholders. </p>
+                            <p> Making Twitter a private company gives Mr. Musk some advantages. Unlike publicly traded companies, privately held firms do not have to make quarterly public disclosures about their performance. They are also subject to less regulatory scrutiny and can be more tightly controlled by an owner. That means Mr. Musk can make over Twitter — including tweaking the platform’s content rules, its finances and its priorities — without having to consider the worries of the investing public. </p>
+                            <p> “It’s hard to run a public company if you think you should be the one running it and you’re not open to other views from people, like stockholders,” said Brian J.M. Quinn, a professor at Boston College Law School. “By taking it private, you feel like you have a lot more flexibility.” </p>
+                            <p> Here’s how Twitter is set to change as a private company under Mr. Musk. </p>
+                            <h2 id="link-1449895"> How is Mr. Musk taking Twitter private? </h2>
+                            <p> As part of buying Twitter, Mr. Musk is merging the social media company with <a href="https://www.nytimes.com/2022/10/06/technology/elon-musk-x.html" title="">X Holdings</a>, a corporate entity that he established in Delaware to handle the deal. X is buying out all of Twitter’s stock and will control the service, and Mr. Musk will control the holding company. </p>
+                        </div>
+                        <div data-testid="photoviewer-wrapper">
+                            <figure aria-label="media" role="group">
+                                <div>
+                                    <p><span>Image</span></p>
+                                </div>
+                                <figcaption>
+                                    <span aria-hidden="true">Twitter’s logo on the screens of the New York Stock Exchange during the company’s initial public offering in 2013.</span><span><span>Credit...</span><span><span aria-hidden="false">Lucas Jackson/Reuters</span></span></span>
+                                </figcaption>
+                            </figure>
+                        </div>
+                        <div>
+                            <h2 id="link-53d6d93b"> What happens to Twitter’s stock? </h2>
+                            <p> Twitter will be delisted from the New York Stock Exchange and its shares will no longer trade on public markets as of Nov. 8, according to <a href="https://www.sec.gov/Archives/edgar/data/876661/000087666122000890/xslF25X02/primary_doc.xml" title="" rel="noopener noreferrer" target="_blank">a securities filing</a>. In September, Twitter’s shareholders approved the company’s sale to Mr. Musk and agreed to sell their stock to him for $54.20 a share. Investors will be able to claim the cash value of their shares. </p>
+                        </div>
+                        <div>
+                            <h2 id="link-cc3eb45"> What happens to Twitter’s board of directors? </h2>
+                            <p> With the deal’s completion, <a href="https://www.nytimes.com/2022/10/04/technology/twitter-board-elon-musk.html" title="">Twitter’s board of directors</a> will dissolve and its nine members will no longer preside over the company’s operations. Mr. Musk will most likely appoint a new board made up of friends and investors who helped fund the acquisition. The new board will be responsible for plotting Twitter’s trajectory as a private company. </p>
+                            <p> “It will still be required by law to have a board of directors, and that would probably include Elon Musk and some of the other big equity investors in the company,” said Eric Talley, a professor at Columbia Law School. “I expect Mr. Musk will run it as a somewhat friendly dictatorship.” </p>
+                            <h2 id="link-3f9ca2b1"> What happens to Twitter’s top executives? </h2>
+                            <p> Mr. Musk has already started cleaning house, with several of Twitter’s top executives <a href="https://www.nytimes.com/2022/10/27/technology/elon-musk-twitter-deal-complete.html" title="">getting fired on Thursday</a>. </p>
+                            <p> The executives who were fired include <a href="https://www.nytimes.com/2021/11/29/technology/parag-agrawal-twitter.html" title="">Parag Agrawal</a>, Twitter’s chief executive, who has clashed publicly and privately with Mr. Musk. When Mr. Musk complained this year that Twitter had an unchecked spam problem, Mr. Agrawal tweeted to rebut his claims. Mr. Musk responded with a poop emoji. </p>
+                            <p> At another point, Mr. Agrawal texted Mr. Musk, telling the billionaire that his criticisms were harming Twitter, according to a <a href="https://www.documentcloud.org/documents/23112929-elon-musk-text-exhibits-twitter-v-musk" title="" rel="noopener noreferrer" target="_blank">court filing</a>. </p>
+                            <p> “This is a waste of time,” Mr. Musk retorted. </p>
+                            <p> Other executives who were fired include Ned Segal, Twitter’s chief financial officer; Vijaya Gadde, the top legal and policy executive; and Sean Edgett, the general counsel. </p>
+                        </div>
+                        <div>
+                            <p> Under the merger agreement, Mr. Agrawal was potentially set to receive a golden parachute worth about $60 million, with Mr. Segal to receive $46 million, while Ms. Gadde would receive about $20 million. It was not immediately clear whether Mr. Musk intended to make the payments. </p>
+                        </div>
+                        <div data-testid="photoviewer-wrapper">
+                            <figure aria-label="media" role="group">
+                                <div>
+                                    <p><span>Image</span></p>
+                                </div>
+                                <figcaption>
+                                    <span aria-hidden="true">Parag Agrawal was fired by Mr. Musk as Twitter’s chief executive on Thursday. </span><span><span>Credit...</span><span><span aria-hidden="false">Kevin Dietsch/Getty Images</span></span></span>
+                                </figcaption>
+                            </figure>
+                        </div>
+                        <div>
+                            <h2 id="link-79d7db93"> What about Twitter’s employees? </h2>
+                            <p> Twitter has about 7,500 employees. Some of them <a href="https://www.nytimes.com/2022/10/21/technology/twitter-employees-elon-musk.html" title="">have been jittery</a> for months about the company’s sale to Mr. Musk. Many could face layoffs or job changes as their new owner takes over. </p>
+                            <p> Their compensation is also set to change. Employees typically receive stock options in the company. But, with the delisting of Twitter’s stock, employees are set to be cashed out for shares they already have and to be paid with cash bonuses going forward, instead of the stock options they were scheduled to receive, according to the merger agreement. Some <a href="https://www.nytimes.com/2022/10/21/technology/twitter-employees-elon-musk.html" title="">employees have worried</a> that Mr. Musk may not honor the agreement. </p>
+                            <p> “Most of these employees have been in a public company and are used to public option grants, which are liquid,” Mr. Quinn said. “They will have to come up with some other Silicon Valley-friendly method of keeping people around.” </p>
+                            <h2 id="link-13174875"> What financial pressures will Twitter face as a private company? </h2>
+                            <p> By going private, Twitter will avoid some public scrutiny since it will no longer be required to make quarterly disclosures about the health of its business. This will give Mr. Musk some flexibility as he changes Twitter. </p>
+                            <p> But he will face pressure from the banks that lent him $12.5 billion for the deal to begin repaying his debt. The cost of repaying those loans could run as high as $1 billion a year, financial analysts said. </p>
+                        </div>
+                        <div>
+                            <p> “He has less public pressure, but he has a lot of private pressure from the banks to make the payments,” Mr. Quinn said of Mr. Musk. “Like almost every other private-equity take-private, he’s going to need a manager who is very focused on operations, being lean and being able to pay the bills on a day-to-day basis.” </p>
+                            <p> Mr. Musk also took about $7.1 billion from equity investors to push the deal through. He may also face pressure from those investors, who might expect him to take Twitter public again at some point so that they can recoup their investment. </p>
+                            <p> In some take-private deals, owners have opted to sell branches of their companies to pay their debts. Mr. Musk could choose to do the same at Twitter. </p>
+                            <p> “It’s conceivable that some aspects of Twitter could potentially be carved off, sold off or spun off to raise money that could go toward paying the debt,” Mr. Talley said. “Twitter kind of is pared down to its core mission right now. They would have to get a little creative.” </p>
+                        </div>
+                    </section>
+                </article>
+            </div>
+        </main>
+    </div>
+</DIV>

--- a/packages/readabilityjs/test/test-pages/nytimes.com/source.html
+++ b/packages/readabilityjs/test/test-pages/nytimes.com/source.html
@@ -1,0 +1,11853 @@
+<!DOCTYPE html>
+<html
+  lang="en"
+  class="story nytapp-vi-article"
+  xmlns:og="http://opengraphprotocol.org/schema/"
+>
+<head>
+    <meta charset="utf-8" />
+    <title data-rh="true">
+        How Twitter Will Change as a Private Company Under Elon Musk - The New
+        York Times
+    </title>
+    <meta
+      data-rh="true"
+      name="robots"
+      content="noarchive, max-image-preview:large"
+    />
+    <meta
+      data-rh="true"
+      name="description"
+      content="The social media company went public in 2013. But Elon Musk is taking it private as part of his acquisition of the firm. Here’s what that means."
+    />
+    <meta
+      data-rh="true"
+      property="og:url"
+      content="https://www.nytimes.com/2022/10/28/technology/twitter-changes.html"
+    />
+    <meta data-rh="true" property="og:type" content="article" />
+    <meta
+      data-rh="true"
+      property="og:title"
+      content="How Twitter Will Change as a Private Company"
+    />
+    <meta
+      data-rh="true"
+      property="og:image"
+      content="https://static01.nyt.com/images/2022/10/29/business/00jpTWITTER-PRIVATE2-print/00MUSK-TWITTER-facebookJumbo.jpg"
+    />
+    <meta
+      data-rh="true"
+      property="og:image:alt"
+      content="Elon Musk plans to change Twitter from a public to a privately held company."
+    />
+    <meta
+      data-rh="true"
+      property="og:description"
+      content="The social media company went public in 2013. But Elon Musk is taking it private as part of his acquisition of the firm. Here’s what that means."
+    />
+    <meta
+      data-rh="true"
+      property="twitter:url"
+      content="https://www.nytimes.com/2022/10/28/technology/twitter-changes.html"
+    />
+    <meta
+      data-rh="true"
+      property="twitter:title"
+      content="How Twitter Will Change as a Private Company"
+    />
+    <meta
+      data-rh="true"
+      property="twitter:description"
+      content="The social media company went public in 2013. But Elon Musk is taking it private as part of his acquisition of the firm. Here’s what that means."
+    />
+    <meta
+      data-rh="true"
+      property="twitter:image"
+      content="https://static01.nyt.com/images/2022/10/29/business/00jpTWITTER-PRIVATE2-print/00MUSK-TWITTER-videoSixteenByNine3000.jpg"
+    />
+    <meta
+      data-rh="true"
+      property="twitter:image:alt"
+      content="Elon Musk plans to change Twitter from a public to a privately held company."
+    />
+    <meta
+      data-rh="true"
+      property="twitter:card"
+      content="summary_large_image"
+    />
+    <link
+      data-rh="true"
+      rel="canonical"
+      href="https://www.nytimes.com/2022/10/28/technology/twitter-changes.html"
+    />
+    <link
+      data-rh="true"
+      rel="alternate"
+      href="nyt://article/1d7bf428-be78-562f-9287-bdbdf47502a0"
+    />
+    <link
+      data-rh="true"
+      rel="amphtml"
+      href="https://www.nytimes.com/2022/10/28/technology/twitter-changes.amp.html"
+    />
+    <link
+      data-rh="true"
+      rel="alternate"
+      type="application/json+oembed"
+      href="https://www.nytimes.com/svc/oembed/json/?url=https%3A%2F%2Fwww.nytimes.com%2F2022%2F10%2F28%2Ftechnology%2Ftwitter-changes.html"
+      title="How Twitter Will Change as a Private Company"
+    />
+    <script data-rh="true" type="application/ld+json">
+        {
+            "@context": "http://schema.org",
+            "@type": "NewsArticle",
+            "description": "The social media company went public in 2013. But Elon Musk is taking it private as part of his acquisition of the firm. Here’s what that means.",
+            "image": [
+                {
+                    "@context": "http://schema.org",
+                    "@type": "ImageObject",
+                    "url": "https://static01.nyt.com/images/2022/10/29/business/00jpTWITTER-PRIVATE2-print/00MUSK-TWITTER-videoSixteenByNineJumbo1600.jpg",
+                    "height": 900,
+                    "width": 1600,
+                    "caption": "Elon Musk plans to change Twitter from a public to a privately held company."
+                },
+                {
+                    "@context": "http://schema.org",
+                    "@type": "ImageObject",
+                    "url": "https://static01.nyt.com/images/2022/10/29/business/00jpTWITTER-PRIVATE2-print/merlin_214496130_63f02e73-7e2f-47ef-9597-f0b9fc9d20c3-superJumbo.jpg",
+                    "height": 1365,
+                    "width": 2048,
+                    "caption": "Elon Musk plans to change Twitter from a public to a privately held company."
+                },
+                {
+                    "@context": "http://schema.org",
+                    "@type": "ImageObject",
+                    "url": "https://static01.nyt.com/images/2022/10/29/business/00jpTWITTER-PRIVATE2-print/00MUSK-TWITTER-mediumSquareAt3X.jpg",
+                    "height": 1800,
+                    "width": 1800,
+                    "caption": "Elon Musk plans to change Twitter from a public to a privately held company."
+                }
+            ],
+            "mainEntityOfPage": "https://www.nytimes.com/2022/10/28/technology/twitter-changes.html",
+            "url": "https://www.nytimes.com/2022/10/28/technology/twitter-changes.html",
+            "inLanguage": "en",
+            "author": [
+                {
+                    "@context": "http://schema.org",
+                    "@type": "Person",
+                    "url": "https://www.nytimes.com/by/kate-conger",
+                    "name": "Kate Conger"
+                }
+            ],
+            "dateModified": "2022-10-28T18:54:00.000Z",
+            "datePublished": "2022-10-28T09:00:25.000Z",
+            "headline": "How Twitter Will Change as a Private Company Under Elon Musk",
+            "alternativeHeadline": "How Twitter Will Change as a Private Company",
+            "publisher": { "@id": "https://www.nytimes.com/#publisher" },
+            "copyrightHolder": { "@id": "https://www.nytimes.com/#publisher" },
+            "sourceOrganization": { "@id": "https://www.nytimes.com/#publisher" },
+            "copyrightYear": 2022,
+            "isAccessibleForFree": false,
+            "hasPart": {
+                "@type": "WebPageElement",
+                "isAccessibleForFree": false,
+                "cssSelector": ".meteredContent"
+            },
+            "isPartOf": {
+                "@type": ["CreativeWork", "Product"],
+                "name": "The New York Times",
+                "productID": "nytimes.com:basic"
+            }
+        }
+    </script>
+    <script data-rh="true" type="application/ld+json">
+        {
+            "@context": "http://schema.org",
+            "@type": "NewsMediaOrganization",
+            "name": "The New York Times",
+            "logo": {
+                "@context": "http://schema.org",
+                "@type": "ImageObject",
+                "url": "https://static01.nyt.com/images/misc/NYT_logo_rss_250x40.png",
+                "height": 40,
+                "width": 250
+            },
+            "url": "https://www.nytimes.com/",
+            "@id": "https://www.nytimes.com/#publisher",
+            "diversityPolicy": "https://www.nytco.com/diversity-and-inclusion-at-the-new-york-times/",
+            "ethicsPolicy": "https://www.nytco.com/who-we-are/culture/standards-and-ethics/",
+            "masthead": "https://www.nytimes.com/interactive/2020/09/08/admin/the-new-york-times-masthead.html",
+            "foundingDate": "1851-09-18",
+            "sameAs": "https://en.wikipedia.org/wiki/The_New_York_Times"
+        }
+    </script>
+    <meta
+      data-rh="true"
+      property="article:published_time"
+      content="2022-10-28T09:00:25.000Z"
+    />
+    <meta
+      data-rh="true"
+      property="article:modified_time"
+      content="2022-10-28T18:54:00.000Z"
+    />
+    <meta data-rh="true" http-equiv="Content-Language" content="en" />
+    <meta data-rh="true" name="articleid" content="100000008591603" />
+    <meta
+      data-rh="true"
+      name="nyt_uri"
+      content="nyt://article/1d7bf428-be78-562f-9287-bdbdf47502a0"
+    />
+    <meta
+      data-rh="true"
+      name="pubp_event_id"
+      content="pubp://event/859041c3b72144faae00a2b948a91e8a"
+    />
+    <meta
+      data-rh="true"
+      name="image"
+      content="https://static01.nyt.com/images/2022/10/29/business/00jpTWITTER-PRIVATE2-print/00MUSK-TWITTER-facebookJumbo.jpg"
+    />
+    <meta data-rh="true" name="byl" content="By Kate Conger" />
+    <meta
+      data-rh="true"
+      name="news_keywords"
+      content=",Elon Musk,Social Media,Mergers and Acquisitions,Stocks;Bonds,Computers and the Internet,Tech Industry,Board of directors,Appointments and Executive Changes,Stock Options ESPP,Parag Agrawal"
+    />
+    <meta data-rh="true" name="pdate" content="20221028" />
+    <meta data-rh="true" property="article:section" content="Technology" />
+    <meta data-rh="true" property="article:tag" content="Twitter" />
+    <meta data-rh="true" property="article:tag" content="Musk, Elon" />
+    <meta data-rh="true" property="article:tag" content="Social Media" />
+    <meta
+      data-rh="true"
+      property="article:tag"
+      content="Mergers, Acquisitions and Divestitures"
+    />
+    <meta data-rh="true" property="article:tag" content="Stocks and Bonds" />
+    <meta
+      data-rh="true"
+      property="article:tag"
+      content="Computers and the Internet"
+    />
+    <meta data-rh="true" property="article:tag" content="Boards of Directors" />
+    <meta
+      data-rh="true"
+      property="article:tag"
+      content="Appointments and Executive Changes"
+    />
+    <meta
+      data-rh="true"
+      property="article:tag"
+      content="Stock Options and Purchase Plans"
+    />
+    <meta data-rh="true" property="article:tag" content="Agrawal, Parag" />
+    <meta data-rh="true" property="article:opinion" content="false" />
+    <meta data-rh="true" property="article:content_tier" content="metered" />
+    <meta data-rh="true" name="CG" content="technology" />
+    <meta data-rh="true" name="SCG" content="" />
+    <meta data-rh="true" name="CN" content="" />
+    <meta data-rh="true" name="CT" content="" />
+    <meta data-rh="true" name="PT" content="article" />
+    <meta data-rh="true" name="PST" content="News" />
+    <meta
+      data-rh="true"
+      name="url"
+      content="https://www.nytimes.com/2022/10/28/technology/twitter-changes.html"
+    />
+    <meta
+      data-rh="true"
+      name="msapplication-starturl"
+      content="https://www.nytimes.com"
+    />
+    <meta
+      data-rh="true"
+      property="al:android:url"
+      content="nyt://article/1d7bf428-be78-562f-9287-bdbdf47502a0"
+    />
+    <meta
+      data-rh="true"
+      property="al:android:package"
+      content="com.nytimes.android"
+    />
+    <meta data-rh="true" property="al:android:app_name" content="NYTimes" />
+    <meta data-rh="true" name="twitter:app:name:googleplay" content="NYTimes" />
+    <meta
+      data-rh="true"
+      name="twitter:app:id:googleplay"
+      content="com.nytimes.android"
+    />
+    <meta
+      data-rh="true"
+      name="twitter:app:url:googleplay"
+      content="nyt://article/1d7bf428-be78-562f-9287-bdbdf47502a0"
+    />
+    <meta
+      data-rh="true"
+      property="al:iphone:url"
+      content="nytimes://www.nytimes.com/2022/10/28/technology/twitter-changes.html"
+    />
+    <meta
+      data-rh="true"
+      property="al:iphone:app_store_id"
+      content="284862083"
+    />
+    <meta data-rh="true" property="al:iphone:app_name" content="NYTimes" />
+    <meta
+      data-rh="true"
+      property="al:ipad:url"
+      content="nytimes://www.nytimes.com/2022/10/28/technology/twitter-changes.html"
+    />
+    <meta data-rh="true" property="al:ipad:app_store_id" content="357066198" />
+    <meta data-rh="true" property="al:ipad:app_name" content="NYTimes" />
+
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta property="fb:app_id" content="9869919170" />
+    <meta name="twitter:site" content="@nytimes" />
+    <meta name="slack-app-id" content="A0121HXPPTQ" />
+
+    <script>
+        const override = new URL(window.location).searchParams.get(
+          "sentryOverride"
+        );
+        if (override || Math.floor(Math.random() * 100) <= 1) {
+            document.write(
+              '<script src="https://js.sentry-cdn.com/7bc8bccf5c254286a99b11c68f6bf4ce.min.js" crossorigin="anonymous">' +
+              "<" +
+              "/script>"
+            );
+        }
+    </script>
+    <script>
+        if (window.Sentry) {
+            window.Sentry.onLoad(function () {
+                window.Sentry.init({
+                    maxBreadcrumbs: 30,
+                    release: "3c1954f16c628adac7f75074613cc5f18af9a916",
+                    environment: "prd",
+                    beforeSend: function (e, v) {
+                        if (
+                          /amazon-adsystem|ads-us|ampproject|amp4ads|pubads|2mdn|chartbeat|gsi|bk_addPageCtx|yimg|BOOMR|boomerang/.test(
+                            (v.originalException && v.originalException.stack) || ""
+                          )
+                        )
+                            return null;
+                        return e;
+                    },
+                });
+            });
+        }
+    </script>
+
+    <link
+      data-rh="true"
+      rel="shortcut icon"
+      href="/vi-assets/static-assets/favicon-d2483f10ef688e6f89e23806b9700298.ico"
+    />
+    <link
+      data-rh="true"
+      rel="apple-touch-icon"
+      href="/vi-assets/static-assets/apple-touch-icon-28865b72953380a40aa43318108876cb.png"
+    />
+    <link
+      data-rh="true"
+      rel="apple-touch-icon-precomposed"
+      sizes="144×144"
+      href="/vi-assets/static-assets/ios-ipad-144x144-28865b72953380a40aa43318108876cb.png"
+    />
+    <link
+      data-rh="true"
+      rel="apple-touch-icon-precomposed"
+      sizes="114×114"
+      href="/vi-assets/static-assets/ios-iphone-114x144-080e7ec6514fdc62bcbb7966d9b257d2.png"
+    />
+    <link
+      data-rh="true"
+      rel="apple-touch-icon-precomposed"
+      href="/vi-assets/static-assets/ios-default-homescreen-57x57-43808a4cd5333b648057a01624d84960.png"
+    />
+    <link
+      href="https://g1.nyt.com/fonts/css/web-fonts.d05a02583ca20b8afd5115f3ef8f1b8d134f743d.css"
+      rel="stylesheet"
+      type="text/css"
+    />
+    <link
+      rel="stylesheet"
+      href="/vi-assets/static-assets/global-f449cfd9976ad673ef2b7ab5098b85be.css"
+    />
+    <style>
+        [data-timezone] {
+            display: none;
+        }
+    </style>
+    <style
+      data-lights-css="k008qs 1dv1kvn 1hyfx7x nuvmzp 9e9ivx hnzl8o 6n7j50 1fe7a5q 1f8er69 10488qs 1e1s8k7 15uy5yv jq1cx6 yywogo vxcmzt 113xjf1 1baulvz 1sirvy4 1xlo06v 79elbk 1uhsiac 1ch24e9 1n1thlk 1w019mi 4m7ryc q1aqo6 1egxmzr 11s78ai 1u3tlb2 1yccqtv 1tel06d 12fr9lp 18z7m18 1aor85t 1hqnpie epjblv fwqvlz 1u4hfeb x15j1o tvohiw 1iwv8en 1n6z4y 1ly73wi rfqw0c 19vbshk l9onyx 1rxm0ex knunh2 etxl5s m3796d 1qej4jr go3nob 1nkuxcu 136d4fr 1r2mflq nwd8t8 bsn42l r4qme7 z3e15g sklrp3 10cldcv 1r7ky0e ew4tgv s99gbd 53u6y8 1pcai02 1t83a55 o7i5g3 1w3yqu0 m541wo 1dxpste cm1d69 95lxlj 8r08w0 1px5j0 76fnlk 1gcsvhw 1at4x3t 4od1bx 10ikpw rrnxp3 1q2w90k 1bymuyk ui9rw0 1f7ibof fzvsed 123u7tk tkwi90 1wr3we4 10698na nhjhh0 y3sf94 1r0gz1j 1o0kkht 1bvtpon 4skfbu 9eyi4s 1wb2lb aulw98 swbuts 1vxca1d z1t82k ejne5g hme5ai 1vkm6nb 1n0orw4 9hm018 pga13o 6yj280 8qgvsz 1a48zt4 1dyerrh rq4mmj y5g5d7 1u46b97 1e2jphy 233int 4anu6l at9mc1 c4adj9 1ho5u4o 13o0c9t a7htku 8z235g 1l8buln jevhma n8ff4n 8blifj 1sbuyqj d754w4 1xdhyk6 xaa95i 7v35jk fi5tub 2fg4z9 xactqe 11rqvxt fbykdt 1tnh8ll 1vxyf6h name 5j8bii duration delay timing-function"
+    >
+        @-webkit-keyframes animation-5j8bii {
+            from {
+                opacity: 0;
+            }
+            to {
+                opacity: 1;
+            }
+        }
+        @keyframes animation-5j8bii {
+            from {
+                opacity: 0;
+            }
+            to {
+                opacity: 1;
+            }
+        }
+        .css-k008qs {
+            display: -webkit-box;
+            display: -webkit-flex;
+            display: -ms-flexbox;
+            display: flex;
+        }
+        .css-1dv1kvn {
+            border: 0;
+            -webkit-clip: rect(0 0 0 0);
+            clip: rect(0 0 0 0);
+            height: 1px;
+            margin: -1px;
+            overflow: hidden;
+            padding: 0;
+            position: absolute;
+            width: 1px;
+        }
+        .css-1hyfx7x {
+            display: none;
+        }
+        .css-nuvmzp {
+            font-size: 14.25px;
+            font-family: nyt-franklin, helvetica, arial, sans-serif;
+            font-weight: 700;
+            text-transform: uppercase;
+            -webkit-letter-spacing: 0.7px;
+            -moz-letter-spacing: 0.7px;
+            -ms-letter-spacing: 0.7px;
+            letter-spacing: 0.7px;
+            line-height: 19px;
+        }
+        .css-nuvmzp:hover {
+            -webkit-text-decoration: underline;
+            text-decoration: underline;
+        }
+        .css-9e9ivx {
+            display: none;
+            font-size: 10px;
+            margin-left: auto;
+            text-transform: uppercase;
+        }
+        .hasLinks .css-9e9ivx {
+            display: block;
+        }
+        @media (min-width: 740px) {
+            .hasLinks .css-9e9ivx {
+                margin: none;
+                position: absolute;
+                right: 20px;
+            }
+        }
+        @media (min-width: 1024px) {
+            .hasLinks .css-9e9ivx {
+                display: none;
+            }
+        }
+        .css-hnzl8o {
+            display: inline-block;
+            font-size: 12px;
+            -webkit-transition: color 0.6s ease;
+            transition: color 0.6s ease;
+            color: #121212;
+        }
+        .css-hnzl8o:hover {
+            color: #666;
+        }
+        .css-6n7j50 {
+            display: inline;
+        }
+        .css-1fe7a5q {
+            display: inline-block;
+            height: 16px;
+            vertical-align: sub;
+            width: 16px;
+        }
+        .css-1f8er69 {
+            border: 0;
+            -webkit-clip: rect(0 0 0 0);
+            clip: rect(0 0 0 0);
+            height: 1px;
+            margin: -1px;
+            overflow: hidden;
+            padding: 0;
+            position: absolute;
+            width: 1px;
+            border-radius: 3px;
+            cursor: pointer;
+            font-family: nyt-franklin, helvetica, arial, sans-serif;
+            -webkit-transition: ease 0.6s;
+            transition: ease 0.6s;
+            white-space: nowrap;
+            vertical-align: middle;
+            background-color: transparent;
+            color: #000;
+            font-size: 11px;
+            line-height: 11px;
+            font-weight: 700;
+            -webkit-letter-spacing: 0.02em;
+            -moz-letter-spacing: 0.02em;
+            -ms-letter-spacing: 0.02em;
+            letter-spacing: 0.02em;
+            padding: 11px 12px 8px;
+            background: #fff;
+            display: inline-block;
+            left: 44px;
+            text-transform: uppercase;
+            -webkit-transition: none;
+            transition: none;
+        }
+        .css-1f8er69:active,
+        .css-1f8er69:focus {
+            -webkit-clip: auto;
+            clip: auto;
+            overflow: visible;
+            width: auto;
+            height: auto;
+        }
+        .css-1f8er69::-moz-focus-inner {
+            padding: 0;
+            border: 0;
+        }
+        .css-1f8er69:-moz-focusring {
+            outline: 1px dotted;
+        }
+        .css-1f8er69:disabled,
+        .css-1f8er69.disabled {
+            opacity: 0.5;
+            cursor: default;
+        }
+        .css-1f8er69:active,
+        .css-1f8er69.active {
+            background-color: #f7f7f7;
+        }
+        @media (min-width: 740px) {
+            .css-1f8er69:hover {
+                background-color: #f7f7f7;
+            }
+        }
+        .css-1f8er69:focus {
+            margin-top: 3px;
+            padding: 8px 8px 6px;
+        }
+        @media (min-width: 1024px) {
+            .css-1f8er69 {
+                left: 112px;
+            }
+        }
+        .css-10488qs {
+            display: none;
+        }
+        @media (min-width: 1024px) {
+            .css-10488qs {
+                display: inline-block;
+                position: relative;
+            }
+        }
+        .css-1e1s8k7 {
+            font-size: 11px;
+            text-align: center;
+            padding-bottom: 25px;
+        }
+        @media (min-width: 1024px) {
+            .css-1e1s8k7 {
+                padding: 0 3% 9px;
+            }
+        }
+        .css-1e1s8k7.dockVisible {
+            padding-bottom: 45px;
+        }
+        @media (min-width: 1024px) {
+            .css-1e1s8k7.dockVisible {
+                padding: 0 3% 45px;
+            }
+        }
+        @media (min-width: 1150px) {
+            .css-1e1s8k7 {
+                margin: 0 auto;
+                max-width: 1200px;
+            }
+        }
+        .NYTApp .css-1e1s8k7 {
+            display: none;
+        }
+        @media print {
+            .css-1e1s8k7 {
+                display: none;
+            }
+        }
+        .css-15uy5yv {
+            border-top: 1px solid #ebebeb;
+            padding-top: 9px;
+        }
+        .css-jq1cx6 {
+            color: #666;
+            font-family: nyt-franklin, helvetica, arial, sans-serif;
+            padding: 10px 0;
+            -webkit-text-decoration: none;
+            text-decoration: none;
+            white-space: nowrap;
+        }
+        .css-jq1cx6:hover {
+            -webkit-text-decoration: underline;
+            text-decoration: underline;
+        }
+        .css-yywogo {
+            color: var(--color-signal-editorial, #326891);
+        }
+        .css-yywogo:visited {
+            color: var(--color-signal-editorial, #326891);
+        }
+        .css-vxcmzt {
+            display: -webkit-inline-box;
+            display: -webkit-inline-flex;
+            display: -ms-inline-flexbox;
+            display: inline-flex;
+        }
+        .css-113xjf1 {
+            position: relative;
+            display: -webkit-inline-box;
+            display: -webkit-inline-flex;
+            display: -ms-inline-flexbox;
+            display: inline-flex;
+            vertical-align: top;
+        }
+        .css-1baulvz {
+            display: inline-block;
+        }
+        .css-1sirvy4 {
+            padding: 0;
+            margin-left: 0;
+            margin-right: 0;
+        }
+        @media (max-width: 420px) {
+            .css-1sirvy4 {
+                margin-left: -9px;
+                margin-right: -10px;
+            }
+        }
+        .css-1xlo06v {
+            color: #999;
+            display: inline;
+            margin-right: 12px;
+            width: 100%;
+        }
+        @media (max-width: 420px) {
+            .css-1xlo06v {
+                margin-right: 6px;
+            }
+        }
+        .css-1xlo06v > a,
+        .css-1xlo06v > button {
+            -webkit-text-decoration: none;
+            text-decoration: none;
+        }
+        .css-1xlo06v > a:focus,
+        .css-1xlo06v > button:focus {
+            display: inline-block;
+            outline: none;
+            box-shadow: 0 0 2px 1px rgb(0 95 204);
+        }
+        @supports selector(:focus-visible) {
+            .css-1xlo06v > a:focus,
+            .css-1xlo06v > button:focus {
+                box-shadow: none;
+            }
+            .css-1xlo06v > a:focus-visible,
+            .css-1xlo06v > button:focus-visible {
+                box-shadow: 0 0 2px 1px rgb(0 95 204);
+            }
+        }
+        .css-1xlo06v > a:focus {
+            border-radius: 100%;
+        }
+        .css-1xlo06v:last-of-type {
+            margin-right: 0;
+        }
+        .css-79elbk {
+            position: relative;
+        }
+        .css-1uhsiac {
+            height: auto;
+            width: auto;
+            border-radius: 100%;
+            background-color: transparent;
+        }
+        .css-1uhsiac:focus {
+            outline: none;
+            box-shadow: 0 0 2px 1px rgb(0 95 204);
+        }
+        @supports selector(:focus-visible) {
+            .css-1uhsiac:focus {
+                box-shadow: none;
+            }
+            .css-1uhsiac:focus-visible {
+                box-shadow: 0 0 2px 1px rgb(0 95 204);
+            }
+        }
+        .css-1ch24e9#ap-gift-article-tooltip {
+            display: none;
+            width: 215px;
+            position: absolute;
+            background-color: #000;
+            border: 1px solid #000;
+            box-shadow: 0 1px 3px rgba(0, 0, 0, 0.15);
+            border-radius: 4px;
+            font-family: nyt-franklin, helvetica, arial, sans-serif;
+            font-size: 0.75rem;
+            line-height: 1rem;
+            color: #121212;
+            box-sizing: border-box;
+            top: 38px;
+            left: 2px;
+            z-index: 199;
+        }
+        .css-1ch24e9#ap-gift-article-tooltip button {
+            width: 10px;
+            position: absolute;
+            right: 9px;
+            top: 9px;
+            background: transparent;
+        }
+        .css-1ch24e9#ap-gift-article-tooltip svg {
+            stroke: #fff;
+        }
+        @media (max-width: 600px) {
+            .css-1ch24e9#ap-gift-article-tooltip {
+                left: -9px;
+            }
+        }
+        #ap-gift-article-tooltip .css-1n1thlk {
+            border: 9px inset transparent;
+            display: inline-block;
+            height: 0;
+            position: absolute;
+            width: 0;
+            border-bottom: 12px solid #000;
+            left: 4%;
+            top: -21px;
+        }
+        @media (max-width: 600px) {
+            #ap-gift-article-tooltip .css-1n1thlk {
+                left: 8%;
+            }
+        }
+        #ap-gift-article-tooltip .css-1w019mi {
+            border: 10px inset transparent;
+            display: inline-block;
+            height: 0;
+            position: absolute;
+            width: 0;
+            border-bottom: 14px solid #000;
+            bottom: -15px;
+            left: -10px;
+        }
+        @media (min-width: 1150px) {
+            #ap-gift-article-tooltip .css-1w019mi {
+                border-bottom: 14px solid #000;
+            }
+        }
+        #ap-gift-article .css-4m7ryc,
+        #ap-gift-article-tooltip .css-4m7ryc {
+            font-size: 0.75rem;
+            line-height: 1.0625rem;
+        }
+        #ap-gift-article .css-4m7ryc strong,
+        #ap-gift-article-tooltip .css-4m7ryc strong {
+            font-weight: 700;
+        }
+        .css-q1aqo6 {
+            height: auto;
+            width: auto;
+            border-radius: 30px;
+            background-color: transparent;
+        }
+        .css-q1aqo6:focus {
+            outline: none;
+            box-shadow: 0 0 4px 1px rgb(0 95 204);
+        }
+        @supports selector(:focus-visible) {
+            .css-q1aqo6:focus {
+                box-shadow: none;
+            }
+            .css-q1aqo6:focus-visible {
+                box-shadow: 0 0 4px 1px rgb(0 95 204);
+            }
+        }
+        .css-1egxmzr {
+            display: inline-block;
+        }
+        .AUD_GiftAllocation_0922-1_RightCount .css-1egxmzr {
+            display: none;
+        }
+        .AUD_GiftAllocation_0922-2_LeftCount .css-1egxmzr {
+            display: none;
+        }
+        .css-11s78ai {
+            display: none;
+        }
+        .AUD_GiftAllocation_0922-1_RightCount .css-11s78ai {
+            display: inline-block;
+        }
+        .AUD_GiftAllocation_0922-2_LeftCount .css-11s78ai {
+            display: none;
+        }
+        .css-1u3tlb2 {
+            display: none;
+        }
+        .AUD_GiftAllocation_0922-1_RightCount .css-1u3tlb2 {
+            display: none;
+        }
+        .AUD_GiftAllocation_0922-2_LeftCount .css-1u3tlb2 {
+            display: inline-block;
+        }
+        .css-1yccqtv {
+            height: auto;
+            width: auto;
+            border: solid 1px #dfdfdf;
+            background-color: #fff;
+            border-radius: 100%;
+        }
+        .css-1yccqtv:hover {
+            background-color: #ebebeb;
+            border: 1px solid #ebebeb;
+        }
+        .css-1yccqtv .hiddenClass {
+            display: none;
+        }
+        .css-1tel06d {
+            display: none;
+        }
+        @media (min-width: 740px) {
+            .css-1tel06d {
+                display: -webkit-box;
+                display: -webkit-flex;
+                display: -ms-flexbox;
+                display: flex;
+                width: 16px;
+                height: 31px;
+            }
+        }
+        @media (min-width: 1024px) {
+            .css-1tel06d {
+                display: none;
+            }
+        }
+        @media print {
+            .css-1tel06d {
+                display: none;
+            }
+        }
+        .css-12fr9lp {
+            height: 23px;
+            margin-top: 6px;
+        }
+        .css-18z7m18 {
+            display: none;
+        }
+        @media (min-width: 1024px) {
+            .css-18z7m18 {
+                display: -webkit-box;
+                display: -webkit-flex;
+                display: -ms-flexbox;
+                display: flex;
+                margin-top: 0;
+            }
+        }
+        @media print {
+            .css-18z7m18 {
+                display: block;
+            }
+        }
+        .css-1aor85t {
+            display: none;
+        }
+        @media (min-width: 740px) {
+            .css-1aor85t {
+                position: fixed;
+                display: -webkit-box;
+                display: -webkit-flex;
+                display: -ms-flexbox;
+                display: flex;
+                opacity: 0;
+                z-index: 1;
+                -webkit-transition: all 0.2s ease-in-out;
+                transition: all 0.2s ease-in-out;
+                width: 100%;
+                height: 32.063px;
+                background: white;
+                padding: 5px 0;
+                top: 0;
+                text-align: center;
+                font-family: nyt-cheltenham, georgia, "times new roman", times, serif;
+                box-shadow: rgba(0, 0, 0, 0.08) 0 0 5px 1px;
+                border-bottom: 1px solid #e2e2e2;
+            }
+        }
+        @media print {
+            .css-1aor85t {
+                position: relative;
+                border: none;
+                display: inline-block;
+                opacity: 1 !important;
+                visibility: visible !important;
+            }
+        }
+        .css-1hqnpie {
+            margin-left: 20px;
+            margin-right: 20px;
+            max-width: 1605px;
+            display: -webkit-box;
+            display: -webkit-flex;
+            display: -ms-flexbox;
+            display: flex;
+            -webkit-flex-direction: column;
+            -ms-flex-direction: column;
+            flex-direction: column;
+            position: relative;
+            width: 100%;
+        }
+        @media (min-width: 1360px) {
+            .css-1hqnpie {
+                margin-left: 20px;
+                margin-right: 20px;
+            }
+        }
+        @media (min-width: 1780px) {
+            .css-1hqnpie {
+                margin-left: auto;
+                margin-right: auto;
+            }
+        }
+        @media print {
+            .css-1hqnpie {
+                margin-left: 0;
+                margin-right: 0;
+                width: 100%;
+                max-width: 100%;
+            }
+        }
+        .css-epjblv {
+            display: -webkit-box;
+            display: -webkit-flex;
+            display: -ms-flexbox;
+            display: flex;
+            -webkit-flex-direction: row;
+            -ms-flex-direction: row;
+            flex-direction: row;
+            max-width: 1605px;
+            overflow: hidden;
+            position: absolute;
+            width: 56%;
+            margin-left: calc((100% - 56%) / 2);
+        }
+        @media (min-width: 1024px) {
+            .css-epjblv {
+                width: 53%;
+                margin-left: calc((100% - 53%) / 2);
+            }
+        }
+        @media print {
+            .css-epjblv {
+                display: none;
+            }
+        }
+        .css-fwqvlz {
+            font-family: nyt-cheltenham-small, georgia, "times new roman";
+            font-weight: 400;
+            font-size: 13px;
+            -webkit-letter-spacing: 0.015em;
+            -moz-letter-spacing: 0.015em;
+            -ms-letter-spacing: 0.015em;
+            letter-spacing: 0.015em;
+            margin-top: 10.5px;
+            margin-right: auto;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+        }
+        .css-1u4hfeb {
+            font-family: nyt-franklin, helvetica, arial, sans-serif;
+            font-weight: 700;
+            font-size: 0.75rem;
+            text-transform: uppercase;
+            -webkit-letter-spacing: 0;
+            -moz-letter-spacing: 0;
+            -ms-letter-spacing: 0;
+            letter-spacing: 0;
+            margin-top: 12.5px;
+            margin-bottom: auto;
+            margin-left: auto;
+            white-space: nowrap;
+        }
+        .css-1u4hfeb:hover {
+            -webkit-text-decoration: underline;
+            text-decoration: underline;
+        }
+        .css-x15j1o {
+            display: inline-block;
+            padding-left: 7px;
+            padding-right: 7px;
+            font-size: 13px;
+            margin-top: 10px;
+            margin-bottom: auto;
+            color: #ccc;
+        }
+        .css-tvohiw {
+            margin-top: -1px;
+            margin-bottom: auto;
+            margin-left: auto;
+            z-index: 50;
+            box-shadow: -14px 2px 7px -2px rgba(255, 255, 255, 0.7);
+        }
+        @media (min-width: 740px) {
+            .css-1iwv8en {
+                margin-top: 1px;
+            }
+        }
+        @media (min-width: 1024px) {
+            .css-1iwv8en {
+                margin-top: 0;
+            }
+        }
+        .css-1n6z4y {
+            font-family: nyt-franklin, helvetica, arial, sans-serif;
+            color: #ccc !important;
+            border-left: 1px solid #ccc;
+            margin-left: 10px;
+            padding: 10px;
+            display: none;
+        }
+        @media print {
+            .css-1n6z4y {
+                display: inline-block;
+            }
+        }
+        .css-1ly73wi {
+            position: absolute;
+            width: 1px;
+            height: 1px;
+            margin: -1px;
+            padding: 0;
+            border: 0;
+            -webkit-clip: rect(0 0 0 0);
+            clip: rect(0 0 0 0);
+            overflow: hidden;
+        }
+        .css-rfqw0c {
+            text-align: center;
+            height: 100%;
+            display: block;
+        }
+        .css-19vbshk {
+            color: #ccc;
+            display: none;
+            font-family: nyt-franklin, helvetica, arial, sans-serif;
+            font-size: 0.5625rem;
+            font-weight: 300;
+            -webkit-letter-spacing: 0.05rem;
+            -moz-letter-spacing: 0.05rem;
+            -ms-letter-spacing: 0.05rem;
+            letter-spacing: 0.05rem;
+            line-height: 0.5625rem;
+            margin-left: auto;
+            text-align: center;
+            text-transform: uppercase;
+        }
+        @media (min-width: 600px) {
+            .css-19vbshk {
+                display: inline-block;
+            }
+        }
+        .css-19vbshk p {
+            margin-bottom: auto;
+            margin-right: 7px;
+            margin-top: auto;
+            text-transform: none;
+        }
+        .css-l9onyx {
+            color: #ccc;
+            font-family: nyt-franklin, helvetica, arial, sans-serif;
+            font-size: 0.5625rem;
+            font-weight: 300;
+            -webkit-letter-spacing: 0.05rem;
+            -moz-letter-spacing: 0.05rem;
+            -ms-letter-spacing: 0.05rem;
+            letter-spacing: 0.05rem;
+            line-height: 0.5625rem;
+            margin-bottom: 9px;
+            text-align: center;
+            text-transform: uppercase;
+        }
+        .css-1rxm0ex {
+            display: block;
+        }
+        @media (min-width: 1024px) {
+            .css-1rxm0ex {
+                display: inline-block;
+                white-space: pre;
+            }
+        }
+        .css-knunh2 {
+            padding-bottom: 1px;
+        }
+        @media (min-width: 600px) {
+            .css-knunh2:hover {
+                color: var(--color-content-tertiary, #5a5a5a);
+                border-bottom: 1px solid var(--color-content-tertiary, #5a5a5a);
+            }
+        }
+        .css-etxl5s {
+            -webkit-text-decoration: none;
+            text-decoration: none;
+            color: var(--color-content-primary, #121212);
+        }
+        .css-m3796d {
+            min-width: unset;
+            padding: 0.5px 0 0.5px 20px;
+            display: -webkit-box;
+            display: -webkit-flex;
+            display: -ms-flexbox;
+            display: flex;
+            -webkit-align-items: center;
+            -webkit-box-align: center;
+            -ms-flex-align: center;
+            align-items: center;
+            -webkit-box-pack: left;
+            -webkit-justify-content: left;
+            -ms-flex-pack: left;
+            justify-content: left;
+            overflow-x: auto;
+            white-space: nowrap;
+            -webkit-scrollbar-width: none;
+            -moz-scrollbar-width: none;
+            -ms-scrollbar-width: none;
+            scrollbar-width: none;
+        }
+        @media (min-width: 620px) {
+            .css-m3796d {
+                min-width: 620px;
+            }
+        }
+        .css-m3796d::-webkit-scrollbar {
+            display: none;
+        }
+        @media (pointer: coarse) {
+            .css-m3796d {
+                overflow-x: scroll;
+                -webkit-overflow-scrolling: touch;
+            }
+        }
+        @media (min-width: 1024px) {
+            .css-m3796d {
+                -webkit-align-items: baseline;
+                -webkit-box-align: baseline;
+                -ms-flex-align: baseline;
+                align-items: baseline;
+            }
+        }
+        @media (max-width: 599px) {
+            .css-m3796d::after {
+                content: "";
+                background: linear-gradient(
+                  90deg,
+                  rgba(255, 255, 255, 0),
+                  var(--color-background-elevated, #ffffff)
+                );
+                height: 40px;
+                position: absolute;
+                right: 0;
+                width: 24px;
+                z-index: 2;
+            }
+            @media (prefers-color-scheme: dark) {
+                .NYTApp .css-m3796d::after {
+                    background: linear-gradient(
+                      90deg,
+                      rgba(42, 42, 42, 0),
+                      var(--color-background-elevated, #ffffff)
+                    );
+                }
+            }
+        }
+        .css-1qej4jr {
+            padding: 1em 0;
+            margin-right: 1.4em;
+        }
+        .css-1qej4jr:last-child {
+            margin-right: 20px;
+        }
+        .css-go3nob {
+            font-family: nyt-franklin, helvetica, arial, sans-serif;
+            display: -webkit-box;
+            display: -webkit-flex;
+            display: -ms-flexbox;
+            display: flex;
+            width: auto;
+            list-style: none;
+            padding-left: 0;
+            -webkit-flex-shrink: 0;
+            -ms-flex-negative: 0;
+            flex-shrink: 0;
+            -webkit-box-pack: center;
+            -webkit-justify-content: center;
+            -ms-flex-pack: center;
+            justify-content: center;
+            -webkit-align-items: baseline;
+            -webkit-box-align: baseline;
+            -ms-flex-align: baseline;
+            align-items: baseline;
+        }
+        .css-1nkuxcu {
+            width: 25px;
+            height: 25px;
+            border-radius: 3px;
+            cursor: pointer;
+            font-family: nyt-franklin, helvetica, arial, sans-serif;
+            -webkit-transition: ease 0.6s;
+            transition: ease 0.6s;
+            white-space: nowrap;
+            vertical-align: middle;
+            background-color: transparent;
+            color: #000;
+            font-size: 11px;
+            line-height: 11px;
+            font-weight: 700;
+            -webkit-letter-spacing: 0.02em;
+            -moz-letter-spacing: 0.02em;
+            -ms-letter-spacing: 0.02em;
+            letter-spacing: 0.02em;
+            padding: 11px 12px 8px;
+            padding: 10px;
+        }
+        .css-1nkuxcu::-moz-focus-inner {
+            padding: 0;
+            border: 0;
+        }
+        .css-1nkuxcu:-moz-focusring {
+            outline: 1px dotted;
+        }
+        .css-1nkuxcu:disabled,
+        .css-1nkuxcu.disabled {
+            opacity: 0.5;
+            cursor: default;
+        }
+        .css-1nkuxcu:active,
+        .css-1nkuxcu.active {
+            background-color: #f7f7f7;
+        }
+        @media (min-width: 740px) {
+            .css-1nkuxcu:hover {
+                background-color: #f7f7f7;
+            }
+        }
+        .css-136d4fr {
+            padding: 0 10px;
+            height: 55px;
+            position: absolute;
+            left: 0;
+            top: 0;
+            -webkit-align-items: center;
+            -webkit-box-align: center;
+            -ms-flex-align: center;
+            align-items: center;
+            -webkit-box-pack: center;
+            -webkit-justify-content: center;
+            -ms-flex-pack: center;
+            justify-content: center;
+            background: #fff;
+            display: none;
+        }
+        @media (min-width: 1150px) {
+            .css-136d4fr {
+                display: -webkit-box;
+                display: -webkit-flex;
+                display: -ms-flexbox;
+                display: flex;
+            }
+        }
+        .css-1r2mflq {
+            top: 0;
+            position: -webkit-sticky;
+            position: sticky;
+            background-color: var(--color-background-elevated, #ffffff);
+            z-index: 902;
+        }
+        @media print {
+            .css-1r2mflq {
+                display: none;
+            }
+        }
+        @media (min-width: 1024px) {
+            .css-1r2mflq {
+                margin-top: 3px;
+            }
+        }
+        .css-nwd8t8 {
+            width: 100%;
+            background-color: var(--color-background-tertiary, #ebebeb);
+        }
+        .sizeSmall .css-bsn42l {
+            width: 50%;
+        }
+        @media (min-width: 600px) {
+            .sizeSmall .css-bsn42l {
+                width: 300px;
+            }
+        }
+        @media (min-width: 1440px) {
+            .sizeSmall .css-bsn42l {
+                width: 300px;
+            }
+        }
+        @media (max-width: 600px) {
+            .sizeSmall .css-bsn42l {
+                width: 50%;
+            }
+        }
+        .sizeSmall.sizeSmallNoCaption .css-bsn42l {
+            margin-left: auto;
+            margin-right: auto;
+        }
+        @media (min-width: 740px) {
+            .sizeSmall.layoutVertical .css-bsn42l {
+                max-width: 250px;
+            }
+        }
+        @media (min-width: 1024px) {
+            .sizeSmall.layoutVertical .css-bsn42l {
+                width: 250px;
+            }
+        }
+        @media (max-width: 740px) {
+            .sizeSmall.layoutVertical .css-bsn42l {
+                max-width: 250px;
+            }
+        }
+        @media (min-width: 740px) {
+            .sizeSmall.layoutHorizontal .css-bsn42l {
+                max-width: 300px;
+            }
+        }
+        @media (min-width: 1024px) {
+            .sizeSmall.layoutHorizontal .css-bsn42l {
+                width: 300px;
+            }
+        }
+        @media (max-width: 740px) {
+            .sizeSmall.layoutHorizontal .css-bsn42l {
+                max-width: 300px;
+            }
+        }
+        @media (min-width: 600px) {
+            .sizeMedium.layoutVertical.verticalVideo .css-bsn42l {
+                width: 310px;
+            }
+        }
+        .css-r4qme7 {
+            margin: 0 6px 0 0;
+            width: 6px;
+            height: 6px;
+            border-radius: 50%;
+            background-color: var(--color-background-quaternary, #c7c7c7);
+            -webkit-transition: background-color 0.2s ease;
+            transition: background-color 0.2s ease;
+        }
+        .css-z3e15g {
+            position: fixed;
+            opacity: 0;
+            -webkit-scroll-events: none;
+            -moz-scroll-events: none;
+            -ms-scroll-events: none;
+            scroll-events: none;
+            top: 0;
+            left: 0;
+            bottom: 0;
+            right: 0;
+            -webkit-transition: opacity 0.2s;
+            transition: opacity 0.2s;
+            background-color: #fff;
+            pointer-events: none;
+        }
+        .css-sklrp3 {
+            margin: 28px 0;
+        }
+        .css-10cldcv {
+            margin-left: 20px;
+            margin-right: 20px;
+            width: calc(100% - 40px);
+            max-width: 600px;
+        }
+        @media (min-width: 600px) {
+            .css-10cldcv {
+                margin-left: auto;
+                margin-right: auto;
+            }
+        }
+        @media (min-width: 740px) {
+            .css-10cldcv {
+                width: 600px;
+            }
+        }
+        @media print {
+            .css-10cldcv {
+                margin-left: 0;
+                margin-right: 0;
+                width: 100%;
+                max-width: 100%;
+            }
+        }
+        .css-1r7ky0e .e6idgb70 + .e1h9rw200 {
+            margin-top: 0;
+        }
+        .css-1r7ky0e .eoo0vm40 + .e1gnsphs0 {
+            margin-top: -0.3em;
+        }
+        .css-1r7ky0e .e6idgb70 + .eoo0vm40 {
+            margin-top: 0;
+        }
+        .css-1r7ky0e .eoo0vm40 + figure {
+            margin-top: 1.2rem;
+        }
+        .css-1r7ky0e .e1gnsphs0 + figure {
+            margin-top: 1.2rem;
+        }
+        .css-ew4tgv {
+            display: none;
+        }
+        @media (min-width: 1024px) {
+            .css-ew4tgv {
+                display: -webkit-box;
+                display: -webkit-flex;
+                display: -ms-flexbox;
+                display: flex;
+                margin-right: 0;
+                margin-left: auto;
+                width: 130px;
+                -webkit-align-items: center;
+                -webkit-box-align: center;
+                -ms-flex-align: center;
+                align-items: center;
+            }
+        }
+        @media (min-width: 1150px) {
+            .css-ew4tgv {
+                width: 210px;
+            }
+        }
+        @media print {
+            .css-ew4tgv {
+                display: none;
+            }
+        }
+        .css-s99gbd {
+            display: -webkit-box;
+            display: -webkit-flex;
+            display: -ms-flexbox;
+            display: flex;
+            -webkit-flex-direction: column;
+            -ms-flex-direction: column;
+            flex-direction: column;
+            margin-bottom: 1rem;
+        }
+        @media (min-width: 1024px) {
+            .css-s99gbd {
+                -webkit-flex-direction: row;
+                -ms-flex-direction: row;
+                flex-direction: row;
+                height: 100%;
+                width: 945px;
+                margin-left: auto;
+                margin-right: auto;
+            }
+        }
+        @media (min-width: 1150px) {
+            .css-s99gbd {
+                width: 1110px;
+                margin-left: auto;
+                margin-right: auto;
+            }
+        }
+        @media (min-width: 1280px) {
+            .css-s99gbd {
+                width: 1170px;
+            }
+        }
+        @media (min-width: 1440px) {
+            .css-s99gbd {
+                width: 1200px;
+            }
+        }
+        @media print {
+            .css-s99gbd {
+                margin-left: 0;
+                margin-right: 0;
+                width: 100%;
+                max-width: 100%;
+            }
+        }
+        @media print {
+            .css-s99gbd {
+                margin-bottom: 1em;
+                display: block;
+            }
+        }
+        .css-53u6y8 {
+            margin-left: auto;
+            margin-right: auto;
+            width: 100%;
+        }
+        @media (min-width: 1024px) {
+            .css-53u6y8 {
+                margin-left: calc((100% - 600px) / 2);
+                margin-right: 0;
+                width: 600px;
+            }
+        }
+        @media (min-width: 1440px) {
+            .css-53u6y8 {
+                max-width: 600px;
+                width: 600px;
+                margin-left: calc((100% - 600px) / 2);
+            }
+        }
+        @media print {
+            .css-53u6y8 {
+                margin-left: 0;
+                margin-right: 0;
+                width: 100%;
+                max-width: 100%;
+            }
+        }
+        .css-1pcai02 {
+            font-size: 1.0625rem;
+            line-height: 1.5rem;
+            font-weight: 500;
+        }
+        .css-1pcai02 strong {
+            font-weight: 700;
+        }
+        .css-1pcai02 em {
+            font-style: italic;
+        }
+        .css-1pcai02 a {
+            color: var(--color-signal-editorial, #326891);
+            -webkit-text-decoration: underline;
+            text-decoration: underline;
+            -webkit-text-decoration-thickness: 1px;
+            text-decoration-thickness: 1px;
+            text-underline-offset: 1px;
+        }
+        .css-1pcai02 a:hover {
+            -webkit-text-decoration: none;
+            text-decoration: none;
+        }
+        .css-1t83a55:not(:last-child) {
+            padding-bottom: 1.5rem;
+        }
+        .css-o7i5g3 {
+            position: relative;
+            display: -webkit-box;
+            display: -webkit-flex;
+            display: -ms-flexbox;
+            display: flex;
+            -webkit-flex: none;
+            -ms-flex: none;
+            flex: none;
+            -webkit-flex-flow: row nowrap;
+            -ms-flex-flow: row nowrap;
+            flex-flow: row nowrap;
+            overflow-y: hidden;
+            -webkit-scroll-snap-type: x mandatory;
+            -moz-scroll-snap-type: x mandatory;
+            -ms-scroll-snap-type: x mandatory;
+            scroll-snap-type: x mandatory;
+            -webkit-overflow-scrolling: touch;
+            -webkit-scroll-behavior: smooth;
+            -moz-scroll-behavior: smooth;
+            -ms-scroll-behavior: smooth;
+            scroll-behavior: smooth;
+            z-index: 2;
+            -webkit-scrollbar-width: none;
+            -moz-scrollbar-width: none;
+            -ms-scrollbar-width: none;
+            scrollbar-width: none;
+            margin-left: 0;
+            padding-left: 20px;
+            width: auto;
+            -webkit-clip-path: none;
+            clip-path: none;
+        }
+        @media (min-width: 600px) {
+            .css-o7i5g3 {
+                margin-left: -20px;
+                padding-left: 0;
+                width: calc(100% + 40px);
+                -webkit-clip-path: inset(0 20px);
+                clip-path: inset(0 20px);
+            }
+        }
+        @media (prefers-reduced-motion: reduce) {
+            .css-o7i5g3 {
+                -webkit-scroll-behavior: auto;
+                -moz-scroll-behavior: auto;
+                -ms-scroll-behavior: auto;
+                scroll-behavior: auto;
+            }
+        }
+        .css-o7i5g3::-webkit-scrollbar {
+            display: none;
+        }
+        .css-1w3yqu0 {
+            position: relative;
+            -webkit-scroll-snap-align: center;
+            -moz-scroll-snap-align: center;
+            -ms-scroll-snap-align: center;
+            scroll-snap-align: center;
+            -webkit-scroll-snap-stop: always;
+            -moz-scroll-snap-stop: always;
+            -ms-scroll-snap-stop: always;
+            scroll-snap-stop: always;
+            box-sizing: border-box;
+            border: 1px solid var(--color-stroke-quaternary, #dfdfdf);
+            padding: 15px;
+        }
+        @media (min-width: 600px) {
+            .css-1w3yqu0 {
+                border: none;
+                padding: 0 20px 10px;
+            }
+        }
+        .css-m541wo {
+            display: -webkit-box;
+            display: -webkit-flex;
+            display: -ms-flexbox;
+            display: flex;
+            -webkit-scroll-snap-align: center;
+            -moz-scroll-snap-align: center;
+            -ms-scroll-snap-align: center;
+            scroll-snap-align: center;
+            -webkit-flex: 0 0 80%;
+            -ms-flex: 0 0 80%;
+            flex: 0 0 80%;
+            margin-right: 20px;
+        }
+        @media (min-width: 600px) {
+            .css-m541wo {
+                -webkit-flex: none;
+                -ms-flex: none;
+                flex: none;
+                margin-right: 0;
+                width: 100%;
+            }
+        }
+        .css-m541wo:last-child {
+            padding-right: 20px;
+            margin-right: 0;
+        }
+        @media (min-width: 600px) {
+            .css-m541wo:last-child {
+                padding-right: 0;
+            }
+        }
+        .css-1dxpste {
+            list-style: none;
+            counter-reset: list-block-counter;
+            display: -webkit-inline-box;
+            display: -webkit-inline-flex;
+            display: -ms-inline-flexbox;
+            display: inline-flex;
+            -webkit-flex-flow: row nowrap;
+            -ms-flex-flow: row nowrap;
+            flex-flow: row nowrap;
+            -webkit-align-items: center;
+            -webkit-box-align: center;
+            -ms-flex-align: center;
+            align-items: center;
+        }
+        .css-cm1d69 {
+            -webkit-box-pack: end;
+            -webkit-justify-content: flex-end;
+            -ms-flex-pack: end;
+            justify-content: flex-end;
+            position: absolute;
+            display: none;
+            z-index: 1;
+        }
+        div .css-cm1d69 {
+            right: 0;
+            width: 82px;
+        }
+        @media (min-width: 600px) {
+            .css-cm1d69 {
+                display: -webkit-box;
+                display: -webkit-flex;
+                display: -ms-flexbox;
+                display: flex;
+            }
+        }
+        .css-95lxlj {
+            display: -webkit-inline-box;
+            display: -webkit-inline-flex;
+            display: -ms-inline-flexbox;
+            display: inline-flex;
+            -webkit-box-pack: center;
+            -webkit-justify-content: center;
+            -ms-flex-pack: center;
+            justify-content: center;
+            -webkit-align-items: center;
+            -webkit-box-align: center;
+            -ms-flex-align: center;
+            align-items: center;
+            white-space: nowrap;
+            width: 25px;
+            height: 25px;
+            border-radius: 50%;
+            background-color: var(--color-background-primary, #ffffff);
+            border: 1px solid var(--color-stroke-quaternary, #dfdfdf);
+            cursor: pointer;
+            outline: none;
+            right: 0;
+        }
+        .css-95lxlj::after {
+            content: "";
+            display: inline-block;
+            margin-left: 2px;
+            margin-bottom: 1;
+            width: 7px;
+            height: 7px;
+            line-height: 0;
+            border-top: 2px solid var(--color-content-primary, #121212);
+            border-right: 2px solid var(--color-content-primary, #121212);
+            border-color: var(--color-content-primary, #121212);
+        }
+        .css-95lxlj:hover {
+            background-color: var(--color-stroke-quaternary, #dfdfdf);
+        }
+        .css-95lxlj::after {
+            margin-left: -2px;
+            -webkit-transform: rotate(45deg);
+            -ms-transform: rotate(45deg);
+            transform: rotate(45deg);
+        }
+        .css-8r08w0 {
+            display: -webkit-box;
+            display: -webkit-flex;
+            display: -ms-flexbox;
+            display: flex;
+            -webkit-flex-direction: row;
+            -ms-flex-direction: row;
+            flex-direction: row;
+            -webkit-box-pack: center;
+            -webkit-justify-content: center;
+            -ms-flex-pack: center;
+            justify-content: center;
+            position: relative;
+            min-height: 40px;
+        }
+        .css-1px5j0 {
+            font-family: nyt-franklin, helvetica, arial, sans-serif;
+            color: var(--color-content-secondary, #363636);
+            background-color: var(--color-background-primary, #ffffff);
+            box-sizing: border-box;
+            width: 100%;
+            overflow: hidden;
+            padding: 0;
+            border: none;
+            margin: 1.25rem auto 1.5rem;
+        }
+        @media (min-width: 600px) {
+            .css-1px5j0 {
+                overflow: unset;
+                padding: 20px;
+                max-width: 600px;
+                border: 1px solid var(--color-stroke-quaternary, #dfdfdf);
+                margin: 1.5rem auto 1.75rem;
+            }
+        }
+        @media print {
+            .css-1px5j0 {
+                display: none;
+            }
+        }
+        .css-76fnlk {
+            display: block;
+            margin-right: auto;
+            margin-left: auto;
+            width: calc(100% - 40px);
+        }
+        @media (min-width: 600px) {
+            .css-76fnlk {
+                width: 100%;
+            }
+        }
+        .css-1gcsvhw {
+            font-weight: 700;
+            font-size: 1.1875rem;
+            line-height: 1.375rem;
+            margin-bottom: 1rem;
+            border-top: 1px solid var(--color-stroke-quaternary, #dfdfdf);
+            border-bottom: none;
+            padding-top: 1rem;
+        }
+        @media (min-width: 600px) {
+            .css-1gcsvhw {
+                border-top: none;
+                border-bottom: 1px solid var(--color-stroke-quaternary, #dfdfdf);
+                padding-top: 0;
+                padding-bottom: 1rem;
+            }
+        }
+        .css-1at4x3t {
+            font-family: nyt-franklin, helvetica, arial, sans-serif;
+            font-weight: 500;
+            border: 1px solid var(--color-stroke-quaternary, #dfdfdf);
+            color: var(--color-content-secondary, #363636);
+            background-color: var(--color-background-primary, #ffffff);
+            max-width: 600px;
+            box-sizing: border-box;
+            font-size: 1rem;
+            line-height: 1.375rem;
+            width: calc(100% - 40px);
+            padding: 15px 15px 20px;
+            margin: 1.25rem auto 1.5rem;
+        }
+        @media (min-width: 740px) {
+            .css-1at4x3t {
+                font-size: 1.0625rem;
+                line-height: 1.5rem;
+                width: 100%;
+                padding: 25px;
+                margin: 1.5rem auto 1.75rem;
+            }
+        }
+        @media print {
+            .css-1at4x3t {
+                display: none;
+            }
+        }
+        .css-1at4x3t strong {
+            font-weight: 700;
+        }
+        .css-1at4x3t em {
+            font-style: italic;
+        }
+        .css-1at4x3t a {
+            color: var(--color-signal-editorial, #326891);
+            -webkit-text-decoration: underline;
+            text-decoration: underline;
+            -webkit-text-decoration-thickness: 1px;
+            text-decoration-thickness: 1px;
+            text-underline-offset: 1px;
+        }
+        .css-1at4x3t a:hover {
+            -webkit-text-decoration: none;
+            text-decoration: none;
+        }
+        .css-4od1bx {
+            font-weight: 700;
+            font-size: 1.1875rem;
+            margin-top: 0;
+            margin-bottom: 4px;
+            line-height: 1.375rem;
+        }
+        @media (min-width: 740px) {
+            .css-4od1bx {
+                line-height: 1.4375rem;
+            }
+        }
+        .css-10ikpw {
+            list-style: disc;
+            margin-top: 10px;
+        }
+        .css-10ikpw li {
+            margin-left: 12px;
+        }
+        .css-10ikpw li:not(:last-child) {
+            margin-bottom: 10px;
+        }
+        @media (min-width: 740px) {
+            .css-10ikpw li:not(:last-child) {
+                margin-bottom: 15px;
+            }
+        }
+        @media (min-width: 740px) {
+            .css-10ikpw {
+                margin-top: 15px;
+            }
+        }
+        .css-rrnxp3 {
+            -webkit-transition: all 0.4s ease-in-out;
+            transition: all 0.4s ease-in-out;
+        }
+        .css-1q2w90k {
+            opacity: 1;
+            visibility: visible;
+            -webkit-animation-name: animation-5j8bii;
+            animation-name: animation-5j8bii;
+            -webkit-animation-duration: 300ms;
+            animation-duration: 300ms;
+            -webkit-animation-delay: 0ms;
+            animation-delay: 0ms;
+            -webkit-animation-timing-function: ease-out;
+            animation-timing-function: ease-out;
+        }
+        @media print {
+            .css-1q2w90k {
+                display: none;
+            }
+        }
+        @media (min-width: 1024px) {
+            .css-1q2w90k {
+                position: fixed;
+                width: 100%;
+                top: 0;
+                left: 0;
+                z-index: 200;
+                background-color: #fff;
+                border-bottom: none;
+                -webkit-transition: all 0.2s ease-in-out;
+                transition: all 0.2s ease-in-out;
+            }
+        }
+        @media (min-width: 1024px) {
+            .css-1bymuyk {
+                position: relative;
+                border-bottom: 1px solid #e2e2e2;
+            }
+        }
+        .css-ui9rw0 {
+            background: #fff;
+            border-bottom: 1px solid #e2e2e2;
+            height: 36px;
+            padding: 8px 15px 3px;
+            position: relative;
+        }
+        @media (min-width: 740px) {
+            .css-ui9rw0 {
+                background: #fff;
+                padding: 10px 15px 6px;
+            }
+        }
+        @media (min-width: 1024px) {
+            .css-ui9rw0 {
+                background: transparent;
+                border-bottom: 0;
+                padding: 4px 15px 2px;
+            }
+        }
+        @media (min-width: 1024px) {
+            .css-ui9rw0 {
+                margin: 0 auto;
+                max-width: 1605px;
+            }
+        }
+        .css-1f7ibof {
+            display: -webkit-box;
+            display: -webkit-flex;
+            display: -ms-flexbox;
+            display: flex;
+            -webkit-box-pack: space-around;
+            -webkit-justify-content: space-around;
+            -ms-flex-pack: space-around;
+            justify-content: space-around;
+            left: 10px;
+            position: absolute;
+        }
+        @media print {
+            .css-1f7ibof {
+                display: none;
+            }
+        }
+        .css-fzvsed {
+            border-radius: 3px;
+            cursor: pointer;
+            font-family: nyt-franklin, helvetica, arial, sans-serif;
+            -webkit-transition: ease 0.6s;
+            transition: ease 0.6s;
+            white-space: nowrap;
+            vertical-align: middle;
+            background-color: transparent;
+            color: #000;
+            font-size: 11px;
+            line-height: 11px;
+            font-weight: 700;
+            -webkit-letter-spacing: 0.02em;
+            -moz-letter-spacing: 0.02em;
+            -ms-letter-spacing: 0.02em;
+            letter-spacing: 0.02em;
+            padding: 11px 12px 8px;
+            border: 0;
+            padding: 8px 9px;
+            text-transform: uppercase;
+        }
+        .css-fzvsed.hidden {
+            opacity: 0;
+            visibility: hidden;
+        }
+        .css-fzvsed.hidden:focus {
+            opacity: 1;
+        }
+        .css-fzvsed::-moz-focus-inner {
+            padding: 0;
+            border: 0;
+        }
+        .css-fzvsed:-moz-focusring {
+            outline: 1px dotted;
+        }
+        .css-fzvsed:disabled,
+        .css-fzvsed.disabled {
+            opacity: 0.5;
+            cursor: default;
+        }
+        .css-fzvsed:active,
+        .css-fzvsed.active {
+            background-color: #f7f7f7;
+        }
+        @media (min-width: 740px) {
+            .css-fzvsed:hover {
+                background-color: #f7f7f7;
+            }
+        }
+        @media (min-width: 1024px) {
+            .css-fzvsed {
+                display: none;
+            }
+        }
+        .css-123u7tk {
+            border-radius: 3px;
+            cursor: pointer;
+            font-family: nyt-franklin, helvetica, arial, sans-serif;
+            -webkit-transition: ease 0.6s;
+            transition: ease 0.6s;
+            white-space: nowrap;
+            vertical-align: middle;
+            background-color: #fff;
+            border: 1px solid #ebebeb;
+            color: #333;
+            font-size: 11px;
+            line-height: 11px;
+            font-weight: 500;
+            -webkit-letter-spacing: 0.02em;
+            -moz-letter-spacing: 0.02em;
+            -ms-letter-spacing: 0.02em;
+            letter-spacing: 0.02em;
+            padding: 11px 12px 8px;
+            text-transform: uppercase;
+            display: none;
+            padding: 8px 9px 9px;
+        }
+        .css-123u7tk::-moz-focus-inner {
+            padding: 0;
+            border: 0;
+        }
+        .css-123u7tk:-moz-focusring {
+            outline: 1px dotted;
+        }
+        .css-123u7tk:disabled,
+        .css-123u7tk.disabled {
+            opacity: 0.5;
+            cursor: default;
+        }
+        .css-123u7tk:active,
+        .css-123u7tk.active {
+            background-color: #f7f7f7;
+        }
+        @media (min-width: 740px) {
+            .css-123u7tk:hover {
+                background-color: #f7f7f7;
+            }
+        }
+        @media (min-width: 1024px) {
+            .css-123u7tk {
+                border: 0;
+                display: inline-block;
+                margin-right: 8px;
+            }
+        }
+        .css-tkwi90 {
+            border-radius: 3px;
+            cursor: pointer;
+            font-family: nyt-franklin, helvetica, arial, sans-serif;
+            -webkit-transition: ease 0.6s;
+            transition: ease 0.6s;
+            white-space: nowrap;
+            vertical-align: middle;
+            background-color: transparent;
+            color: #000;
+            font-size: 11px;
+            line-height: 11px;
+            font-weight: 700;
+            -webkit-letter-spacing: 0.02em;
+            -moz-letter-spacing: 0.02em;
+            -ms-letter-spacing: 0.02em;
+            letter-spacing: 0.02em;
+            padding: 11px 12px 8px;
+            border: 0;
+        }
+        .css-tkwi90::-moz-focus-inner {
+            padding: 0;
+            border: 0;
+        }
+        .css-tkwi90:-moz-focusring {
+            outline: 1px dotted;
+        }
+        .css-tkwi90:disabled,
+        .css-tkwi90.disabled {
+            opacity: 0.5;
+            cursor: default;
+        }
+        .css-tkwi90:active,
+        .css-tkwi90.active {
+            background-color: #f7f7f7;
+        }
+        @media (min-width: 740px) {
+            .css-tkwi90:hover {
+                background-color: #f7f7f7;
+            }
+        }
+        .css-tkwi90.activeSearchButton {
+            background-color: #f7f7f7;
+        }
+        @media (min-width: 1024px) {
+            .css-tkwi90 {
+                padding: 8px 9px 9px;
+            }
+        }
+        .css-1wr3we4 {
+            display: none;
+        }
+        @media (min-width: 1024px) {
+            .css-1wr3we4 {
+                display: block;
+                position: absolute;
+                left: 105px;
+                line-height: 19px;
+                top: 10px;
+            }
+        }
+        .css-10698na {
+            text-align: center;
+        }
+        @media (min-width: 740px) {
+            .css-10698na {
+                padding-top: 0;
+            }
+        }
+        @media print {
+            .css-10698na a[href]::after {
+                content: "";
+            }
+            .css-10698na svg {
+                fill: black;
+            }
+        }
+        .css-nhjhh0 {
+            display: block;
+            width: 189px;
+            height: 26px;
+            margin: 5px auto 0;
+        }
+        @media (min-width: 740px) {
+            .css-nhjhh0 {
+                width: 225px;
+                height: 31px;
+                margin: 4px auto 0;
+            }
+        }
+        @media (min-width: 1024px) {
+            .css-nhjhh0 {
+                width: 195px;
+                height: 26px;
+                margin: 6px auto 0;
+            }
+        }
+        .css-y3sf94 {
+            display: -webkit-box;
+            display: -webkit-flex;
+            display: -ms-flexbox;
+            display: flex;
+            -webkit-box-pack: space-around;
+            -webkit-justify-content: space-around;
+            -ms-flex-pack: space-around;
+            justify-content: space-around;
+            position: absolute;
+            right: 10px;
+            top: 9px;
+        }
+        @media (min-width: 1024px) {
+            .css-y3sf94 {
+                top: 4px;
+            }
+        }
+        @media print {
+            .css-y3sf94 {
+                display: none;
+            }
+        }
+        .css-1r0gz1j {
+            -webkit-align-items: center;
+            -webkit-box-align: center;
+            -ms-flex-align: center;
+            align-items: center;
+            display: -webkit-box;
+            display: -webkit-flex;
+            display: -ms-flexbox;
+            display: flex;
+            font-family: nyt-franklin, helvetica, arial, sans-serif;
+            font-size: 11px;
+            -webkit-box-pack: space-around;
+            -webkit-justify-content: space-around;
+            -ms-flex-pack: space-around;
+            justify-content: space-around;
+            padding: 13px 20px 12px;
+        }
+        @media (min-width: 740px) {
+            .css-1r0gz1j {
+                position: relative;
+            }
+        }
+        @media (min-width: 1024px) {
+            .css-1r0gz1j {
+                -webkit-box-pack: justify;
+                -webkit-justify-content: space-between;
+                -ms-flex-pack: justify;
+                justify-content: space-between;
+                border: none;
+                padding: 0;
+                height: 0;
+                -webkit-transform: translateY(38px);
+                -ms-transform: translateY(38px);
+                transform: translateY(38px);
+                -webkit-align-items: flex-end;
+                -webkit-box-align: flex-end;
+                -ms-flex-align: flex-end;
+                align-items: flex-end;
+            }
+        }
+        @media print {
+            .css-1r0gz1j {
+                display: none;
+            }
+        }
+        .css-1o0kkht {
+            color: #121212;
+            font-size: 0.6875rem;
+            font-family: nyt-franklin, helvetica, arial, sans-serif;
+            display: none;
+            width: auto;
+            font-weight: 700;
+        }
+        @media (min-width: 740px) {
+            .css-1o0kkht {
+                text-align: center;
+                width: 100%;
+            }
+        }
+        @media (min-width: 1024px) {
+            .css-1o0kkht {
+                font-size: 12px;
+                width: auto;
+                margin-bottom: 5px;
+            }
+        }
+        .css-1bvtpon {
+            display: none;
+        }
+        .css-4skfbu {
+            color: #999;
+            display: -webkit-box;
+            display: -webkit-flex;
+            display: -ms-flexbox;
+            display: flex;
+            -webkit-flex-shrink: 0;
+            -ms-flex-negative: 0;
+            flex-shrink: 0;
+            font-family: nyt-franklin, helvetica, arial, sans-serif;
+            font-size: 17px;
+            margin-bottom: 5px;
+            margin-bottom: 0;
+        }
+        @media print {
+            .css-4skfbu {
+                display: none;
+            }
+        }
+        .css-9eyi4s {
+            color: #999;
+            display: inline;
+            margin-right: 12px;
+            width: 100%;
+            position: relative;
+        }
+        @media (max-width: 420px) {
+            .css-9eyi4s {
+                margin-right: 6px;
+            }
+        }
+        .css-9eyi4s > a,
+        .css-9eyi4s > button {
+            -webkit-text-decoration: none;
+            text-decoration: none;
+        }
+        .css-9eyi4s > a:focus,
+        .css-9eyi4s > button:focus {
+            display: inline-block;
+            outline: none;
+            box-shadow: 0 0 2px 1px rgb(0 95 204);
+        }
+        @supports selector(:focus-visible) {
+            .css-9eyi4s > a:focus,
+            .css-9eyi4s > button:focus {
+                box-shadow: none;
+            }
+            .css-9eyi4s > a:focus-visible,
+            .css-9eyi4s > button:focus-visible {
+                box-shadow: 0 0 2px 1px rgb(0 95 204);
+            }
+        }
+        .css-9eyi4s > a:focus {
+            border-radius: 100%;
+        }
+        .css-9eyi4s:last-of-type {
+            margin-right: 0;
+        }
+        .css-1wb2lb {
+            display: inline-block;
+            vertical-align: middle;
+            width: 20px;
+            background-color: #fff;
+            border: 1px #dfdfdf solid;
+            border-radius: 100%;
+            padding: 6px;
+            overflow: initial;
+            vertical-align: middle;
+            height: 20px;
+        }
+        .css-1wb2lb:hover {
+            background-color: #ebebeb;
+            border: 1px solid #ebebeb;
+        }
+        .css-1wb2lb:focus {
+            border-radius: 100%;
+            outline: none;
+            box-shadow: 0 0 2px 1px rgb(0 95 204);
+        }
+        @supports selector(:focus-visible) {
+            .css-1wb2lb:focus {
+                box-shadow: none;
+            }
+            .css-1wb2lb:focus-visible {
+                box-shadow: 0 0 2px 1px rgb(0 95 204);
+            }
+        }
+        .css-aulw98 {
+            direction: ltr;
+            display: inline-block;
+            vertical-align: middle;
+            background-color: #fff;
+            color: #333;
+            border: solid 1px #dfdfdf;
+            -webkit-transition: background-color 0.1s, color 0.1s;
+            transition: background-color 0.1s, color 0.1s;
+            border-radius: 30px;
+            padding: 6px 10px 6px;
+            font-size: 0.75rem;
+            font-family: nyt-franklin, helvetica, arial, sans-serif;
+            line-height: 0.9375rem;
+            text-align: right;
+            font-weight: 500;
+            background-color: #fff;
+            color: #333;
+            border: solid 1px #dfdfdf;
+            -webkit-transition: background-color 0.1s, color 0.1s;
+            transition: background-color 0.1s, color 0.1s;
+        }
+        .css-aulw98:hover {
+            background-color: #ebebeb;
+        }
+        .css-aulw98:hover .gift-count {
+            background-color: #fafafa;
+        }
+        @media (max-width: 600px) {
+            .css-aulw98 {
+                padding: 6px 7px 5px;
+            }
+        }
+        .css-aulw98:hover {
+            border: solid 1px #ebebeb;
+        }
+        .css-aulw98 svg path {
+            fill: #333;
+            -webkit-transition: fill 0.5s;
+            transition: fill 0.5s;
+        }
+        .css-aulw98 svg {
+            margin-right: 5px;
+            vertical-align: -6px;
+            height: 20px;
+        }
+        .css-aulw98:hover {
+            border: solid 1px #ebebeb;
+        }
+        .css-aulw98 svg path {
+            fill: #333;
+            -webkit-transition: fill 0.5s;
+            transition: fill 0.5s;
+        }
+        .css-swbuts {
+            height: 18px;
+            width: 18px;
+            padding: 7px;
+            overflow: visible;
+            vertical-align: middle;
+            cursor: not-allowed;
+        }
+        .css-swbuts g {
+            stroke-width: 0.1px;
+        }
+        @media (min-width: 1150px) {
+            .css-swbuts:hover g,
+            .css-swbuts:focus g {
+                stroke: #333;
+            }
+        }
+        @media (min-width: 1150px) {
+            .css-swbuts:hover g,
+            .css-swbuts:focus g {
+                stroke: #666;
+                opacity: 1;
+            }
+        }
+        .css-1vxca1d {
+            position: relative;
+            margin: 0 auto;
+        }
+        @media (min-width: 600px) {
+            .css-1vxca1d {
+                margin: 0 auto 20px;
+            }
+        }
+        .css-1vxca1d .relatedcoverage + .recirculation {
+            margin-top: 20px;
+        }
+        .css-1vxca1d .wrap + .recirculation {
+            margin-top: 20px;
+        }
+        @media (min-width: 1024px) {
+            .css-1vxca1d {
+                padding-top: 40px;
+            }
+        }
+        .css-z1t82k {
+            display: none;
+            min-height: 280px;
+        }
+        @media (min-width: 765px) {
+            .css-z1t82k {
+                background-color: #f7f7f7;
+                border-bottom: 1px solid #f3f3f3;
+                display: block;
+                padding-bottom: 15px;
+                padding-top: 15px;
+                margin: 0;
+            }
+        }
+        @media print {
+            .css-z1t82k {
+                display: none;
+            }
+        }
+        .css-ejne5g {
+            margin-left: 20px;
+            margin-right: 20px;
+            width: calc(100% - 40px);
+            max-width: 600px;
+            display: -webkit-box;
+            display: -webkit-flex;
+            display: -ms-flexbox;
+            display: flex;
+            -webkit-align-items: flex-end;
+            -webkit-box-align: flex-end;
+            -ms-flex-align: flex-end;
+            align-items: flex-end;
+            margin-top: 0.25rem;
+            margin-bottom: 1.25rem;
+        }
+        @media (min-width: 600px) {
+            .css-ejne5g {
+                margin-left: auto;
+                margin-right: auto;
+            }
+        }
+        @media (min-width: 740px) {
+            .css-ejne5g {
+                width: 600px;
+            }
+        }
+        @media print {
+            .css-ejne5g {
+                margin-left: 0;
+                margin-right: 0;
+                width: 100%;
+                max-width: 100%;
+            }
+        }
+        @media (min-width: 740px) {
+            .css-ejne5g {
+                margin-bottom: 1.25rem;
+            }
+        }
+        .css-hme5ai {
+            -webkit-align-items: center;
+            -webkit-box-align: center;
+            -ms-flex-align: center;
+            align-items: center;
+            display: -webkit-box;
+            display: -webkit-flex;
+            display: -ms-flexbox;
+            display: flex;
+            margin-bottom: 1.25rem;
+            margin-left: 20px;
+            margin-right: 20px;
+            width: calc(100% - 40px);
+            max-width: 600px;
+        }
+        @media (min-width: 600px) {
+            .css-hme5ai {
+                margin-left: auto;
+                margin-right: auto;
+            }
+        }
+        @media (min-width: 740px) {
+            .css-hme5ai {
+                width: 600px;
+            }
+        }
+        @media print {
+            .css-hme5ai {
+                margin-left: 0;
+                margin-right: 0;
+                width: 100%;
+                max-width: 100%;
+            }
+        }
+        .css-hme5ai .e6idgb70 {
+            margin-bottom: 0;
+        }
+        @media print {
+            .css-hme5ai .e6idgb70 {
+                margin-left: 0;
+                margin-right: 0;
+                width: 100%;
+                max-width: 100%;
+            }
+        }
+        .css-hme5ai:empty {
+            display: none;
+        }
+        .css-1n0orw4 {
+            font-style: normal;
+            font-stretch: normal;
+            margin-bottom: 1.25rem;
+            color: var(--color-content-secondary, #363636);
+            font-family: nyt-cheltenham, georgia, "times new roman", times, serif;
+            font-weight: 300;
+            font-size: 1.25rem;
+            line-height: 1.5625rem;
+        }
+        @media (min-width: 740px) {
+            .css-1n0orw4 {
+                font-size: 1.4375rem;
+                line-height: 1.875rem;
+            }
+        }
+        @media (min-width: 740px) {
+            .css-1n0orw4 {
+                margin-bottom: 1.875rem;
+            }
+        }
+        .css-9hm018 {
+            color: #999;
+            display: -webkit-box;
+            display: -webkit-flex;
+            display: -ms-flexbox;
+            display: flex;
+            -webkit-flex-shrink: 0;
+            -ms-flex-negative: 0;
+            flex-shrink: 0;
+            font-family: nyt-franklin, helvetica, arial, sans-serif;
+            font-size: 17px;
+            margin-bottom: 5px;
+        }
+        @media print {
+            .css-9hm018 {
+                display: none;
+            }
+        }
+        @media (min-width: 740px) {
+            .css-9hm018 {
+                border-top: 1px solid #ebebeb;
+                padding-top: 20px;
+            }
+        }
+        .css-pga13o#ap-share-article {
+            font-family: nyt-franklin, helvetica, arial, sans-serif;
+            font-style: normal;
+            font-weight: 500;
+            font-size: 1rem;
+            line-height: 1rem;
+            color: #000;
+            padding: 21px 20px 15px 22px;
+            text-align: left;
+        }
+        @media (min-width: 1150px) {
+            .css-pga13o#ap-share-article {
+                position: static;
+                top: auto;
+                left: auto;
+                overflow-y: hidden;
+                font-size: 0.875rem;
+                line-height: 0.875rem;
+                padding: 14px;
+            }
+        }
+        #ap-gift-article-tooltip .css-pga13o {
+            padding: 13px 15px 12px 15px;
+            color: #fff;
+        }
+        #ap-gift-article .css-6yj280,
+        #ap-gift-article-tooltip .css-6yj280 {
+            font-size: 0.75rem;
+            line-height: 1.0625rem;
+        }
+        #ap-gift-article .css-6yj280 strong,
+        #ap-gift-article-tooltip .css-6yj280 strong {
+            font-weight: 700;
+        }
+        #ap-gift-article .css-6yj280,
+        #ap-gift-article-tooltip .css-6yj280 {
+            font-size: 0.875rem;
+            margin-bottom: 4px;
+        }
+        .css-8qgvsz {
+            font-weight: 700;
+        }
+        .css-1a48zt4 {
+            opacity: 1;
+            -webkit-transition: opacity 0.3s 0.2s;
+            transition: opacity 0.3s 0.2s;
+        }
+        .css-1dyerrh {
+            margin: 1.25rem auto 1.5rem;
+            margin-top: 20px;
+            margin-bottom: 32px;
+        }
+        .css-1dyerrh strong {
+            font-weight: 700;
+        }
+        .css-1dyerrh em {
+            font-style: italic;
+        }
+        .css-1dyerrh.sizeSmall {
+            width: calc(100% - 40px);
+            display: -webkit-box;
+            display: -webkit-flex;
+            display: -ms-flexbox;
+            display: flex;
+        }
+        @media (min-width: 600px) {
+            .css-1dyerrh.sizeSmall {
+                max-width: 600px;
+                margin-left: auto;
+                margin-right: auto;
+            }
+        }
+        @media (min-width: 1024px) {
+            .css-1dyerrh.sizeSmall {
+                width: 100%;
+            }
+        }
+        @media (min-width: 1440px) {
+            .css-1dyerrh.sizeSmall {
+                max-width: 600px;
+            }
+        }
+        .css-1dyerrh.sizeSmall.sizeSmallNoCaption {
+            display: block;
+        }
+        @media print {
+            .css-1dyerrh.sizeSmall.sizeSmallNoCaption {
+                display: none;
+            }
+        }
+        .css-1dyerrh.sizeMedium {
+            width: 100%;
+            max-width: 600px;
+            margin-right: auto;
+            margin-left: auto;
+        }
+        @media (min-width: 600px) {
+            .css-1dyerrh.sizeMedium {
+                width: calc(100% - 40px);
+            }
+        }
+        @media (min-width: 740px) {
+            .css-1dyerrh.sizeMedium {
+                max-width: 600px;
+            }
+        }
+        @media (min-width: 600px) {
+            .css-1dyerrh.sizeMedium.layoutVertical {
+                width: 420px;
+            }
+        }
+        .css-1dyerrh.sizeMedium.layoutVertical.verticalVideo {
+            width: calc(100% - 40px);
+        }
+        @media (min-width: 600px) {
+            .css-1dyerrh.sizeMedium.layoutVertical.verticalVideo {
+                width: 310px;
+            }
+        }
+        .css-1dyerrh.sizeLarge {
+            width: 100%;
+            max-width: 1200px;
+            margin-left: auto;
+            margin-right: auto;
+        }
+        @media (min-width: 600px) {
+            .css-1dyerrh.sizeLarge {
+                width: auto;
+            }
+        }
+        @media (min-width: 740px) {
+            .css-1dyerrh.sizeLarge.layoutVertical {
+                width: 600px;
+            }
+            .css-1dyerrh.sizeLarge.layoutVertical.verticalVideo {
+                width: 600px;
+            }
+        }
+        @media (min-width: 1024px) {
+            .css-1dyerrh.sizeLarge {
+                width: 945px;
+            }
+        }
+        @media (min-width: 1440px) {
+            .css-1dyerrh.sizeLarge {
+                width: 1200px;
+            }
+            .css-1dyerrh.sizeLarge.layoutVertical {
+                width: 720px;
+            }
+            .css-1dyerrh.sizeLarge.layoutVertical.verticalVideo {
+                width: 600px;
+            }
+        }
+        @media (min-width: 740px) {
+            .css-1dyerrh {
+                margin: 2.5rem auto;
+            }
+        }
+        @media print {
+            .css-1dyerrh {
+                display: none;
+            }
+        }
+        @media (min-width: 740px) {
+            .css-1dyerrh {
+                margin-top: 25px;
+            }
+        }
+        .css-rq4mmj {
+            height: auto;
+            width: 100%;
+            width: 100%;
+            vertical-align: top;
+        }
+        .css-rq4mmj img {
+            width: 100%;
+            vertical-align: top;
+        }
+        .css-y5g5d7 {
+            color: var(--color-content-quaternary, #727272);
+            font-family: nyt-imperial, georgia, "times new roman", times, serif;
+            margin: 10px 20px 0;
+            text-align: left;
+        }
+        .css-y5g5d7 a {
+            color: var(--color-signal-editorial, #326891);
+            -webkit-text-decoration: none;
+            text-decoration: none;
+        }
+        .css-y5g5d7 a:hover,
+        .css-y5g5d7 a:focus {
+            -webkit-text-decoration: underline;
+            text-decoration: underline;
+        }
+        @media (min-width: 600px) {
+            .css-y5g5d7 {
+                margin-left: 0;
+            }
+        }
+        .sizeSmall .css-y5g5d7 {
+            display: -webkit-box;
+            display: -webkit-flex;
+            display: -ms-flexbox;
+            display: flex;
+            -webkit-flex-direction: column;
+            -ms-flex-direction: column;
+            flex-direction: column;
+            width: calc(50% - 15px);
+            margin: auto 0 15px 15px;
+        }
+        @media (min-width: 600px) {
+            .sizeSmall .css-y5g5d7 {
+                width: 260px;
+                margin-left: 15px;
+            }
+        }
+        @media (min-width: 740px) {
+            .sizeSmall .css-y5g5d7 {
+                margin-left: 15px;
+            }
+        }
+        @media (min-width: 1440px) {
+            .sizeSmall .css-y5g5d7 {
+                width: 330px;
+                margin-left: 15px;
+            }
+        }
+        @media (max-width: 600px) {
+            .sizeSmall .css-y5g5d7 {
+                margin: auto 0 0 15px;
+            }
+        }
+        .sizeSmall.sizeSmallNoCaption .css-y5g5d7 {
+            margin-left: auto;
+            margin-right: auto;
+            margin-top: 10px;
+        }
+        .sizeMedium .css-y5g5d7 {
+            max-width: 900px;
+        }
+        .sizeMedium.layoutVertical.verticalVideo .css-y5g5d7 {
+            margin-left: 0;
+            margin-right: 0;
+        }
+        .sizeLarge .css-y5g5d7 {
+            max-width: none;
+        }
+        @media (min-width: 600px) {
+            .sizeLarge .css-y5g5d7 {
+                margin-left: 20px;
+            }
+        }
+        @media (min-width: 740px) {
+            .sizeLarge .css-y5g5d7 {
+                margin-left: 20px;
+                max-width: 900px;
+            }
+        }
+        @media (min-width: 1024px) {
+            .sizeLarge .css-y5g5d7 {
+                margin-left: 0;
+                max-width: 720px;
+            }
+        }
+        @media (min-width: 1440px) {
+            .sizeLarge .css-y5g5d7 {
+                margin-left: 0;
+                max-width: 900px;
+            }
+        }
+        @media (min-width: 740px) {
+            .sizeLarge.layoutVertical .css-y5g5d7 {
+                margin-left: 0;
+            }
+        }
+        .sizeFull .css-y5g5d7 {
+            margin-left: 20px;
+        }
+        @media (min-width: 600px) {
+            .sizeFull .css-y5g5d7 {
+                max-width: 900px;
+            }
+        }
+        @media (min-width: 740px) {
+            .sizeFull .css-y5g5d7 {
+                max-width: 900px;
+            }
+        }
+        @media (min-width: 1440px) {
+            .sizeFull .css-y5g5d7 {
+                max-width: 900px;
+            }
+        }
+        @media print {
+            .css-y5g5d7 {
+                display: none;
+            }
+        }
+        .css-1u46b97 {
+            display: inline;
+            color: var(--color-content-quaternary, #727272);
+            font-family: nyt-imperial, georgia, "times new roman", times, serif;
+            line-height: 1.125rem;
+            -webkit-letter-spacing: 0.01em;
+            -moz-letter-spacing: 0.01em;
+            -ms-letter-spacing: 0.01em;
+            letter-spacing: 0.01em;
+            font-size: 0.75rem;
+        }
+        @media (min-width: 740px) {
+            .css-1u46b97 {
+                font-size: 0.75rem;
+            }
+        }
+        @media (min-width: 1150px) {
+            .css-1u46b97 {
+                font-size: 0.8125rem;
+            }
+        }
+        .css-1e2jphy {
+            display: -webkit-box;
+            display: -webkit-flex;
+            display: -ms-flexbox;
+            display: flex;
+            width: 100%;
+            -webkit-align-items: center;
+            -webkit-box-align: center;
+            -ms-flex-align: center;
+            align-items: center;
+            margin-bottom: 0.25rem;
+        }
+        .css-1e2jphy > img,
+        .css-1e2jphy a > img,
+        .css-1e2jphy div > img {
+            margin-right: 10px;
+        }
+        .css-233int {
+            display: inline-block;
+        }
+        .css-4anu6l {
+            display: inline-block;
+            margin: 0;
+            font-size: 0.875rem;
+            line-height: 1.125rem;
+            font-family: nyt-franklin, helvetica, arial, sans-serif;
+            font-weight: 700;
+            color: var(--color-content-secondary, #363636);
+        }
+        @media (min-width: 740px) {
+            .css-4anu6l {
+                font-size: 0.9375rem;
+                line-height: 1.25rem;
+            }
+        }
+        .css-at9mc1 {
+            margin-bottom: 0.78125rem;
+            margin-top: 0;
+            overflow-wrap: break-word;
+            color: var(--color-content-secondary, #363636);
+            font-family: nyt-imperial, georgia, "times new roman", times, serif;
+            font-size: 1.125rem;
+            line-height: 1.5625rem;
+            margin-left: 20px;
+            margin-right: 20px;
+            width: calc(100% - 40px);
+            max-width: 600px;
+        }
+        @media (min-width: 740px) {
+            .css-at9mc1 {
+                margin-bottom: 0.9375rem;
+                margin-top: 0;
+            }
+        }
+        .css-at9mc1 .css-yywogo {
+            -webkit-text-decoration: underline;
+            text-decoration: underline;
+            -webkit-text-decoration-style: solid;
+            text-decoration-style: solid;
+            -webkit-text-decoration-thickness: 1px;
+            text-decoration-thickness: 1px;
+            -webkit-text-decoration-color: var(--color-signal-editorial, #326891);
+            text-decoration-color: var(--color-signal-editorial, #326891);
+        }
+        .css-at9mc1 .css-yywogo:hover,
+        .css-at9mc1 .css-yywogo:focus {
+            -webkit-text-decoration: none;
+            text-decoration: none;
+        }
+        @media (min-width: 740px) {
+            .css-at9mc1 {
+                font-size: 1.25rem;
+                line-height: 1.875rem;
+            }
+        }
+        .css-at9mc1:first-child {
+            margin-top: 0;
+        }
+        .css-at9mc1:last-child {
+            margin-bottom: 0;
+        }
+        .css-at9mc1.e1h9rw200:last-child {
+            margin-bottom: 0.75rem;
+        }
+        .css-at9mc1.eoo0vm40:first-child {
+            margin-top: 0.8125rem;
+        }
+        @media (min-width: 600px) {
+            .css-at9mc1 {
+                margin-left: auto;
+                margin-right: auto;
+            }
+        }
+        @media (min-width: 1024px) {
+            .css-at9mc1 {
+                margin-left: 0;
+                margin-right: 0;
+                width: 100%;
+                max-width: 100%;
+            }
+            .css-at9mc1.eoo0vm40:first-child {
+                margin-top: 1.1875rem;
+            }
+        }
+        @media print {
+            .css-at9mc1 {
+                margin-left: 0;
+                margin-right: 0;
+                width: 100%;
+                max-width: 100%;
+            }
+        }
+        .css-c4adj9 {
+            background-color: #f7f7f7;
+            border-bottom: 1px solid #f3f3f3;
+            border-top: 1px solid #f3f3f3;
+            margin: 2rem auto;
+            padding-bottom: 30px;
+            padding-top: 12px;
+            text-align: center;
+            margin-top: 60px;
+            min-height: 280px;
+        }
+        @media (min-width: 740px) {
+            .css-c4adj9 {
+                margin: 3rem auto;
+            }
+        }
+        @media print {
+            .css-c4adj9 {
+                display: none;
+            }
+        }
+        @media (min-width: 740px) {
+            .css-c4adj9 {
+                margin-bottom: 0;
+                margin-top: 0;
+            }
+        }
+        .css-1ho5u4o {
+            list-style: none;
+            margin: 0 0 15px;
+            padding: 0;
+        }
+        @media (min-width: 600px) {
+            .css-1ho5u4o {
+                display: inline-block;
+            }
+        }
+        .css-13o0c9t {
+            list-style: none;
+            line-height: 8px;
+            margin: 0 0 35px;
+            padding: 0;
+        }
+        @media (min-width: 600px) {
+            .css-13o0c9t {
+                display: inline-block;
+            }
+        }
+        .css-a7htku {
+            display: inline-block;
+            line-height: 20px;
+            padding: 0 10px;
+        }
+        .css-a7htku:first-child {
+            border-left: none;
+        }
+        .css-a7htku.desktop {
+            display: none;
+        }
+        @media (min-width: 740px) {
+            .css-a7htku.smartphone {
+                display: none;
+            }
+            .css-a7htku.desktop {
+                display: inline-block;
+            }
+            .css-a7htku.mobileOnly {
+                display: none;
+            }
+        }
+        .css-8z235g {
+            margin-top: 1.5625rem;
+        }
+        @media (min-width: 740px) {
+            .css-8z235g {
+                margin-top: 3.75rem;
+            }
+        }
+        .css-8z235g .e6idgb70 {
+            color: var(--color-content-primary, #121212);
+            font-weight: 700;
+            line-height: 0.75rem;
+        }
+        @media print {
+            .css-8z235g .e6idgb70 {
+                margin-left: 0;
+                margin-right: 0;
+                width: 100%;
+                max-width: 100%;
+            }
+        }
+        .css-8z235g .e1h9rw200 {
+            margin-bottom: 0.5rem;
+            margin-left: 20px;
+            margin-right: 20px;
+            width: calc(100% - 40px);
+            max-width: 600px;
+            margin-top: 0;
+        }
+        @media (min-width: 600px) {
+            .css-8z235g .e1h9rw200 {
+                margin-left: auto;
+                margin-right: auto;
+            }
+        }
+        @media (min-width: 740px) {
+            .css-8z235g .e1h9rw200 {
+                width: 600px;
+            }
+        }
+        @media print {
+            .css-8z235g .e1h9rw200 {
+                margin-left: 0;
+                margin-right: 0;
+                width: 100%;
+                max-width: 100%;
+            }
+        }
+        @media (min-width: 740px) {
+            .css-8z235g .e1h9rw200 {
+                max-width: none;
+                margin-left: auto;
+                margin-right: auto;
+                position: relative;
+                width: 600px;
+            }
+            @media print {
+                .css-8z235g .e1h9rw200 {
+                    margin-left: 0;
+                    margin-right: 0;
+                    width: 100%;
+                    max-width: 100%;
+                }
+            }
+        }
+        .css-8z235g .e1wiw3jv0 {
+            color: var(--color-content-secondary, #363636);
+            margin-left: 20px;
+            margin-right: 20px;
+            width: calc(100% - 40px);
+            max-width: 600px;
+        }
+        @media (min-width: 600px) {
+            .css-8z235g .e1wiw3jv0 {
+                margin-left: auto;
+                margin-right: auto;
+            }
+        }
+        @media (min-width: 740px) {
+            .css-8z235g .e1wiw3jv0 {
+                width: 600px;
+            }
+        }
+        @media print {
+            .css-8z235g .e1wiw3jv0 {
+                margin-left: 0;
+                margin-right: 0;
+                width: 100%;
+                max-width: 100%;
+            }
+        }
+        @media print {
+            .css-8z235g .e1wiw3jv0 {
+                margin-left: 0;
+                margin-right: 0;
+                width: 100%;
+                max-width: 100%;
+            }
+        }
+        .css-8z235g .e16638kd0 {
+            display: inline-block;
+            width: auto;
+            margin-left: 0;
+            margin-top: 0;
+            margin-bottom: 0;
+        }
+        .css-8z235g .eatfx1z0 {
+            margin-right: 15px;
+            font-weight: 700;
+            font-size: 14px;
+            line-height: 1;
+        }
+        .css-8z235g .section-kicker .opinion-bar {
+            font-size: 25px;
+        }
+        .css-8z235g .css-sklrp3 {
+            margin-left: 20px;
+            margin-right: 20px;
+            width: calc(100% - 40px);
+            max-width: 600px;
+            margin-top: 0;
+            margin-bottom: 0;
+        }
+        @media (min-width: 600px) {
+            .css-8z235g .css-sklrp3 {
+                margin-left: auto;
+                margin-right: auto;
+            }
+        }
+        @media (min-width: 740px) {
+            .css-8z235g .css-sklrp3 {
+                width: 600px;
+            }
+        }
+        @media print {
+            .css-8z235g .css-sklrp3 {
+                margin-left: 0;
+                margin-right: 0;
+                width: 100%;
+                max-width: 100%;
+            }
+        }
+        .css-8z235g .e1g7ppur0 {
+            margin-bottom: 30px;
+            margin-top: 20px;
+        }
+        @media (min-width: 740px) {
+            .css-8z235g .e1g7ppur0 {
+                margin-top: 25px;
+            }
+        }
+        @media (min-width: 1024px) {
+            .css-8z235g .e1g7ppur0 {
+                margin-bottom: 43px;
+            }
+        }
+        .css-8z235g .css-mdjrty {
+            margin-left: 20px;
+            margin-right: 20px;
+            width: calc(100% - 40px);
+            max-width: 600px;
+            max-width: 600px;
+        }
+        @media (min-width: 600px) {
+            .css-8z235g .css-mdjrty {
+                margin-left: auto;
+                margin-right: auto;
+            }
+        }
+        @media (min-width: 740px) {
+            .css-8z235g .css-mdjrty {
+                width: 600px;
+            }
+        }
+        @media print {
+            .css-8z235g .css-mdjrty {
+                margin-left: 0;
+                margin-right: 0;
+                width: 100%;
+                max-width: 100%;
+            }
+        }
+        @media print {
+            .css-8z235g .css-mdjrty {
+                display: none;
+            }
+        }
+        .css-8z235g .eakwutd0 {
+            margin-bottom: 20px;
+            color: var(--color-content-primary, #121212);
+        }
+        @media print {
+            .css-8z235g .eakwutd0 {
+                margin-left: 0;
+                margin-right: 0;
+                width: 100%;
+                max-width: 100%;
+            }
+        }
+        .css-1l8buln {
+            color: var(--color-content-primary, #121212);
+            font-family: nyt-cheltenham, georgia, "times new roman", times, serif;
+            font-weight: 700;
+            font-style: italic;
+            font-size: 1.9375rem;
+            line-height: 2.25rem;
+            text-align: left;
+        }
+        @media (min-width: 740px) {
+            .css-1l8buln {
+                font-size: 2.5rem;
+                line-height: 2.875rem;
+            }
+        }
+        .css-jevhma {
+            margin-right: 7px;
+            color: var(--color-content-quaternary, #727272);
+            font-family: nyt-imperial, georgia, "times new roman", times, serif;
+            font-size: 0.875rem;
+            line-height: 1.125rem;
+        }
+        @media (min-width: 740px) {
+            .css-jevhma {
+                font-size: 0.9375rem;
+                line-height: 1.25rem;
+            }
+        }
+        .css-jevhma strong {
+            font-weight: 700;
+        }
+        .css-jevhma em {
+            font-style: italic;
+        }
+        .css-jevhma a {
+            color: var(--color-signal-editorial, #326891);
+        }
+        .css-jevhma a:visited {
+            color: var(--color-signal-editorial, #326891);
+        }
+        .css-n8ff4n {
+            color: inherit;
+            -webkit-text-decoration: underline;
+            text-decoration: underline;
+            text-underline-offset: 1px;
+            -webkit-text-decoration-thickness: 1px;
+            text-decoration-thickness: 1px;
+            -webkit-text-decoration-color: var(--color-content-quaternary, #727272);
+            text-decoration-color: var(--color-content-quaternary, #727272);
+        }
+        .css-n8ff4n:hover,
+        .css-n8ff4n:focus {
+            -webkit-text-decoration: none;
+            text-decoration: none;
+        }
+        .css-8blifj {
+            font-family: nyt-franklin, helvetica, arial, sans-serif;
+            font-weight: 500;
+            color: var(--color-content-secondary, #363636);
+            margin-bottom: 1rem;
+            font-size: 0.8125rem;
+            line-height: 1rem;
+            margin-bottom: 0;
+            display: -webkit-box;
+            display: -webkit-flex;
+            display: -ms-flexbox;
+            display: flex;
+            -webkit-flex-wrap: wrap;
+            -ms-flex-wrap: wrap;
+            flex-wrap: wrap;
+            -webkit-flex-shrink: 1;
+            -ms-flex-negative: 1;
+            flex-shrink: 1;
+        }
+        .css-1sbuyqj {
+            display: inline-block;
+            padding-right: 1em;
+        }
+        .css-d754w4 {
+            width: 100%;
+            max-width: 600px;
+            margin: 1.25rem auto 1.5rem;
+        }
+        @media (min-width: 600px) {
+            .css-d754w4 {
+                width: calc(100% - 40px);
+            }
+        }
+        @media (min-width: 740px) {
+            .css-d754w4 {
+                width: auto;
+                max-width: 600px;
+            }
+        }
+        @media (min-width: 740px) {
+            .css-d754w4 {
+                margin: 2.5rem auto;
+            }
+        }
+        .css-d754w4 strong {
+            font-weight: 700;
+        }
+        .css-d754w4 em {
+            font-style: italic;
+        }
+        .css-xaa95i {
+            font-family: nyt-imperial, georgia, "times new roman", times, serif;
+            color: var(--color-content-quaternary, #727272);
+            margin: 10px 20px 0 20px;
+            text-align: left;
+        }
+        .css-xaa95i a {
+            color: var(--color-signal-editorial, #326891);
+            -webkit-text-decoration: none;
+            text-decoration: none;
+        }
+        .css-xaa95i a:hover,
+        .css-xaa95i a:focus {
+            -webkit-text-decoration: underline;
+            text-decoration: underline;
+        }
+        @media (min-width: 600px) {
+            .css-xaa95i {
+                margin-left: 0;
+                margin-right: 20px;
+            }
+        }
+        @media (min-width: 1440px) {
+            .css-xaa95i {
+                max-width: px;
+            }
+        }
+        .css-7v35jk {
+            display: -webkit-box;
+            display: -webkit-flex;
+            display: -ms-flexbox;
+            display: flex;
+            -webkit-align-items: center;
+            -webkit-box-align: center;
+            -ms-flex-align: center;
+            align-items: center;
+            -webkit-box-pack: left;
+            -webkit-justify-content: left;
+            -ms-flex-pack: left;
+            justify-content: left;
+            background: var(--color-background-elevated, #ffffff);
+            border-bottom: 1px solid var(--color-stroke-quaternary, #dfdfdf);
+            min-height: 55px;
+            position: relative;
+        }
+        @media (min-width: 600px) {
+            .css-7v35jk {
+                -webkit-box-pack: center;
+                -webkit-justify-content: center;
+                -ms-flex-pack: center;
+                justify-content: center;
+            }
+        }
+        @media print {
+            .css-7v35jk {
+                display: none;
+            }
+        }
+        .css-7v35jk::after {
+            content: "";
+            position: absolute;
+            top: 0;
+            left: 0;
+            height: 100%;
+            width: 100%;
+            z-index: -1;
+            box-shadow: 0 0 transparent, 0 0 transparent, 1px 3px 6px #00000026;
+            opacity: 0;
+            -webkit-transition: opacity 200ms ease-out;
+            transition: opacity 200ms ease-out;
+        }
+        @media (prefers-color-scheme: dark) {
+            .NYTApp .css-7v35jk::after {
+                box-shadow: none;
+            }
+        }
+        .css-fi5tub {
+            font-family: nyt-franklin, helvetica, arial, sans-serif;
+            -webkit-flex-shrink: 0;
+            -ms-flex-negative: 0;
+            flex-shrink: 0;
+            font-size: 0.8125rem;
+            font-weight: 500;
+            color: var(--color-content-primary, #121212);
+        }
+        @media (min-width: 600px) {
+            .css-fi5tub {
+                font-size: 0.875rem;
+            }
+        }
+        .css-2fg4z9 {
+            font-style: italic;
+        }
+        .css-xactqe {
+            color: var(--color-content-primary, #121212);
+            font-family: nyt-cheltenham, georgia, "times new roman", times, serif;
+            font-weight: 600;
+            font-size: 1.625rem;
+            line-height: 1.875rem;
+            margin-left: 20px;
+            margin-right: 20px;
+            width: calc(100% - 40px);
+            max-width: 600px;
+            margin: 30px 20px 0.75rem;
+            text-align: left;
+        }
+        @media (min-width: 740px) {
+            .css-xactqe {
+                font-size: 1.75rem;
+                line-height: 2.125rem;
+            }
+        }
+        .css-xactqe .css-yywogo {
+            border-bottom: 1px solid var(--color-signal-editorial, #326891);
+            -webkit-text-decoration: none;
+            text-decoration: none;
+        }
+        .css-xactqe .css-yywogo:hover,
+        .css-xactqe .css-yywogo:focus {
+            border-bottom: 1px solid var(--color-signal-editorial, #326891);
+            -webkit-text-decoration: none;
+            text-decoration: none;
+        }
+        .css-xactqe:first-child {
+            margin-top: 0;
+        }
+        .css-xactqe:last-child {
+            margin-bottom: 0;
+        }
+        .css-xactqe.e1h9rw200:last-child {
+            margin-bottom: 0.75rem;
+        }
+        .css-xactqe.eoo0vm40:first-child {
+            margin-top: 0.8125rem;
+        }
+        @media (min-width: 600px) {
+            .css-xactqe {
+                margin-left: auto;
+                margin-right: auto;
+            }
+        }
+        @media (min-width: 1024px) {
+            .css-xactqe {
+                margin-left: 0;
+                margin-right: 0;
+                width: 100%;
+                max-width: 100%;
+            }
+            .css-xactqe.eoo0vm40:first-child {
+                margin-top: 1.1875rem;
+            }
+        }
+        @media print {
+            .css-xactqe {
+                margin-left: 0;
+                margin-right: 0;
+                width: 100%;
+                max-width: 100%;
+            }
+        }
+        @media (min-width: 740px) {
+            .css-xactqe {
+                margin-top: 35px;
+                margin-left: auto;
+                margin-right: auto;
+                margin-bottom: 1.25rem;
+            }
+        }
+        @media print {
+            .css-xactqe {
+                margin-left: 0;
+                margin-right: 0;
+                width: 100%;
+                max-width: 100%;
+            }
+        }
+        .css-11rqvxt {
+            font-family: nyt-franklin, helvetica, arial, sans-serif;
+            font-size: 0.875rem;
+            line-height: 0.875rem;
+            font-weight: 700;
+            -webkit-flex-shrink: 0;
+            -ms-flex-negative: 0;
+            flex-shrink: 0;
+            width: auto;
+            display: -webkit-box;
+            display: -webkit-flex;
+            display: -ms-flexbox;
+            display: flex;
+            margin-right: 16px;
+            padding-right: 15px;
+            color: var(--color-content-primary, #121212);
+            background-color: var(--color-background-elevated, #ffffff);
+            box-shadow: 4px 0 7px 10px var(--color-background-elevated, #ffffff);
+            border-right: 1px solid var(--color-stroke-quaternary, #dfdfdf);
+            color: var(--color-content-primary, #121212);
+        }
+        @media (min-width: 600px) {
+            .css-11rqvxt {
+                font-size: 0.9375rem;
+                line-height: 0.9375rem;
+            }
+        }
+        .css-fbykdt {
+            margin: 0 6px 0 0;
+            width: 6px;
+            height: 6px;
+            border-radius: 50%;
+            background-color: var(--color-background-quaternary, #c7c7c7);
+            -webkit-transition: background-color 0.2s ease;
+            transition: background-color 0.2s ease;
+            background-color: var(--color-background-inversePrimary, #121212);
+        }
+        .css-1tnh8ll {
+            display: -webkit-inline-box;
+            display: -webkit-inline-flex;
+            display: -ms-inline-flexbox;
+            display: inline-flex;
+            -webkit-box-pack: center;
+            -webkit-justify-content: center;
+            -ms-flex-pack: center;
+            justify-content: center;
+            -webkit-align-items: center;
+            -webkit-box-align: center;
+            -ms-flex-align: center;
+            align-items: center;
+            white-space: nowrap;
+            width: 25px;
+            height: 25px;
+            border-radius: 50%;
+            background-color: var(--color-background-primary, #ffffff);
+            border: 1px solid var(--color-stroke-quaternary, #dfdfdf);
+            cursor: pointer;
+            outline: none;
+            left: 0;
+            margin-right: 10px;
+            cursor: default;
+        }
+        .css-1tnh8ll::after {
+            content: "";
+            display: inline-block;
+            margin-left: 2px;
+            margin-bottom: 1;
+            width: 7px;
+            height: 7px;
+            line-height: 0;
+            border-top: 2px solid var(--color-content-primary, #121212);
+            border-right: 2px solid var(--color-content-primary, #121212);
+            border-color: var(--color-content-primary, #121212);
+        }
+        .css-1tnh8ll:hover {
+            background-color: var(--color-stroke-quaternary, #dfdfdf);
+        }
+        .css-1tnh8ll::after {
+            -webkit-transform: rotate(-135deg);
+            -ms-transform: rotate(-135deg);
+            transform: rotate(-135deg);
+        }
+        .css-1tnh8ll:hover {
+            background-color: var(--color-background-primary, #ffffff);
+        }
+        .css-1tnh8ll::after {
+            border-color: var(--color-stroke-quaternary, #dfdfdf);
+        }
+        .css-1vxyf6h {
+            width: 100%;
+            max-width: 600px;
+            margin: 1.25rem auto 1.5rem;
+        }
+        @media (min-width: 600px) {
+            .css-1vxyf6h {
+                width: calc(100% - 40px);
+            }
+        }
+        @media (min-width: 740px) {
+            .css-1vxyf6h {
+                width: auto;
+                max-width: 600px;
+            }
+        }
+        @media (min-width: 600px) {
+            .css-1vxyf6h {
+                width: 420px;
+            }
+        }
+        @media (min-width: 740px) {
+            .css-1vxyf6h {
+                margin: 2.5rem auto;
+            }
+        }
+        .css-1vxyf6h strong {
+            font-weight: 700;
+        }
+        .css-1vxyf6h em {
+            font-style: italic;
+        }
+    </style>
+
+    <script type="text/javascript">
+        // 32.96kB
+        window.viHeadScriptSize = 32.96;
+        window.NYTD = {};
+        window.vi = window.vi || {};
+        window.vi.pageType = { type: "", edge: "vi-story" };
+        (function () {
+            var userAgent =
+                window.navigator.userAgent ||
+                window.navigator.vendor ||
+                window.opera ||
+                "",
+              inNewsreaderApp =
+                userAgent.includes("nytios") || userAgent.includes("nyt_android"),
+              inXWordsApp =
+                userAgent.includes("nyt_xwords_ios") ||
+                userAgent.includes("Crosswords"),
+              inAndroid =
+                userAgent.includes("nyt_android") ||
+                userAgent.includes("Crosswords"),
+              iniOS =
+                userAgent.includes("nytios") ||
+                userAgent.includes("nyt_xwords_ios"),
+              isInWebviewByUserAgent =
+                (inAndroid || iniOS) && (inNewsreaderApp || inXWordsApp);
+            function appType() {
+                return inNewsreaderApp
+                  ? "newsreader"
+                  : inXWordsApp
+                    ? "crosswords"
+                    : "";
+            }
+            function deviceType() {
+                return inAndroid ? "ANDROID" : iniOS ? "IOS" : "";
+            }
+            var _f = function (e) {
+                window.vi.webviewEnvironment = {
+                    appType: appType(),
+                    deviceType: deviceType(),
+                    isInWebview:
+                      e.webviewEnvironment.isInWebview || isInWebviewByUserAgent,
+                };
+            };
+            _f.apply(null, [
+                {
+                    gqlUrlClient: "https://samizdat-graphql.nytimes.com/graphql/v2",
+                    gqlRequestHeaders: {
+                        "nyt-app-type": "project-vi",
+                        "nyt-app-version": "0.0.5",
+                        "nyt-token":
+                          "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAs+/oUCTBmD/cLdmcecrnBMHiU/pxQCn2DDyaPKUOXxi4p0uUSZQzsuq1pJ1m5z1i0YGPd1U1OeGHAChWtqoxC7bFMCXcwnE1oyui9G1uobgpm1GdhtwkR7ta7akVTcsF8zxiXx7DNXIPd2nIJFH83rmkZueKrC4JVaNzjvD+Z03piLn5bHWU6+w+rA+kyJtGgZNTXKyPh6EC6o5N+rknNMG5+CdTq35p8f99WjFawSvYgP9V64kgckbTbtdJ6YhVP58TnuYgr12urtwnIqWP9KSJ1e5vmgf3tunMqWNm6+AnsqNj8mCLdCuc5cEB74CwUeQcP2HQQmbCddBy2y0mEwIDAQAB",
+                    },
+                    gqlFetchTimeout: 1500,
+                    disablePersistedQueries: false,
+                    fastlyHeaders: {},
+                    initialDeviceType: "desktop",
+                    fastlyAbraConfig: {
+                        ".ver": "10910.000",
+                        HOME_chartbeat: "0_Control",
+                        INT_cwv_dfp_deferAds_0322: "",
+                        MX_NewArchitecture_gamesLP: "0_Control",
+                    },
+                    internalPreviewConfig: {},
+                    webviewEnvironment: { isInWebview: false },
+                    serviceWorkerFile: "service-worker-test-1669657616122.js",
+                },
+            ]);
+        })();
+        (function () {
+            var _f = function (i) {
+                (window.vi = window.vi || {}),
+                  (window.vi.env = Object.freeze(i)),
+                  (window.hybrid = !1);
+            };
+            _f.apply(null, [
+                {
+                    JKIDD_PATH: "https://a.nytimes.com/svc/nyt/data-layer",
+                    ET2_URL: "https://a.et.nytimes.com",
+                    ALS_URL: "https://als-svc.nytimes.com",
+                    WEDDINGS_PATH: "https://content.api.nytimes.com",
+                    GDPR_PATH:
+                      "https://us-central1-nyt-dsra-prd.cloudfunctions.net/datagov-dsr-formhandler",
+                    RECAPTCHA_SITEKEY: "6LevSGcUAAAAAF-7fVZF05VTRiXvBDAY4vBSPaTF",
+                    ABRA_ET_URL: "//et.nytimes.com",
+                    NODE_ENV: "production",
+                    EXPERIMENTAL_ROUTE_PREFIX: "",
+                    ENVIRONMENT: "prd",
+                    RELEASE: "3c1954f16c628adac7f75074613cc5f18af9a916",
+                    RELEASE_TAG: "vi-newsreader@v2717",
+                    AUTH_HOST: "https://myaccount.nytimes.com",
+                    METER_HOST: "https://meter-svc.nytimes.com",
+                    MESSAGING_LANDING_PAGE_HOST: "https://www.nytimes.com",
+                    CAPI_HOST: "https://mwcm.nytimes.com",
+                    SWG_PUBLICATION_ID: "nytimes.com",
+                    GQL_FETCH_TIMEOUT: "1500",
+                    GOOGLE_CLIENT_ID:
+                      "1005640118348-amh5tgkq641oru4fbhr3psm3gt2tcc94.apps.googleusercontent.com",
+                    STORY_SURROGATE_CONTROL:
+                      "max-age=300, stale-if-error=259200, stale-while-revalidate=259200",
+                    ONBOARDING_API_KEY: "lpCO5UAWFCa4e4KyawC71aeNUZ7n92r06JwVu6w4",
+                },
+            ]);
+        })();
+        (function () {
+            var _f = function () {
+                var e = window;
+                e.initWebview = function (e) {
+                    var i = document.documentElement;
+                    if (e.OS) {
+                        var t = e.OS.toUpperCase();
+                        i.classList.add(t);
+                    }
+                    e.BaseFontSize && (i.dataset.baseFontSize = e.BaseFontSize);
+                };
+                var i = e.navigator.userAgent.toLowerCase();
+                /iphone|ipod|ipad/.test(i) ||
+                void 0 === e.config ||
+                e.initWebview(e.config);
+            };
+            _f.apply(null, []);
+        })();
+        !(function (a) {
+            var s,
+              c,
+              p,
+              _,
+              d,
+              l,
+              u = [],
+              f = {
+                  pv_id: "",
+                  ctx_id: "",
+                  intra: !1,
+                  force_xhr: !1,
+                  store_last_response: !1,
+              },
+              g =
+                "object" == typeof a.navigator &&
+                "string" == typeof a.navigator.userAgent &&
+                /iP(ad|hone|od)/.test(a.navigator.userAgent),
+              y = "object" == typeof a.navigator && a.navigator.sendBeacon,
+              v = y ? (g ? "xhr_ios" : "beacon") : "xhr";
+            function h() {
+                var e,
+                  t,
+                  n = a.crypto || a.msCrypto;
+                if (n) t = n.getRandomValues(new Uint8Array(18));
+                else
+                    for (t = []; t.length < 18; )
+                        t.push((256 * Math.random()) ^ (255 & (e = e || +new Date()))),
+                          (e = Math.floor(e / 256));
+                return btoa(String.fromCharCode.apply(String, t))
+                  .replace(/\+/g, "-")
+                  .replace(/\//g, "_");
+            }
+            if (a.nyt_et)
+                try {
+                    console.warn("et2 snippet should only load once per page");
+                } catch (e) {}
+            else
+                (a.nyt_et = function () {
+                    var e,
+                      t,
+                      n,
+                      o = arguments;
+                    function r(e) {
+                        var t, n, o, r, i;
+                        u.length &&
+                        ((t = s + "track"),
+                          (n = JSON.stringify(u)),
+                          (e = e),
+                          (o = f.force_xhr),
+                          (r = f.store_last_response),
+                          !o && ("beacon" === v || (y && e))
+                            ? ((o = a.navigator.sendBeacon(t, n)), r && (l = o))
+                            : ((i =
+                              "undefined" != typeof XMLHttpRequest
+                                ? new XMLHttpRequest()
+                                : new ActiveXObject("Microsoft.XMLHTTP")).open(
+                              "POST",
+                              t
+                            ),
+                              (i.withCredentials = !0),
+                              i.setRequestHeader("Accept", "*/*"),
+                              "string" == typeof n
+                                ? i.setRequestHeader(
+                                  "Content-Type",
+                                  "text/plain;charset=UTF-8"
+                                )
+                                : "[object Blob]" === {}.toString.call(n) &&
+                                n.type &&
+                                i.setRequestHeader("Content-Type", n.type),
+                            r &&
+                            !i.onload &&
+                            ((i.onload = function () {
+                                l = i.response;
+                            }),
+                              (i.onerror = function (e) {
+                                  l = !1;
+                              })),
+                              i.send(n)),
+                          (u.length = 0),
+                          clearTimeout(d),
+                          (d = null));
+                    }
+                    if (
+                      "string" == typeof o[0] &&
+                      /init/.test(o[0]) &&
+                      ((f = (function (e, t) {
+                          var n = "",
+                            o = "",
+                            r = !1,
+                            i = !1,
+                            a = !1;
+                          if (
+                            "string" == typeof e &&
+                            "init" == e &&
+                            "object" == typeof t &&
+                            ("boolean" == typeof t.intranet && t.intranet && (r = !0),
+                            "boolean" == typeof t.force_xhr && t.force_xhr && (i = !0),
+                            "boolean" == typeof t.store_last_response &&
+                            t.store_last_response &&
+                            (a = !0),
+                            "string" == typeof t.pv_id_override &&
+                            "string" == typeof t.ctx_id_override)
+                          )
+                              if (
+                                24 <= t.pv_id_override.length &&
+                                24 <= t.ctx_id_override.length
+                              )
+                                  (n = t.pv_id_override), (o = t.ctx_id_override);
+                              else
+                                  try {
+                                      console.warn("override id(s) must be >= 24 chars long");
+                                  } catch (e) {}
+                          return {
+                              pv_id: n,
+                              ctx_id: o,
+                              intra: r,
+                              store_last_response: a,
+                              force_xhr: i,
+                          };
+                      })(o[0], o[3])),
+                        (p = f.pv_id || h()),
+                      "init" == o[0] && !c)
+                    ) {
+                        if (
+                          ((c = f.ctx_id || h()),
+                          "string" != typeof o[1] || !/^http/.test(o[1]))
+                        )
+                            throw new Error("init must include an et host url");
+                        if (
+                          ((s = String(o[1]).replace(/([^\/])$/, "$1/")),
+                          "string" != typeof o[2])
+                        )
+                            throw new Error("init must include a source app name");
+                        _ = o[2];
+                    }
+                    var i = o.length - 1;
+                    (e = o[i] && "object" == typeof o[i] ? o[i] : e) ||
+                    /init/.test(o[0])
+                      ? e &&
+                      !e.subject &&
+                      console.warn("event data {} must include a subject")
+                      : console.warn(
+                        "when invoked without 'init' or 'pageinit', nyt_et() must include a event data"
+                      ),
+                    s &&
+                    e &&
+                    e.subject &&
+                    ((i = e.subject),
+                      delete e.subject,
+                      (n =
+                        "page_exit" == i || "ob_click" == (e.eventData || {}).type),
+                      (t = "page" == i || "page_soft" == i ? p : h()),
+                      u.push({
+                          context_id: c,
+                          pageview_id: p,
+                          event_id: t,
+                          client_lib: "v1.3.0",
+                          sourceApp: _,
+                          intranet: f.intra ? 1 : void 0,
+                          subject: i,
+                          how: n && g && y ? "beacon_ios" : v,
+                          client_ts: +new Date(),
+                          data: JSON.parse(JSON.stringify(e)),
+                      }),
+                      "send" == o[0] || t == p || n
+                        ? r(n)
+                        : ("soon" == o[0] &&
+                        (clearTimeout(d), (d = setTimeout(r, 200))),
+                          (d = d || setTimeout(r, 5500))));
+                }),
+                  (a.nyt_et.get_pageview_id = function () {
+                      return p;
+                  }),
+                  (a.nyt_et.get_context_id = function () {
+                      return c;
+                  }),
+                  (a.nyt_et.get_host = function () {
+                      return s;
+                  }),
+                  (a.nyt_et.get_last_send_response = function () {
+                      var e = l;
+                      return e && (l = null), e;
+                  });
+        })(window);
+        (function initWebUnifiedTracking(root) {
+            var _root;
+
+            root = root || (typeof window !== "undefined" ? window : undefined);
+            var UnifiedTracking =
+              ((_root = root) === null || _root === void 0
+                ? void 0
+                : _root.UnifiedTracking) || {};
+            UnifiedTracking.context = "web";
+
+            if (!root) {
+                return UnifiedTracking;
+            }
+
+            root.UnifiedTracking = UnifiedTracking;
+
+            UnifiedTracking.sendAnalytic = function sendAnalytic(
+              eventName,
+              dataBlob
+            ) {
+                root.dataLayer = root.dataLayer || [];
+
+                if (Array.isArray(root.dataLayer)) {
+                    // Don't use a spread operator here for babel reasons
+                    dataBlob.event = dataBlob.event || eventName;
+                    root.dataLayer.push(dataBlob);
+                }
+
+                return Promise.resolve({
+                    success: true,
+                });
+            };
+
+            return UnifiedTracking;
+        })(window);
+        !(function (r) {
+            var n, t;
+            (r = r || self),
+              (n = r.Abra),
+              ((t = r.Abra =
+                (function () {
+                    "use strict";
+                    var r = Array.isArray,
+                      n = function (r, n, t) {
+                          var e = r(t, n),
+                            u = e[0],
+                            o = e[1];
+                          if (null == u || "" === u) return n;
+                          for (
+                            var i = String(u).split("."), a = 0;
+                            a < i.length && (n = n[i[a]]);
+                            a++
+                          );
+                          return null == n && (n = o), null != n ? n : null;
+                      },
+                      t = function (r, n, t) {
+                          return r(t, n).reduce(function (r, n) {
+                              return parseFloat(r) + parseFloat(n);
+                          }, 0);
+                      },
+                      e = function (r, n, t) {
+                          var e = r(t, n);
+                          return e[0] / e[1];
+                      },
+                      u = function (r, n, t) {
+                          var e = r(t, n);
+                          return e[0] % e[1];
+                      },
+                      o = function (r, n, t) {
+                          return r(t, n).reduce(function (r, n) {
+                              return parseFloat(r) * parseFloat(n);
+                          }, 1);
+                      },
+                      i = function (r, n, t) {
+                          var e = r(t, n),
+                            u = e[0],
+                            o = e[1];
+                          return void 0 === o ? -u : u - o;
+                      };
+                    function a(n) {
+                        return !((r(n) && 0 === n.length) || !n);
+                    }
+                    var f = function (r, n, t) {
+                          for (var e, u = 0; u < t.length; u++)
+                              if (!a((e = r(t[u], n)))) return e;
+                          return e;
+                      },
+                      c = function (r, n, t) {
+                          var e;
+                          for (e = 0; e < t.length - 1; e += 2)
+                              if (a(r(t[e], n))) return r(t[e + 1], n);
+                          return t.length === e + 1 ? r(t[e], n) : null;
+                      },
+                      l = function (r, n, t) {
+                          return !a(r(t, n)[0]);
+                      },
+                      v = function (r, n, t) {
+                          for (var e, u = 0; u < t.length; u++)
+                              if (a((e = r(t[u], n)))) return e;
+                          return e;
+                      },
+                      d = function (r, n, t) {
+                          var e = r(t, n);
+                          return e[0] === e[1];
+                      },
+                      s = function (r, n, t) {
+                          var e = r(t, n);
+                          return e[0] !== e[1];
+                      },
+                      h = function (r, n, t) {
+                          var e = r(t, n),
+                            u = e[0],
+                            o = e[1];
+                          return !(!o || void 0 === o.indexOf) && -1 !== o.indexOf(u);
+                      },
+                      g = function (r, n, t) {
+                          var e = r(t, n);
+                          return e[0] > e[1];
+                      },
+                      p = function (r, n, t) {
+                          var e = r(t, n);
+                          return e[0] >= e[1];
+                      },
+                      b = function (r, n, t) {
+                          var e = r(t, n),
+                            u = e[0],
+                            o = e[1],
+                            i = e[2];
+                          return void 0 === i ? u < o : u < o && o < i;
+                      },
+                      w = function (r, n, t) {
+                          var e = r(t, n),
+                            u = e[0],
+                            o = e[1],
+                            i = e[2];
+                          return void 0 === i ? u <= o : u <= o && o <= i;
+                      },
+                      y = function (r, n, t) {
+                          var e = t[0],
+                            u = t[1],
+                            o = t.slice(2),
+                            i = r(e, n);
+                          if (!i) return null;
+                          if (0 === o.length) return null;
+                          if (1 === o.length) return r(o[0], n);
+                          if (4294967295 === o[0]) return r(o[1], n);
+                          for (
+                            var a = (function (r) {
+                                var n,
+                                  t,
+                                  e,
+                                  u,
+                                  o,
+                                  i = [],
+                                  a = [
+                                      (t = 1732584193),
+                                      (e = 4023233417),
+                                      ~t,
+                                      ~e,
+                                      3285377520,
+                                  ],
+                                  f = [],
+                                  c = unescape(encodeURI(r)) + "\x80",
+                                  l = c.length;
+                                for (f[(r = (--l / 4 + 2) | 15)] = 8 * l; ~l; )
+                                    f[l >> 2] |= c.charCodeAt(l) << (8 * ~l--);
+                                for (n = l = 0; n < r; n += 16) {
+                                    for (
+                                      t = a;
+                                      l < 80;
+                                      t = [
+                                          t[4] +
+                                          (i[l] = l < 16 ? ~~f[n + l] : (2 * c) | (c < 0)) +
+                                          1518500249 +
+                                          [
+                                              (e & u) | (~e & o),
+                                              (c = 341275144 + (e ^ u ^ o)),
+                                              882459459 + ((e & u) | (e & o) | (u & o)),
+                                              c + 1535694389,
+                                          ][(l++ / 5) >> 2] +
+                                          (((c = t[0]) << 5) | (c >>> 27)),
+                                          c,
+                                          (e << 30) | (e >>> 2),
+                                          u,
+                                          o,
+                                      ]
+                                    )
+                                        (c = i[l - 3] ^ i[l - 8] ^ i[l - 14] ^ i[l - 16]),
+                                          (e = t[1]),
+                                          (u = t[2]),
+                                          (o = t[3]);
+                                    for (l = 5; l; ) a[--l] += t[l];
+                                }
+                                return a[0] >>> 0;
+                            })(i + " " + r(u, n));
+                            o.length > 1;
+
+                          ) {
+                              var f = o.splice(0, 2),
+                                c = f[0],
+                                l = f[1];
+                              if (a <= r(c, n)) return r(l, n);
+                          }
+                          return 0 === o.length ? null : r(o[0], n);
+                      },
+                      k = function (r, n, t) {
+                          var e = t[0],
+                            u = t[1],
+                            o = r(e, n);
+                          return null == o ? null : new RegExp(u).test(o);
+                      };
+                    return function (a, m, O, A) {
+                        void 0 === a && (a = {}),
+                        void 0 === m && (m = {}),
+                        void 0 === O && (O = {}),
+                        void 0 === A && (A = !1);
+                        var j = (function () {
+                              var r = {},
+                                n = function (n) {
+                                    if (n)
+                                        for (
+                                          var t,
+                                            e = decodeURIComponent(n[1]),
+                                            u = /(?:^|,)([^,=]+)=([^,]*)/g;
+                                          (t = u.exec(e));
+
+                                        ) {
+                                            var o = t,
+                                              i = o[1],
+                                              a = o[2];
+                                            r[i] = a || null;
+                                        }
+                                };
+                              n(document.cookie.match(/(?:^|;) *abra-overrides=([^;]+)/)),
+                                n(
+                                  window.location.search.match(
+                                    /(?:\?|&)abra-overrides=([^&]+)/
+                                  )
+                                );
+                              var t =
+                                /(?:^|;) *abra-nuke=true(?:;|$)/.test(document.cookie) ||
+                                /(?:\?|&)abra-nuke=true(?:&|$)/.test(
+                                  window.location.search
+                                );
+                              return [r, t];
+                          })(),
+                          x = j[0],
+                          E = j[1];
+                        Object.keys(O).forEach(function (r) {
+                            x[r] = O[r];
+                        });
+                        var F,
+                          C = A || E,
+                          R =
+                            ((F = {
+                                var: n,
+                                if: c,
+                                "===": d,
+                                "!==": s,
+                                and: f,
+                                or: v,
+                                "!": l,
+                                ">": g,
+                                ">=": p,
+                                "<": b,
+                                "<=": w,
+                                "+": t,
+                                "-": i,
+                                "*": o,
+                                "/": e,
+                                "%": u,
+                                in: h,
+                                abtest_partition: y,
+                                regex_match: k,
+                                ref: function (r, n, t) {
+                                    var e = r(t, n)[0];
+                                    return U(e);
+                                },
+                            }),
+                              function n(t, e) {
+                                  if ((e || (e = {}), r(t)))
+                                      return t.map(function (r) {
+                                          return n(r, e);
+                                      });
+                                  if (
+                                    !(function (n) {
+                                        return (
+                                          "object" == typeof n &&
+                                          null !== n &&
+                                          !r(n) &&
+                                          1 === Object.keys(n).length
+                                        );
+                                    })(t)
+                                  )
+                                      return t;
+                                  var u = (function (r) {
+                                        return Object.keys(r)[0];
+                                    })(t),
+                                    o = t[u];
+                                  r(o) || (o = [o]);
+                                  var i = F[u];
+                                  if (!i) throw new Error("Unrecognized operation " + u);
+                                  return i(n, e, o);
+                              }),
+                          U = function (r) {
+                              if (!r) return null;
+                              var n = x[r];
+                              if (void 0 === n) {
+                                  if (!C) {
+                                      if (Object.prototype.hasOwnProperty.call(x, r))
+                                          throw new Error("circular logic");
+                                      (x[r] = void 0), (n = R(a[r], m));
+                                  }
+                                  void 0 === n && (n = null), (x[r] = n);
+                              }
+                              return n;
+                          };
+                        return U;
+                    };
+                })()).noConflict = function () {
+                  return (r.Abra = n), t;
+              });
+        })(this);
+        (function () {
+            var NYTD =
+              "undefined" != typeof window && window.NYTD ? window.NYTD : {};
+            function setupTimeZone() {
+                var e =
+                    '[data-timezone][data-timezone~="' +
+                    new Date().getHours() +
+                    '"] { display: block }',
+                  t = document.createElement("style");
+                (t.innerHTML = e), document.head.appendChild(t);
+            }
+            function addNYTAppClass() {
+                window.vi.webviewEnvironment.isInWebview &&
+                document.documentElement.classList.add("NYTApp"),
+                window.vi.webviewEnvironment.deviceType &&
+                document.documentElement.classList.add(
+                  window.vi.webviewEnvironment.deviceType
+                );
+            }
+            function addNYTPageTypeClass() {
+                var e = window.vi.pageType.edge;
+                e && document.documentElement.classList.add("nytapp-" + e);
+            }
+            function setupPageViewId() {
+                (NYTD.PageViewId = {}),
+                  (NYTD.PageViewId.update = function () {
+                      return (
+                        "undefined" != typeof nyt_et &&
+                        "function" == typeof window.nyt_et.get_pageview_id
+                          ? (window.nyt_et("pageinit"),
+                            (NYTD.PageViewId.current = window.nyt_et.get_pageview_id()))
+                          : (NYTD.PageViewId.current =
+                            "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(
+                              /[xy]/g,
+                              function (e) {
+                                  var t = (16 * Math.random()) | 0;
+                                  return ("x" === e ? t : (3 & t) | 8).toString(16);
+                              }
+                            )),
+                          NYTD.PageViewId.current
+                      );
+                  });
+            }
+            var _f = function (e) {
+                e = e || {};
+                try {
+                    document.domain = "nytimes.com";
+                } catch (e) {}
+                (window.swgUserInfoXhrObject = new XMLHttpRequest()),
+                  setupPageViewId(),
+                  setupTimeZone(),
+                  addNYTAppClass(),
+                  addNYTPageTypeClass(),
+                window.nyt_et &&
+                "function" == typeof window.nyt_et &&
+                window.nyt_et("init", vi.env.ET2_URL, "nyt-vi", {
+                    subject: "page",
+                    canonicalUrl: (
+                      document.querySelector("link[rel=canonical]") || {}
+                    ).href,
+                    articleId: (
+                      document.querySelector("meta[name=articleid]") || {}
+                    ).content,
+                    nyt_uri: (document.querySelector("meta[name=nyt_uri]") || {})
+                      .content,
+                    pubpEventId: (
+                      document.querySelector("meta[name=pubp_event_id]") || {}
+                    ).content,
+                    url: location.href,
+                    referrer: document.referrer || void 0,
+                    client_tz_offset: new Date().getTimezoneOffset(),
+                    fastly_headers: e.fastlyHeaders || {},
+                }),
+                  "undefined" != typeof nyt_et &&
+                  "function" == typeof window.nyt_et.get_pageview_id
+                    ? (NYTD.PageViewId.current = window.nyt_et.get_pageview_id())
+                    : NYTD.PageViewId.update();
+            };
+            _f.apply(null, [
+                {
+                    gqlUrlClient: "https://samizdat-graphql.nytimes.com/graphql/v2",
+                    gqlRequestHeaders: {
+                        "nyt-app-type": "project-vi",
+                        "nyt-app-version": "0.0.5",
+                        "nyt-token":
+                          "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAs+/oUCTBmD/cLdmcecrnBMHiU/pxQCn2DDyaPKUOXxi4p0uUSZQzsuq1pJ1m5z1i0YGPd1U1OeGHAChWtqoxC7bFMCXcwnE1oyui9G1uobgpm1GdhtwkR7ta7akVTcsF8zxiXx7DNXIPd2nIJFH83rmkZueKrC4JVaNzjvD+Z03piLn5bHWU6+w+rA+kyJtGgZNTXKyPh6EC6o5N+rknNMG5+CdTq35p8f99WjFawSvYgP9V64kgckbTbtdJ6YhVP58TnuYgr12urtwnIqWP9KSJ1e5vmgf3tunMqWNm6+AnsqNj8mCLdCuc5cEB74CwUeQcP2HQQmbCddBy2y0mEwIDAQAB",
+                    },
+                    gqlFetchTimeout: 1500,
+                    disablePersistedQueries: false,
+                    fastlyHeaders: {},
+                    initialDeviceType: "desktop",
+                    fastlyAbraConfig: {
+                        ".ver": "10910.000",
+                        HOME_chartbeat: "0_Control",
+                        INT_cwv_dfp_deferAds_0322: "",
+                        MX_NewArchitecture_gamesLP: "0_Control",
+                    },
+                    internalPreviewConfig: {},
+                    webviewEnvironment: { isInWebview: false },
+                    serviceWorkerFile: "service-worker-test-1669657616122.js",
+                },
+            ]);
+        })();
+        (function () {
+            var NYTD =
+              "undefined" != typeof window && window.NYTD ? window.NYTD : {};
+            var _f = function (t) {
+                if (window.Abra && "function" == typeof window.Abra) {
+                    (NYTD.Abra = (function (a) {
+                        var n = (a.document.cookie.match(/(?:^|;) *nyt-a=([^;]*)/) ||
+                            [])[1],
+                          r = [];
+                        (a.dataLayer = a.dataLayer || []),
+                          (d.config = t.abraConfig || {}),
+                          (d.reportedAllocations = {}),
+                          (d.reportedExposures = {});
+                        var e = (t.abraURL || "").match(/current[/]([a-zA-Z-]+).json/i);
+                        d.integration = e && e.length > 1 ? e[1] : "";
+                        try {
+                            d.version = a.Abra(d.config)(".ver");
+                        } catch (t) {
+                            d.version = 0;
+                        }
+                        var o = d.config,
+                          i = { agent_id: n },
+                          c = a.Abra(o, i);
+                        function d(t) {
+                            return d.getAbraSync(t).variant;
+                        }
+                        return (
+                          (d.getAbraSync = function (t) {
+                              var a = d.reportedAllocations[t];
+                              if (void 0 !== a) return { variant: a, allocated: !0 };
+                              var n = null,
+                                r = !1;
+                              try {
+                                  (n = c(t)), (r = !0);
+                              } catch (t) {}
+                              return { variant: n, allocated: r };
+                          }),
+                            (d.reportExposure = function (t) {
+                                var n = d.getAbraSync(t).variant;
+                                (void 0 !== d.reportedExposures[t] &&
+                                  n === d.reportedExposures[t]) ||
+                                ((d.reportedExposures[t] = n),
+                                  a.dataLayer.push({
+                                      event: "ab-expose",
+                                      abtest: {
+                                          test: t,
+                                          variant: n || "0",
+                                          config_ver: d.version,
+                                          integration: d.integration,
+                                      },
+                                  }));
+                            }),
+                            (d.alloc = function () {
+                                Object.keys(d.config)
+                                  .filter(function (t) {
+                                      return !t.includes(".");
+                                  })
+                                  .forEach(function (t) {
+                                      var a = d.getAbraSync(t);
+                                      a.allocated &&
+                                      ((d.reportedAllocations[t] = a.variant),
+                                        r.push({ test: t, variant: a.variant }));
+                                  }),
+                                  a.dataLayer.push({
+                                      event: "ab-alloc",
+                                      abtest: { batch: r },
+                                  });
+                            }),
+                            d.alloc(),
+                            d
+                        );
+                    })(this)),
+                    "1_RightCount" ===
+                    window.NYTD.Abra.getAbraSync("AUD_GiftAllocation_0922")
+                      .variant &&
+                    document.documentElement.classList.add(
+                      "AUD_GiftAllocation_0922-1_RightCount"
+                    ),
+                    "2_LeftCount" ===
+                    window.NYTD.Abra.getAbraSync("AUD_GiftAllocation_0922")
+                      .variant &&
+                    document.documentElement.classList.add(
+                      "AUD_GiftAllocation_0922-2_LeftCount"
+                    );
+                    var a = "SJ_XProductNav_1022";
+                    "1_Order1" === window.NYTD.Abra.getAbraSync(a).variant &&
+                    document.documentElement.classList.add(
+                      "SJ_XProductNav_1022-1_Order1"
+                    ),
+                    "2_Order2" === window.NYTD.Abra.getAbraSync(a).variant &&
+                    document.documentElement.classList.add(
+                      "SJ_XProductNav_1022-2_Order2"
+                    );
+                }
+            };
+            _f.apply(null, [
+                {
+                    abraConfig: {
+                        ".ver": 11019,
+                        UXF_cookingstory_0521: {
+                            abtest_partition: [
+                                { var: "agent_id" },
+                                "UXF_cookingstory_0521",
+                                2147483647,
+                                "0_Control",
+                                4294967295,
+                                "1_cookpromo",
+                            ],
+                        },
+                        STYLN_user_state_api_1122: {
+                            abtest_partition: [
+                                { var: "agent_id" },
+                                "STYLN_user_state_api_1122",
+                            ],
+                        },
+                        styln_trust_inline_explainers_0822: {
+                            if: [
+                                { and: [{ "===": [{ ref: "styln_trust" }, "1_Show"] }] },
+                                {
+                                    abtest_partition: [
+                                        { var: "agent_id" },
+                                        "styln_trust_inline_explainers_0822",
+                                        92341796,
+                                        "0_Control",
+                                        1144608783,
+                                        "1_Variant",
+                                        1146756267,
+                                        "0_Control",
+                                        1148903751,
+                                        "0_Control",
+                                        1153198718,
+                                        "0_Control",
+                                        1155346202,
+                                        "0_Control",
+                                        1157493685,
+                                        "0_Control",
+                                        1159641169,
+                                        "0_Control",
+                                        2190433320,
+                                        "0_Control",
+                                        2276332666,
+                                        "1_Variant",
+                                        2534030704,
+                                        "0_Control",
+                                        2791728741,
+                                        "1_Variant",
+                                        3199750635,
+                                        "0_Control",
+                                        3607772528,
+                                        "1_Variant",
+                                        3951369911,
+                                        "0_Control",
+                                        4294967295,
+                                        "1_Variant",
+                                    ],
+                                },
+                            ],
+                        },
+                        styln_trust: {
+                            abtest_partition: [
+                                { var: "agent_id" },
+                                "styln_trust",
+                                214748364,
+                                "0_Control",
+                                4294967295,
+                                "1_Show",
+                            ],
+                        },
+                        STYLN_remove_relatedlinks: {
+                            abtest_partition: [
+                                { var: "agent_id" },
+                                "STYLN_remove_relatedlinks",
+                                4252017622,
+                                "0_control_STYLN_remove_relatedlinks",
+                                4294967295,
+                                "1_remove_relatedlinks",
+                            ],
+                        },
+                        STYLN_pharmacy_components: {
+                            abtest_partition: [
+                                { var: "agent_id" },
+                                "STYLN_pharmacy_components",
+                                4294967295,
+                                "show",
+                            ],
+                        },
+                        STYLN_opinion_modules_recirc: {
+                            if: [
+                                {
+                                    and: [
+                                        { "===": [{ ref: "STYLN_pharmacy_components" }, "show"] },
+                                    ],
+                                },
+                                {
+                                    abtest_partition: [
+                                        { var: "agent_id" },
+                                        "STYLN_opinion_modules_recirc",
+                                        2147483647,
+                                        "0_control",
+                                        4294967295,
+                                        "1_opinion",
+                                    ],
+                                },
+                            ],
+                        },
+                        STYLN_more_in_storylines_recirc: {
+                            abtest_partition: [
+                                { var: "agent_id" },
+                                "STYLN_more_in_storylines_recirc",
+                                42949672,
+                                "0_control",
+                                85899345,
+                                "1_variant",
+                            ],
+                        },
+                        styln_live_visual_mode_0822: {
+                            abtest_partition: [
+                                { var: "regi_id" },
+                                "styln_live_visual_mode_0822",
+                                57277683,
+                                null,
+                                114538187,
+                                null,
+                                171798691,
+                                null,
+                            ],
+                        },
+                        STYLN_live_updates: {
+                            abtest_partition: [
+                                { var: "agent_id" },
+                                "STYLN_live_updates",
+                                214748364,
+                                "0_control",
+                                429496729,
+                                "2_live_updates",
+                                4294967295,
+                                "1_live_updates",
+                            ],
+                        },
+                        STYLN_live_transition_alerts: {
+                            abtest_partition: [
+                                { var: "agent_id" },
+                                "STYLN_live_transition_alerts",
+                                4294967295,
+                                "1_show",
+                            ],
+                        },
+                        STYLN_live_polling_push: {
+                            abtest_partition: [
+                                { var: "agent_id" },
+                                "STYLN_live_polling_push",
+                                214748364,
+                                "0_hide",
+                                4294967295,
+                                "1_show",
+                            ],
+                        },
+                        STYLN_live_olympics_push: {
+                            abtest_partition: [
+                                { var: "agent_id" },
+                                "STYLN_live_olympics_push",
+                                214748364,
+                                "0_hide",
+                                4294967295,
+                                "1_show",
+                            ],
+                        },
+                        STYLN_live_noreaster_alerts: {
+                            abtest_partition: [
+                                { var: "agent_id" },
+                                "STYLN_live_noreaster_alerts",
+                                214748364,
+                                "0_hide",
+                                4294967295,
+                                "1_show",
+                            ],
+                        },
+                        STYLN_live_newupdates: {
+                            abtest_partition: [
+                                { var: "agent_id" },
+                                "STYLN_live_newupdates",
+                                214748364,
+                                "control",
+                                4294967295,
+                                "variant",
+                            ],
+                        },
+                        STYLN_live_derek_chauvin_trial_alerts: {
+                            if: [
+                                {
+                                    and: [
+                                        { "===": [{ ref: "STYLN_pharmacy_components" }, "show"] },
+                                    ],
+                                },
+                                {
+                                    abtest_partition: [
+                                        { var: "agent_id" },
+                                        "STYLN_live_derek_chauvin_trial_alerts",
+                                        214748364,
+                                        "0_hide",
+                                        4294967295,
+                                        "1_show",
+                                    ],
+                                },
+                            ],
+                        },
+                        STYLN_live_chat: {
+                            abtest_partition: [
+                                { var: "agent_id" },
+                                "STYLN_live_chat",
+                                21474835,
+                                "1_use_sse",
+                                408021892,
+                                "0_Control",
+                                429496729,
+                                "1_use_sse",
+                            ],
+                        },
+                        STYLN_live_barrett_hearings_alerts: {
+                            abtest_partition: [
+                                { var: "agent_id" },
+                                "STYLN_live_barrett_hearings_alerts",
+                                214748364,
+                                "0_hide",
+                                2147483647,
+                                "1_show",
+                                2362232012,
+                                "0_hide",
+                                4294967295,
+                                "1_show",
+                            ],
+                        },
+                        STYLN_liveblog_email: {
+                            abtest_partition: [
+                                { var: "agent_id" },
+                                "STYLN_liveblog_email",
+                                2147483647,
+                                "0_control",
+                                4294967295,
+                                "1_signup",
+                            ],
+                        },
+                        STYLN_lb_pinned_video: {
+                            abtest_partition: [
+                                { var: "agent_id" },
+                                "STYLN_lb_pinned_video",
+                                4294967295,
+                                "1_pin",
+                            ],
+                        },
+                        STYLN_lb_newposts: {
+                            abtest_partition: [
+                                { var: "agent_id" },
+                                "STYLN_lb_newposts",
+                                4080218930,
+                                "0_control",
+                                4294967295,
+                                "1_lb_newposts",
+                            ],
+                        },
+                        STYLN_interruptions_holdout: {
+                            abtest_partition: [
+                                { var: "regi_id" },
+                                "STYLN_interruptions_holdout",
+                                128849018,
+                                "0_control",
+                                4294967295,
+                                "1_show",
+                            ],
+                        },
+                        STYLN_election_2020_alerts: {
+                            abtest_partition: [
+                                { var: "agent_id" },
+                                "STYLN_election_2020_alerts",
+                                214748364,
+                                "0_hide",
+                                4294967295,
+                                "1_show",
+                            ],
+                        },
+                        STYLN_daily_question_block: {
+                            abtest_partition: [
+                                { var: "agent_id" },
+                                "STYLN_daily_question_block",
+                                644245093,
+                                "0_control",
+                                1288490188,
+                                "1_variant",
+                            ],
+                        },
+                        "styln-trending-primary-asset": {
+                            abtest_partition: [
+                                { var: "agent_id" },
+                                "styln-trending-primary-asset",
+                                2147483647,
+                                "0_Control",
+                                4294967295,
+                                "1_Show",
+                            ],
+                        },
+                        "styln-top-links2": {
+                            if: [
+                                {
+                                    and: [
+                                        {
+                                            "!": {
+                                                in: [{ ref: "STYLN_pharmacy_components" }, ["hide"]],
+                                            },
+                                        },
+                                    ],
+                                },
+                                {
+                                    abtest_partition: [
+                                        { var: "agent_id" },
+                                        "styln-top-links2",
+                                        2147483647,
+                                        "0_hide",
+                                        4294967295,
+                                        "1_show",
+                                    ],
+                                },
+                            ],
+                        },
+                        "styln-primary-assets-block": {
+                            abtest_partition: [
+                                { var: "agent_id" },
+                                "styln-primary-assets-block",
+                                1073741823,
+                                "0_Control",
+                                4294967295,
+                                "1_Show",
+                            ],
+                        },
+                        "styln-music-guide": {
+                            if: [
+                                {
+                                    and: [
+                                        { "===": [{ ref: "STYLN_pharmacy_components" }, "show"] },
+                                    ],
+                                },
+                                {
+                                    abtest_partition: [
+                                        { var: "agent_id" },
+                                        "styln-music-guide",
+                                        2147483647,
+                                        "0_Control",
+                                        4294967295,
+                                        "1_Show",
+                                    ],
+                                },
+                            ],
+                        },
+                        "styln-amy-chua": {
+                            if: [
+                                {
+                                    and: [
+                                        { "===": [{ ref: "STYLN_pharmacy_components" }, "show"] },
+                                    ],
+                                },
+                                {
+                                    abtest_partition: [
+                                        { var: "agent_id" },
+                                        "styln-amy-chua",
+                                        2147483647,
+                                        "0_Control",
+                                        4294967295,
+                                        "1_Show",
+                                    ],
+                                },
+                            ],
+                        },
+                        STORY_topical_recirc: {
+                            abtest_partition: [
+                                { var: "agent_id" },
+                                "STORY_topical_recirc",
+                                2147483647,
+                                "0_control",
+                                4294967295,
+                                "1_variant",
+                            ],
+                        },
+                        SJ_XProductNav_1022: {
+                            abtest_partition: [
+                                { var: "agent_id" },
+                                "SJ_XProductNav_1022",
+                                116823109,
+                                "0_Control",
+                                230210246,
+                                "1_Order1",
+                                343597383,
+                                "2_Order2",
+                                1386415442,
+                                "0_Control",
+                                2432669475,
+                                "1_Order1",
+                                3478923509,
+                                "2_Order2",
+                                3865470565,
+                                "3_Holdout",
+                                3878355467,
+                                "0_Control",
+                                3891240369,
+                                "1_Order1",
+                                3904125271,
+                                "2_Order2",
+                                3908420238,
+                                "3_Holdout",
+                                3921305140,
+                                "0_Control",
+                                3934190042,
+                                "1_Order1",
+                                3947074944,
+                                "2_Order2",
+                                3951369911,
+                                "3_Holdout",
+                                3964254813,
+                                "0_Control",
+                                3977139715,
+                                "1_Order1",
+                                3990024617,
+                                "2_Order2",
+                                3994319584,
+                                "3_Holdout",
+                                4007204486,
+                                "0_Control",
+                                4020089388,
+                                "1_Order1",
+                                4032974290,
+                                "2_Order2",
+                                4037269257,
+                                "3_Holdout",
+                                4050154159,
+                                "0_Control",
+                                4063039061,
+                                "1_Order1",
+                                4075923963,
+                                "2_Order2",
+                                4080218930,
+                                "3_Holdout",
+                                4105988734,
+                                "0_Control",
+                                4131758538,
+                                "1_Order1",
+                                4157528342,
+                                "2_Order2",
+                                4166118276,
+                                "3_Holdout",
+                                4179003178,
+                                "0_Control",
+                                4191888080,
+                                "1_Order1",
+                                4204772982,
+                                "2_Order2",
+                                4209067949,
+                                "3_Holdout",
+                                4234837753,
+                                "0_Control",
+                                4260607557,
+                                "1_Order1",
+                                4286377360,
+                                "2_Order2",
+                                4294967295,
+                                "3_Holdout",
+                            ],
+                        },
+                        SJ_welcomeBanner_1022: {
+                            if: [
+                                {
+                                    and: [
+                                        {
+                                            "===": [{ ref: "SJ_universal_holdout_0722" }, "1_test"],
+                                        },
+                                    ],
+                                },
+                                {
+                                    abtest_partition: [
+                                        { var: "regi_id" },
+                                        "SJ_welcomeBanner_1022",
+                                        1073741823,
+                                        "2_Design_Variant",
+                                        2168958483,
+                                        "1_BAU_Design",
+                                        2190433320,
+                                        "2_Design_Variant",
+                                        2276332666,
+                                        "1_BAU_Design",
+                                        2362232012,
+                                        "2_Design_Variant",
+                                        2555505540,
+                                        "1_BAU_Design",
+                                        2748779068,
+                                        "2_Design_Variant",
+                                        3113851289,
+                                        "1_BAU_Design",
+                                        3478923509,
+                                        "2_Design_Variant",
+                                        3865470565,
+                                        "1_BAU_Design",
+                                        4252017622,
+                                        "2_Design_Variant",
+                                        4273492459,
+                                        "1_BAU_Design",
+                                        4294967295,
+                                        "2_Design_Variant",
+                                    ],
+                                },
+                            ],
+                        },
+                        SJ_universal_holdout_0722: {
+                            if: [
+                                { and: [{ "===": [{ var: "user_type" }, "sub"] }] },
+                                {
+                                    abtest_partition: [
+                                        { var: "regi_id" },
+                                        "SJ_universal_holdout_0722",
+                                        85899345,
+                                        "0_holdout",
+                                        4294967295,
+                                        "1_test",
+                                    ],
+                                },
+                            ],
+                        },
+                        SJ_targeted_newsletter_subscriptions_0722: {
+                            if: [
+                                {
+                                    and: [
+                                        {
+                                            "!": {
+                                                in: [
+                                                    { ref: "SJ_universal_holdout_0722" },
+                                                    ["0_holdout"],
+                                                ],
+                                            },
+                                        },
+                                        { "===": [{ var: "user_type" }, "sub"] },
+                                    ],
+                                },
+                                {
+                                    abtest_partition: [
+                                        { var: "regi_id" },
+                                        "SJ_targeted_newsletter_subscriptions_0722",
+                                        858993458,
+                                        "0_Control",
+                                        1717986917,
+                                        "1_List_Recirc",
+                                        2576980377,
+                                        "2_List_No_Recirc",
+                                        3435973836,
+                                        "3_Carousel_Recirc",
+                                        4294967295,
+                                        "4_Carousel_No_Recirc",
+                                    ],
+                                },
+                            ],
+                        },
+                        SJ_newsletter_list_01_0222: {
+                            abtest_partition: [
+                                { var: "regi_id" },
+                                "SJ_newsletter_list_01_0222",
+                                1073741823,
+                                "0_control",
+                                4294967295,
+                                "0_control",
+                            ],
+                        },
+                        SJ_early_tenure_subscriber_test_0712: {
+                            abtest_partition: [
+                                { var: "regi_id" },
+                                "SJ_early_tenure_subscriber_test_0712",
+                                4294967295,
+                                "0_Control",
+                            ],
+                        },
+                        SJ_disrupter_rollout_0822: {
+                            abtest_partition: [
+                                { var: "regi_id" },
+                                "SJ_disrupter_rollout_0822",
+                                4294967295,
+                                "1_disrupter",
+                            ],
+                        },
+                        SJ_disrupter_post90_0822: {
+                            abtest_partition: [
+                                { var: "regi_id" },
+                                "SJ_disrupter_post90_0822",
+                                429496729,
+                                "0_control",
+                                4294967295,
+                                "1_disrupter",
+                            ],
+                        },
+                        SA_Referral_iframe_0520: {
+                            abtest_partition: [
+                                { var: "agent_id" },
+                                "SA_Referral_iframe_0520",
+                                4294967295,
+                                "1_useiframe",
+                            ],
+                        },
+                        SA_get_started_now_01_0921: {
+                            abtest_partition: [
+                                { var: "regi_id" },
+                                "SA_get_started_now_01_0921",
+                                858993458,
+                                "0_control",
+                                4294967295,
+                                "0_control",
+                            ],
+                        },
+                        SA_get_started_later_01_0621: {
+                            abtest_partition: [
+                                { var: "regi_id" },
+                                "SA_get_started_later_01_0621",
+                                2147483647,
+                                "0_control",
+                                3435973836,
+                                "0_control",
+                                4294967295,
+                                "0_control",
+                            ],
+                        },
+                        SA_breadth_step_01_0421: {
+                            abtest_partition: [
+                                { var: "regi_id" },
+                                "SA_breadth_step_01_0421",
+                                2147483647,
+                                "0_control",
+                                4294967295,
+                                "0_control",
+                            ],
+                        },
+                        SA_app_step_01_0521: {
+                            abtest_partition: [
+                                { var: "regi_id" },
+                                "SA_app_step_01_0521",
+                                4294967295,
+                                "0_control",
+                            ],
+                        },
+                        ON_User_State_API: {
+                            abtest_partition: [
+                                { var: "agent_id" },
+                                "ON_User_State_API",
+                                4294967295,
+                                "1_user_state",
+                            ],
+                        },
+                        ON_testIgnoreMe_0902: {
+                            if: [
+                                { and: [{ "!": { in: [{ var: "user_type" }, ["sub"]] } }] },
+                                {
+                                    abtest_partition: [
+                                        { var: "regi_id" },
+                                        "ON_testIgnoreMe_0902",
+                                        2147483647,
+                                        "0_Control",
+                                        4294967295,
+                                        "1_variant",
+                                    ],
+                                },
+                            ],
+                        },
+                        ON_MAPS_audience_split: {
+                            abtest_partition: [
+                                { var: "agent_id" },
+                                "ON_MAPS_audience_split",
+                                2147483647,
+                                "0_onboarding",
+                                4294967295,
+                                "1_maps",
+                            ],
+                        },
+                        ON_formers_benefits_paywall: {
+                            abtest_partition: [
+                                { var: "regi_id" },
+                                "ON_formers_benefits_paywall",
+                                858993458,
+                                "3_basic",
+                                4294967295,
+                                "3_basic",
+                            ],
+                        },
+                        ON_app_dl_mweb_hp_regi_final: {
+                            if: [
+                                { and: [{ "!": { in: [{ var: "user_type" }, ["sub"]] } }] },
+                                {
+                                    abtest_partition: [
+                                        { var: "regi_id" },
+                                        "ON_app_dl_mweb_hp_regi_final",
+                                        214748364,
+                                        "0_control",
+                                        4294967295,
+                                        "0_control",
+                                    ],
+                                },
+                            ],
+                        },
+                        ON_app_dl_mweb_hp_dummy: {
+                            if: [
+                                { and: [{ "!": { in: [{ var: "user_type" }, ["sub"]] } }] },
+                                {
+                                    abtest_partition: [
+                                        { var: "regi_id" },
+                                        "ON_app_dl_mweb_hp_dummy",
+                                        1073741823,
+                                        "0_control",
+                                        2147483647,
+                                        "1_dock_std",
+                                        3221225471,
+                                        "2_dock_exp",
+                                        4294967295,
+                                        "3_custom_dock",
+                                    ],
+                                },
+                            ],
+                        },
+                        MX_NewArchitecture_gamesLP: {
+                            abtest_partition: [
+                                { var: "agent_id" },
+                                "MX_NewArchitecture_gamesLP",
+                                4294967295,
+                                "0_Control",
+                            ],
+                        },
+                        MX_message_selection_integration_0722: {
+                            abtest_partition: [
+                                { var: "agent_id" },
+                                "MX_message_selection_integration_0722",
+                                4294967295,
+                                "0_message_selection_turned_off",
+                            ],
+                        },
+                        MKT_welcome_ad_stp_1120: {
+                            abtest_partition: [
+                                { var: "agent_id" },
+                                "MKT_welcome_ad_stp_1120",
+                                2147483647,
+                                "0_control",
+                                4294967295,
+                                "1_welcome_stp",
+                            ],
+                        },
+                        MKT_segops_regi_bundle_login_test: {
+                            abtest_partition: [
+                                { var: "agent_id" },
+                                "MKT_segops_regi_bundle_login_test",
+                                4294967295,
+                                "1_login",
+                            ],
+                        },
+                        MKT_not_ready_to_sub_survey: {
+                            abtest_partition: [
+                                { var: "agent_id" },
+                                "MKT_not_ready_to_sub_survey",
+                                3221225471,
+                                "0_control",
+                                3435973836,
+                                "1_survey",
+                                4294967295,
+                                "0_control",
+                            ],
+                        },
+                        MKT_formers_benefits_paywall_0822: {
+                            if: [
+                                {
+                                    and: [
+                                        {
+                                            "!": {
+                                                in: [
+                                                    { ref: "ON_formers_benefits_paywall" },
+                                                    ["1_ada_benefits_150", "2_ada_simple_150"],
+                                                ],
+                                            },
+                                        },
+                                    ],
+                                },
+                                {
+                                    abtest_partition: [
+                                        { var: "regi_id" },
+                                        "MKT_formers_benefits_paywall_0822",
+                                        536870911,
+                                        "0_control",
+                                        1073741823,
+                                        "1_ada_benefits_150",
+                                        1610612735,
+                                        "2_ada_simple_150",
+                                        2147483647,
+                                        "3_basic",
+                                    ],
+                                },
+                            ],
+                        },
+                        MKT_dfp_hd_paywall_zip: {
+                            abtest_partition: [
+                                { var: "agent_id" },
+                                "MKT_dfp_hd_paywall_zip",
+                                2147483647,
+                                "0_control",
+                                4294967295,
+                                "1_zip",
+                            ],
+                        },
+                        MKT_CKGiftLPTest_creativeredesign: {
+                            abtest_partition: [
+                                { var: "agent_id" },
+                                "MKT_CKGiftLPTest_creativeredesign",
+                                1431942095,
+                                "0_control",
+                                2863454695,
+                                "1_ck_gift_shortlp",
+                                4294967295,
+                                "2_ck_gift_longlp",
+                            ],
+                        },
+                        MAPS_subonly_cards_gs_092021: {
+                            if: [
+                                { and: [{ "===": [{ var: "user_type" }, "sub"] }] },
+                                {
+                                    abtest_partition: [
+                                        { var: "agent_id" },
+                                        "MAPS_subonly_cards_gs_092021",
+                                        1073741823,
+                                        "2_subandfree",
+                                        4294967295,
+                                        "2_subandfree",
+                                    ],
+                                },
+                            ],
+                        },
+                        MAPS_SubOnboarding_NL_precheck_0922: {
+                            abtest_partition: [
+                                { var: "regi_id" },
+                                "MAPS_SubOnboarding_NL_precheck_0922",
+                                858993458,
+                                "0_control",
+                                4294967295,
+                                "1_precheck",
+                            ],
+                        },
+                        MAPS_scrolly_preview_test: {
+                            abtest_partition: [
+                                { var: "agent_id" },
+                                "MAPS_scrolly_preview_test",
+                                1431512599,
+                                "2_scroll_with_recirc",
+                                4294967295,
+                                "2_scroll_with_recirc",
+                            ],
+                        },
+                        MAPS_OnsiteNL_boldrecirc_0922: {
+                            abtest_partition: [
+                                { var: "agent_id" },
+                                "MAPS_OnsiteNL_boldrecirc_0922",
+                                429496729,
+                                "0_control",
+                                2576980377,
+                                "1_newsletter_takeover",
+                                4294967295,
+                                "0_control",
+                            ],
+                        },
+                        MAPS_foryou_optin_0421: {
+                            if: [
+                                {
+                                    and: [
+                                        { in: [{ var: "user_type" }, ["regi"]] },
+                                        { "===": [{ ref: "ON_MAPS_audience_split" }, "1_maps"] },
+                                    ],
+                                },
+                                {
+                                    abtest_partition: [
+                                        { var: "agent_id" },
+                                        "MAPS_foryou_optin_0421",
+                                        1431942095,
+                                        "0_control",
+                                        2863454695,
+                                        "1_interests",
+                                        4294967295,
+                                        "2_auto_optin",
+                                    ],
+                                },
+                            ],
+                        },
+                        MAPS_cwv_email_signup_dock_0322: {
+                            if: [
+                                { and: [{ "===": [{ var: "user_type" }, "sub"] }] },
+                                {
+                                    abtest_partition: [
+                                        { var: "regi_id" },
+                                        "MAPS_cwv_email_signup_dock_0322",
+                                        4294967295,
+                                        "2_dock_descriptive",
+                                    ],
+                                },
+                            ],
+                        },
+                        InvolChurn_CopyUpdate: {
+                            abtest_partition: [
+                                { var: "agent_id" },
+                                "InvolChurn_CopyUpdate",
+                                2147483647,
+                                "0_control",
+                                4294967295,
+                                "1_concisemessage",
+                            ],
+                        },
+                        dfp_wordlebot_ad: {
+                            abtest_partition: [{ var: "agent_id" }, "dfp_wordlebot_ad"],
+                        },
+                        DFP_Prebid_Price_0722: {
+                            abtest_partition: [
+                                { var: "agent_id" },
+                                "DFP_Prebid_Price_0722",
+                                4294967295,
+                                "0_Control",
+                            ],
+                        },
+                        dfp_messaging_flexframe_ctr: {
+                            abtest_partition: [
+                                { var: "agent_id" },
+                                "dfp_messaging_flexframe_ctr",
+                                322122546,
+                                "2_noheadnosummary",
+                                644245093,
+                                "1_msgInv_noCTA",
+                                4294967295,
+                                "0_control",
+                            ],
+                        },
+                        DFP_live_1022: {
+                            abtest_partition: [
+                                { var: "agent_id" },
+                                "DFP_live_1022",
+                                2147483647,
+                                null,
+                                4294967295,
+                                null,
+                            ],
+                        },
+                        DFP_EngMetrics: {
+                            abtest_partition: [
+                                { var: "agent_id" },
+                                "DFP_EngMetrics",
+                                42949672,
+                                "0_control",
+                                85899345,
+                                "1_hover",
+                            ],
+                        },
+                        DFP_blockDetect_0221: {
+                            abtest_partition: [
+                                { var: "agent_id" },
+                                "DFP_blockDetect_0221",
+                                1073741823,
+                                "1_network_detection",
+                                4294967295,
+                                null,
+                            ],
+                        },
+                        DFP_amzn: {
+                            abtest_partition: [
+                                { var: "agent_id" },
+                                "DFP_amzn",
+                                42949672,
+                                "0_control",
+                                429642757,
+                                "0_control",
+                                472540891,
+                                "1_amzn_fast_fetch",
+                                515490564,
+                                "2_adslot_priority",
+                                901994671,
+                                "2_adslot_priority",
+                                944892804,
+                                "3_no_mnet",
+                            ],
+                        },
+                        DFP_als_home: {
+                            abtest_partition: [
+                                { var: "agent_id" },
+                                "DFP_als_home",
+                                4294967295,
+                                "1_als",
+                            ],
+                        },
+                        DFP_als: {
+                            abtest_partition: [
+                                { var: "agent_id" },
+                                "DFP_als",
+                                4294967295,
+                                "1_als",
+                            ],
+                        },
+                        dfp_adslot4v2: {
+                            abtest_partition: [
+                                { var: "agent_id" },
+                                "dfp_adslot4v2",
+                                4294967295,
+                                "1_external",
+                            ],
+                        },
+                        DATAGOV_banner_202110: {
+                            abtest_partition: [
+                                { var: "agent_id" },
+                                "DATAGOV_banner_202110",
+                                3435973836,
+                                "0_Control",
+                                4294967295,
+                                "1_RejectAll",
+                            ],
+                        },
+                        APP_2021H1_SLS: {
+                            if: [
+                                { and: [{ "===": [{ var: "user_type" }, "sub"] }] },
+                                {
+                                    abtest_partition: [
+                                        { var: "regi_id" },
+                                        "APP_2021H1_SLS",
+                                        1159641169,
+                                        "1_share",
+                                        1932735282,
+                                        "1_share",
+                                        4294967295,
+                                        "1_share",
+                                    ],
+                                },
+                            ],
+                        },
+                        ACCT_SubUpgradesInMUM: {
+                            abtest_partition: [
+                                { var: "regi_id" },
+                                "ACCT_SubUpgradesInMUM",
+                                687194766,
+                                "0_control",
+                                1288490188,
+                                "1_direct_closedBenefits",
+                                1889785609,
+                                "2_direct_openBenefits",
+                                2491081031,
+                                "3_assist_closedBenefits",
+                                3092376452,
+                                "4_assist_openBenefits",
+                                3693671874,
+                                "5_assistSubtle_closedBenefits",
+                                4294967295,
+                                "6_assistSubtle_openBenefits",
+                            ],
+                        },
+                        ACCT_SubAccessExplanation: {
+                            abtest_partition: [
+                                { var: "regi_id" },
+                                "ACCT_SubAccessExplanation",
+                                1431942095,
+                                "0_control",
+                                2863454695,
+                                "1_openWithBenefitsButton",
+                                4294967295,
+                                "2_closedWithBenefitsButton",
+                            ],
+                        },
+                        ACCT_SJ_masthead_user_modal_1022_cwv: {
+                            abtest_partition: [
+                                { var: "regi_id" },
+                                "ACCT_SJ_masthead_user_modal_1022_cwv",
+                                2147483647,
+                                "0_control",
+                                4294967295,
+                                "1_mum_message_with_badge",
+                            ],
+                        },
+                        ACCT_RegiLoginConfusion: {
+                            abtest_partition: [
+                                { var: "regi_id" },
+                                "ACCT_RegiLoginConfusion",
+                                1431942095,
+                                "0_control",
+                                2863454695,
+                                "1_linkSwitchAccount",
+                                4294967295,
+                                "2_linkSwitchAccountMessage",
+                            ],
+                        },
+                        ACCT_MastheadUserModal: {
+                            abtest_partition: [
+                                { var: "regi_id" },
+                                "ACCT_MastheadUserModal",
+                                1431942095,
+                                "0_control",
+                                2863454695,
+                                "1_drawerDesign",
+                                4294967295,
+                                "2_drawerDesignAccountIA",
+                            ],
+                        },
+                    },
+                    abraURL: "https://a1.nyt.com/abra-config/current/vi-prd.json",
+                },
+            ]);
+        })();
+        (function () {
+            var _f = function (e) {
+                var r = function () {
+                    var r = e.url;
+                    try {
+                        r += window.location.search
+                          .slice(1)
+                          .split("&")
+                          .reduce(function (e, r) {
+                              return "ip-override" === r.split("=")[0] ? "?" + r : e;
+                          }, "");
+                    } catch (e) {
+                        console.warn(e);
+                    }
+                    var n = new XMLHttpRequest();
+                    for (var t in ((n.withCredentials = !0),
+                      n.open("POST", r, !0),
+                      n.setRequestHeader("Content-Type", "application/json"),
+                      e.headers))
+                        n.setRequestHeader(t, e.headers[t]);
+                    return n.send(e.body), n;
+                };
+                (window.userXhrObject = r()),
+                  (window.userXhrRefresh = function () {
+                      return (window.userXhrObject = r()), window.userXhrObject;
+                  });
+            };
+            _f.apply(null, [
+                {
+                    url: "https://samizdat-graphql.nytimes.com/graphql/v2",
+                    body: '{"operationName":"UserQuery","variables":{},"query":"   query UserQuery {     user {       __typename       profile {         displayName         email       }       userInfo {         regiId         entitlements         demographics {           emailSubscriptions           wat         }       }       subscriptionDetails {         bundleType         cancellationDate         graceStartDate         graceEndDate         isFreeTrial         hasQueuedSub         startDate         endDate         status         hasActiveEntitlements         entitlements         billingSource         promotionTierType         subscriptionName         subscriptionProducts         subscriptionLabels       }     }   } "}',
+                    headers: {
+                        "nyt-app-type": "project-vi",
+                        "nyt-app-version": "0.0.5",
+                        "nyt-token":
+                          "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAs+/oUCTBmD/cLdmcecrnBMHiU/pxQCn2DDyaPKUOXxi4p0uUSZQzsuq1pJ1m5z1i0YGPd1U1OeGHAChWtqoxC7bFMCXcwnE1oyui9G1uobgpm1GdhtwkR7ta7akVTcsF8zxiXx7DNXIPd2nIJFH83rmkZueKrC4JVaNzjvD+Z03piLn5bHWU6+w+rA+kyJtGgZNTXKyPh6EC6o5N+rknNMG5+CdTq35p8f99WjFawSvYgP9V64kgckbTbtdJ6YhVP58TnuYgr12urtwnIqWP9KSJ1e5vmgf3tunMqWNm6+AnsqNj8mCLdCuc5cEB74CwUeQcP2HQQmbCddBy2y0mEwIDAQAB",
+                    },
+                },
+            ]);
+        })();
+        (function () {
+            var registry = (window._interactiveRegistry = {});
+            function getId(t) {
+                for (
+                  ;
+                  (t = t.parentElement) &&
+                  !t.matches("[data-sourceid].interactive-body");
+
+                );
+                return t ? t.getAttribute("data-sourceid") : null;
+            }
+            (window.registerInteractive = function (t) {
+                var e = {
+                    _subs: { cleanup: [], remount: [] },
+                    id: t,
+                    on: function (t, r) {
+                        return this._subs[t].push(r), e;
+                    },
+                };
+                registry[t] = e;
+            }),
+              (window.getInteractiveBridge = function (t) {
+                  var e = "string" == typeof t ? t : getId(t);
+                  return registry[e];
+              });
+        })();
+        (function () {
+            var _f = function () {
+                "function" != typeof window.onInitNativeAds &&
+                (window.onInitNativeAds = function () {});
+            };
+            _f.apply(null, []);
+        })();
+    </script>
+    <script>
+        !(function (e) {
+            function t(t) {
+                for (
+                  var n, a, i = t[0], l = t[1], f = t[2], c = 0, s = [];
+                  c < i.length;
+                  c++
+                )
+                    (a = i[c]),
+                    Object.prototype.hasOwnProperty.call(o, a) &&
+                    o[a] &&
+                    s.push(o[a][0]),
+                      (o[a] = 0);
+                for (n in l)
+                    Object.prototype.hasOwnProperty.call(l, n) && (e[n] = l[n]);
+                for (p && p(t); s.length; ) s.shift()();
+                return u.push.apply(u, f || []), r();
+            }
+            function r() {
+                for (var e, t = 0; t < u.length; t++) {
+                    for (var r = u[t], n = !0, i = 1; i < r.length; i++) {
+                        var l = r[i];
+                        0 !== o[l] && (n = !1);
+                    }
+                    n && (u.splice(t--, 1), (e = a((a.s = r[0]))));
+                }
+                return e;
+            }
+            var n = {},
+              o = { 95: 0 },
+              u = [];
+            function a(t) {
+                if (n[t]) return n[t].exports;
+                var r = (n[t] = { i: t, l: !1, exports: {} });
+                return e[t].call(r.exports, r, r.exports, a), (r.l = !0), r.exports;
+            }
+            (a.m = e),
+              (a.c = n),
+              (a.d = function (e, t, r) {
+                  a.o(e, t) ||
+                  Object.defineProperty(e, t, { enumerable: !0, get: r });
+              }),
+              (a.r = function (e) {
+                  "undefined" != typeof Symbol &&
+                  Symbol.toStringTag &&
+                  Object.defineProperty(e, Symbol.toStringTag, { value: "Module" }),
+                    Object.defineProperty(e, "__esModule", { value: !0 });
+              }),
+              (a.t = function (e, t) {
+                  if ((1 & t && (e = a(e)), 8 & t)) return e;
+                  if (4 & t && "object" == typeof e && e && e.__esModule) return e;
+                  var r = Object.create(null);
+                  if (
+                    (a.r(r),
+                      Object.defineProperty(r, "default", { enumerable: !0, value: e }),
+                    2 & t && "string" != typeof e)
+                  )
+                      for (var n in e)
+                          a.d(
+                            r,
+                            n,
+                            function (t) {
+                                return e[t];
+                            }.bind(null, n)
+                          );
+                  return r;
+              }),
+              (a.n = function (e) {
+                  var t =
+                    e && e.__esModule
+                      ? function () {
+                          return e.default;
+                      }
+                      : function () {
+                          return e;
+                      };
+                  return a.d(t, "a", t), t;
+              }),
+              (a.o = function (e, t) {
+                  return Object.prototype.hasOwnProperty.call(e, t);
+              }),
+              (a.p = "/vi-assets/static-assets/");
+            var i = (window.webpackJsonp = window.webpackJsonp || []),
+              l = i.push.bind(i);
+            (i.push = t), (i = i.slice());
+            for (var f = 0; f < i.length; f++) t(i[f]);
+            var p = l;
+            r();
+        })([]);
+        //# sourceMappingURL=runtime~adslot-5f69a483ce37423d4090.js.map
+    </script>
+    <script
+      async
+      src="/vi-assets/static-assets/adslot-b820f4a1b9c004ec5295.js"
+    ></script>
+
+    <script data-rh="true">
+        (function () {
+            var _f = function () {
+                const o = "1_block";
+                function n(o) {
+                    return window && window.NYTD && window.NYTD.Abra
+                      ? window.NYTD.Abra(o)
+                      : "";
+                }
+                window.adClientUtils = {
+                    hasActiveToggle: function (r) {
+                        return n(r) !== o;
+                    },
+                    getAbraVar: n,
+                    reportExposure: function (o) {
+                        window &&
+                        window.NYTD &&
+                        window.NYTD.Abra &&
+                        window.NYTD.Abra.reportExposure &&
+                        window.NYTD.Abra.reportExposure(o);
+                    },
+                };
+            };
+            _f.apply(null, []);
+        })();
+        (function () {
+            undefined;
+        })();
+        (function () {
+            var _f = function () {
+                var t,
+                  e,
+                  o = 50,
+                  n = 50;
+                function i(t) {
+                    if (!document.getElementById("3pCheckIframeId")) {
+                        if ((t || (t = 1), !document.body)) {
+                            if (t > o) return;
+                            return (t += 1), setTimeout(i.bind(null, t), n);
+                        }
+                        var e, a, r;
+                        (e = "https://static01.nyt.com/ads/tpc-check.html"),
+                          (a = document.body),
+                          ((r = document.createElement("iframe")).src = e),
+                          (r.id = "3pCheckIframeId"),
+                          (r.style = "display:none;"),
+                          (r.height = 0),
+                          (r.width = 0),
+                          a.insertBefore(r, a.firstChild);
+                    }
+                }
+                function a(t) {
+                    if ("https://static01.nyt.com" === t.origin)
+                        try {
+                            "3PCookieSupported" === t.data &&
+                            googletag.cmd.push(function () {
+                                googletag.pubads().setTargeting("cookie", "true");
+                            }),
+                            "3PCookieNotSupported" === t.data &&
+                            googletag.cmd.push(function () {
+                                googletag.pubads().setTargeting("cookie", "false");
+                            });
+                        } catch (t) {}
+                }
+                function r() {
+                    if (
+                      (function () {
+                          if (
+                            Object.prototype.toString
+                              .call(window.HTMLElement)
+                              .indexOf("Constructor") > 0
+                          )
+                              return !0;
+                          if (
+                            "[object SafariRemoteNotification]" ===
+                            (!window.safari || safari.pushNotification).toString()
+                          )
+                              return !0;
+                          try {
+                              return (
+                                window.localStorage &&
+                                /Safari/.test(window.navigator.userAgent)
+                              );
+                          } catch (t) {
+                              return !1;
+                          }
+                      })()
+                    ) {
+                        try {
+                            window.openDatabase(null, null, null, null);
+                        } catch (e) {
+                            return t(), !0;
+                        }
+                        try {
+                            localStorage.length
+                              ? e()
+                              : ((localStorage.x = 1), localStorage.removeItem("x"), e());
+                        } catch (o) {
+                            navigator.cookieEnabled ? t() : e();
+                        }
+                        return !0;
+                    }
+                }
+                !(function () {
+                    try {
+                        googletag.cmd.push(function () {
+                            googletag.pubads().setTargeting("cookie", "unknown");
+                        });
+                    } catch (t) {}
+                })(),
+                  (t =
+                    function () {
+                        try {
+                            googletag.cmd.push(function () {
+                                googletag.pubads().setTargeting("cookie", "private");
+                            });
+                        } catch (t) {}
+                    } || function () {}),
+                  (e =
+                    function () {
+                        window.addEventListener("message", a, !1), i(0);
+                    } || function () {}),
+                (function () {
+                    if (window.webkitRequestFileSystem)
+                        return (
+                          window.webkitRequestFileSystem(window.TEMPORARY, 1, e, t), !0
+                        );
+                })() ||
+                r() ||
+                (function () {
+                    if (
+                      !window.indexedDB &&
+                      (window.PointerEvent || window.MSPointerEvent)
+                    )
+                        return t(), !0;
+                })() ||
+                e();
+            };
+            _f.apply(null, ["dfp_story_toggle"]);
+        })();
+    </script>
+    <script data-rh="true" id="als-svc">
+        (function () {
+            var _f = function (e, t, a) {
+                var n;
+                if (
+                  !((n = a),
+                  !!(
+                    window &&
+                    window.adClientUtils &&
+                    window.adClientUtils.hasActiveToggle
+                  ) && window.adClientUtils.hasActiveToggle(n))
+                )
+                    return;
+                !(function (e) {
+                    window &&
+                    window.NYTD &&
+                    window.NYTD.Abra &&
+                    window.NYTD.Abra.reportExposure(e);
+                })(a);
+                let i = () => {
+                    var e = new Date(),
+                      t = e.getFullYear();
+                    return (
+                      e.getMonth() < 9 && (t += "0"),
+                        (t += e.getMonth() + 1),
+                      e.getDate() < 10 && (t += "0"),
+                        (t += e.getDate()),
+                      e.getHours() < 10 && (t += "0"),
+                        (t += e.getHours()),
+                      e.getMinutes() < 10 && (t += "0"),
+                        (t += e.getMinutes()),
+                      e.getSeconds() < 10 && (t += "0"),
+                      t + e.getSeconds()
+                    );
+                };
+                (window.googletag = window.googletag || {}),
+                  (googletag.cmd = googletag.cmd || []);
+                let o = new URLSearchParams(location.search).get("alice_rules_test");
+                var l,
+                  s = new XMLHttpRequest(),
+                  r = window.vi.env.ALS_URL,
+                  d = document.querySelector('[name="nyt_uri"]');
+                if (t) l = "uri=" + (g = t);
+                else if ("/" === location.pathname) {
+                    var g = encodeURIComponent(
+                      "https://www.nytimes.com/pages/index.html"
+                    );
+                    l = "uri=" + g;
+                } else if (void 0 === d || "" === d || null === d) {
+                    var c =
+                      e ||
+                      location.protocol + "//" + location.hostname + location.pathname;
+                    l = "url=" + encodeURIComponent(c);
+                } else {
+                    g = encodeURIComponent(d.content);
+                    l = "uri=" + g;
+                }
+                var u = document.querySelector('[name="template"]'),
+                  w = document.querySelector('[name="prop"]'),
+                  m = document.querySelector('[name="plat"]'),
+                  p = null == u || null == u.content ? "" : u.content,
+                  _ = null == w || null == w.content ? "nyt" : w.content,
+                  v = null == m || null == m.content ? "web" : m.content;
+                window.innerWidth < 740 && ((_ = "mnyt"), (v = "mweb"));
+                var b = window.localStorage.getItem("als_test_clientside"),
+                  f = null;
+                window.googletag.cmd.push(function () {
+                    var e = b && 0 !== b.length ? b : "empty_empty_empty_" + i(),
+                      t = f || e;
+                    googletag.pubads().setTargeting("als_test_clientside", t);
+                });
+                var h = window.localStorage.getItem("mktg"),
+                  y = null;
+                window.googletag.cmd.push(function () {
+                    var e = y || h;
+                    e && googletag.pubads().setTargeting("mktg", e);
+                });
+                var U,
+                  L = window.localStorage.getItem("bt");
+                window.googletag.cmd.push(function () {
+                    var e = U || L;
+                    e && googletag.pubads().setTargeting("bt", e);
+                });
+                var T = window.localStorage.getItem("sub"),
+                  S = null;
+                window.googletag.cmd.push(function () {
+                    var e = S || T;
+                    e && googletag.pubads().setTargeting("sub", e);
+                }),
+                  (l = null == o ? l : l + "&alice_rules_test=" + o),
+                  s.open(
+                    "GET",
+                    r + "/als?" + l + "&typ=" + p + "&prop=" + _ + "&plat=" + v,
+                    !0
+                  ),
+                  (s.withCredentials = !0),
+                  s.send(),
+                  (s.onerror = function () {
+                      var e = "reqfailed_reqfailed_reqfailed_" + i();
+                      (f = e),
+                        window.googletag.cmd.push(function () {
+                            googletag.pubads().setTargeting("als_test_clientside", e);
+                        });
+                      var t = {
+                          event: "impression",
+                          module: {
+                              name: "alice-timing",
+                              context: "script-load",
+                              label: "alice-error-reqfail-" + l,
+                          },
+                      };
+                      (window.dataLayer = window.dataLayer || []).push(t);
+                  }),
+                  (s.onreadystatechange = function () {
+                      if (4 === s.readyState)
+                          if (200 === s.status) {
+                              var e = JSON.parse(s.responseText);
+                              (f =
+                                e.als_test_clientside && 0 !== e.als_test_clientside.length
+                                  ? e.als_test_clientside
+                                  : "bou_bou_bou_" + i()),
+                              void 0 !== e.User &&
+                              (void 0 !== e.User.mktg &&
+                              ((y = e.User.mktg),
+                                window.localStorage.setItem("mktg", e.User.mktg)),
+                              void 0 !== e.User.bt &&
+                              ((U = e.User.bt),
+                                window.localStorage.setItem("bt", e.User.bt)),
+                              void 0 !== e.User.sub &&
+                              ((S = e.User.sub),
+                                window.localStorage.setItem("sub", e.User.sub))),
+                                window.googletag.cmd.push(function () {
+                                    if (
+                                      e.als_test_clientside &&
+                                      0 !== e.als_test_clientside.length
+                                    )
+                                        googletag
+                                          .pubads()
+                                          .setTargeting(
+                                            "als_test_clientside",
+                                            e.als_test_clientside
+                                          ),
+                                          window.localStorage.setItem(
+                                            "als_test_clientside",
+                                            "ls-" + e.als_test_clientside
+                                          );
+                                    else {
+                                        var t =
+                                          void 0 === e.als_test_clientside
+                                            ? "undefined_undefined_undefined_" + i()
+                                            : "blank_blank_blank_" + i();
+                                        googletag
+                                          .pubads()
+                                          .setTargeting("als_test_clientside", t);
+                                        var a = {
+                                            event: "impression",
+                                            module: {
+                                                name: "alice-timing",
+                                                context: "script-load",
+                                                label: "alice-error-test-client-undefined",
+                                            },
+                                        };
+                                        (window.dataLayer = window.dataLayer || []).push(a);
+                                    }
+                                    if (void 0 !== e.User) {
+                                        if (y) googletag.pubads().setTargeting("mktg", y);
+                                        else {
+                                            a = {
+                                                event: "impression",
+                                                module: {
+                                                    name: "alice-timing",
+                                                    context: "script-load",
+                                                    label: "alice-error-mktg-undefined",
+                                                },
+                                            };
+                                            (window.dataLayer = window.dataLayer || []).push(a);
+                                        }
+                                        if (void 0 !== U)
+                                            googletag.pubads().setTargeting("bt", U);
+                                        else {
+                                            a = {
+                                                event: "impression",
+                                                module: {
+                                                    name: "alice-timing",
+                                                    context: "script-load",
+                                                    label: "alice-error-bt-undefined",
+                                                },
+                                            };
+                                            (window.dataLayer = window.dataLayer || []).push(a);
+                                        }
+                                        if (S) googletag.pubads().setTargeting("sub", S);
+                                        else {
+                                            a = {
+                                                event: "impression",
+                                                module: {
+                                                    name: "alice-timing",
+                                                    context: "script-load",
+                                                    label: "alice-error-sub-undefined",
+                                                },
+                                            };
+                                            (window.dataLayer = window.dataLayer || []).push(a);
+                                        }
+                                        (e.User.lucidC1 ||
+                                          e.User.lucidC2 ||
+                                          e.User.lucidC3 ||
+                                          e.User.lucidC4 ||
+                                          e.User.lucidC5) &&
+                                        dataLayer.push({
+                                            event: "lucidtest",
+                                            c1_val: e.User.lucidC1,
+                                            c2_val: e.User.lucidC2,
+                                            c3_val: e.User.lucidC3,
+                                            c4_val: e.User.lucidC4,
+                                            c5_val: e.User.lucidC5,
+                                        });
+                                    } else {
+                                        a = {
+                                            event: "impression",
+                                            module: {
+                                                name: "alice-timing",
+                                                context: "script-load",
+                                                label: "alice-error-user-undefined",
+                                            },
+                                        };
+                                        (window.dataLayer = window.dataLayer || []).push(a);
+                                    }
+                                    if (void 0 !== e.Asset)
+                                        for (var n in e.Asset) {
+                                            var o = e.Asset[n];
+                                            if (o) googletag.pubads().setTargeting(n, o);
+                                            else {
+                                                a = {
+                                                    event: "impression",
+                                                    module: {
+                                                        name: "alice-timing",
+                                                        context: "script-load",
+                                                        label: "alice-error-" + n + "-undefined",
+                                                    },
+                                                };
+                                                (window.dataLayer = window.dataLayer || []).push(a);
+                                            }
+                                        }
+                                    else {
+                                        a = {
+                                            event: "impression",
+                                            module: {
+                                                name: "alice-timing",
+                                                context: "script-load",
+                                                label: "alice-error-asset-undefined",
+                                            },
+                                        };
+                                        (window.dataLayer = window.dataLayer || []).push(a);
+                                    }
+                                });
+                          } else {
+                              s.responseText.substring(0, 40);
+                              var t = "error_" + s.status + "_error_" + i();
+                              window.googletag.cmd.push(function () {
+                                  googletag.pubads().setTargeting("als_test_clientside", t);
+                              });
+                              var a = {
+                                  event: "impression",
+                                  module: {
+                                      name: "alice-timing",
+                                      context: "script-load",
+                                      label: "alice-error-ajaxreq-" + s.status + "-" + l,
+                                  },
+                              };
+                              (window.dataLayer = window.dataLayer || []).push(a);
+                          }
+                  });
+            };
+            _f.apply(null, [null, null, "als_toggle"]);
+        })();
+    </script>
+    <script data-rh="true" id="adslot-config">
+        (function () {
+            var AdSlot4 = (function () {
+                "use strict";
+                function a() {
+                    return (
+                      (window.AdSlot4 = window.AdSlot4 || {}),
+                        (window.AdSlot4.cmd = window.AdSlot4.cmd || []),
+                        window.AdSlot4
+                    );
+                }
+                function n() {
+                    return !(
+                      "undefined" == typeof window ||
+                      !window.document ||
+                      !window.document.createElement
+                    );
+                }
+                function t(e) {
+                    return -1 !== document.cookie.indexOf(e);
+                }
+                function o(e) {
+                    var n = {
+                          PURR_AcceptableTrackers: 0,
+                          PURR_AdConfiguration: 5,
+                          PURR_DataSaleOptOutUI: 2,
+                          PURR_DataProcessingConsentUI: 3,
+                          PURR_AcceptableTrackers_v2: 4,
+                          PURR_AdConfiguration_v2: 5,
+                          PURR_DataProcessingPreferenceUI: 6,
+                          PURR_DataSaleOptOutUI_v2: 7,
+                          PURR_CaliforniaNoticesUI: 8,
+                          PURR_EmailMarketingOptInUI: 9,
+                          PURR_DeleteIPAddress: 10,
+                          PURR_AdConfiguration_v3: 11,
+                      },
+                      t = (function (e) {
+                          e = ("; " + document.cookie).split("; " + e + "=");
+                          return 2 === e.length ? e.pop().split(";").shift() : null;
+                      })(e),
+                      o = {};
+                    return (
+                      Object.keys(n).forEach(function (e) {
+                          o[e] = (function (e, n) {
+                              (n = new RegExp("^.{" + n + "}(.)")), (n = e.match(n));
+                              return (null == n ? void 0 : n[1]) || "";
+                          })(t, n[e]);
+                      }),
+                        d.forEach(function (n) {
+                            Object.keys(n.valueMapping).forEach(function (e) {
+                                n.valueMapping[e] === o[n.name] && (o[n.name] = e);
+                            });
+                        }),
+                        o
+                    );
+                }
+                function i() {
+                    var e;
+                    try {
+                        return (function () {
+                            if ("undefined" == typeof window) return !1;
+                            var e = window.navigator.userAgent || window.navigator.vendor,
+                              n = -1 !== e.indexOf("nyt_android"),
+                              t = -1 !== e.indexOf("nytios"),
+                              o = -1 !== e.indexOf("nyt_xwords_ios"),
+                              e = -1 !== e.indexOf("Crosswords");
+                            return n || t || o || e;
+                        })()
+                          ? null !==
+                          (e =
+                            null === window || void 0 === window
+                              ? void 0
+                              : window.config) &&
+                          void 0 !== e &&
+                          e.PurrDirectives
+                            ? window.config.PurrDirectives
+                            : t("override-purr")
+                              ? o("override-purr")
+                              : r({}, c)
+                          : t("nyt-purr")
+                            ? o("nyt-purr")
+                            : r({}, c);
+                    } catch (e) {
+                        return (
+                          console.warn("can’t get directives from cookie or config", e),
+                            r({}, c)
+                        );
+                    }
+                }
+                var r = function () {
+                      return (r =
+                        Object.assign ||
+                        function (e) {
+                            for (var n, t = 1, o = arguments.length; t < o; t++)
+                                for (var i in (n = arguments[t]))
+                                    Object.prototype.hasOwnProperty.call(n, i) &&
+                                    (e[i] = n[i]);
+                            return e;
+                        }).apply(this, arguments);
+                  },
+                  d = [
+                      {
+                          name: "PURR_AcceptableTrackers",
+                          valueMapping: { controllers: "c", processors: "p" },
+                      },
+                      {
+                          name: "PURR_AdConfiguration",
+                          valueMapping: { full: "f", npa: "n", "adluce-socrates": "s" },
+                      },
+                      {
+                          name: "PURR_DataSaleOptOutUI",
+                          valueMapping: { hide: "h", show: "s" },
+                      },
+                      {
+                          name: "PURR_DataProcessingConsentUI",
+                          valueMapping: { hide: "h", show: "s" },
+                      },
+                      {
+                          name: "PURR_AcceptableTrackers_v2",
+                          valueMapping: {
+                              controllers: "c",
+                              processors: "p",
+                              essentials: "e",
+                          },
+                      },
+                      {
+                          name: "PURR_AdConfiguration_v2",
+                          valueMapping: {
+                              full: "f",
+                              rdp: "r",
+                              npa: "n",
+                              adluce: "a",
+                              "adluce-socrates": "s",
+                          },
+                      },
+                      {
+                          name: "PURR_DataProcessingPreferenceUI",
+                          valueMapping: {
+                              hide: "h",
+                              "allow-opt-out": "o",
+                              "allow-opt-in": "i",
+                              "allow-opt-in-or-out": "a",
+                          },
+                      },
+                      {
+                          name: "PURR_DataSaleOptOutUI_v2",
+                          valueMapping: { hide: "h", show: "s", "show-opted-out": "o" },
+                      },
+                      {
+                          name: "PURR_CaliforniaNoticesUI",
+                          valueMapping: { hide: "h", show: "s" },
+                      },
+                      {
+                          name: "PURR_EmailMarketingOptInUI",
+                          valueMapping: { checked: "c", unchecked: "u" },
+                      },
+                      {
+                          name: "PURR_DeleteIPAddress",
+                          valueMapping: { delete: "d", keep: "k" },
+                      },
+                      {
+                          name: "PURR_AdConfiguration_v3",
+                          valueMapping: {
+                              full: "f",
+                              rdp: "r",
+                              npa: "n",
+                              ltd: "l",
+                              "adluce-socrates": "s",
+                          },
+                      },
+                  ],
+                  c = {
+                      PURR_DataSaleOptOutUI: "hide",
+                      PURR_DataSaleOptOutUI_v2: "hide",
+                      PURR_CaliforniaNoticesUI: "hide",
+                      PURR_DataProcessingConsentUI: "hide",
+                      PURR_DataProcessingPreferenceUI: "hide",
+                      PURR_AcceptableTrackers_v2: "controllers",
+                      PURR_AcceptableTrackers: "controllers",
+                      PURR_AdConfiguration_v2: "full",
+                      PURR_AdConfiguration: "full",
+                      PURR_EmailMarketingOptInUI: "checked",
+                      PURR_DeleteIPAddress: "delete",
+                      PURR_AdConfiguration_v3: "full",
+                  };
+                function e() {
+                    return (
+                      "full" ===
+                      ((e = {}),
+                      n() &&
+                      (e =
+                        i().PURR_AdConfiguration_v3 || i().PURR_AdConfiguration_v2),
+                        e)
+                    );
+                    var e;
+                }
+                function u() {
+                    return (
+                      !(
+                        !!n() &&
+                        null !==
+                        window.navigator.userAgent.match(/nyt[-_]?(?:ios|android)/i)
+                      ) && e()
+                    );
+                }
+                function l(e, n, t) {
+                    var o = document.getElementsByTagName("head")[0],
+                      i = document.createElement("script");
+                    n && (i.onload = n),
+                    t && (i.onerror = t),
+                      (i.src = e),
+                      (i.async = !0),
+                      o.appendChild(i);
+                }
+                function s() {
+                    a().cmd.push(function () {
+                        var e = "".concat("GeoEdge", " failed to load");
+                        a().events.publish({ name: h, value: { message: e } });
+                    });
+                }
+                function p() {
+                    return (
+                      !window.grumi &&
+                      (l(
+                        "//rumcdn.geoedge.be/b3960cc6-bfd2-4adc-910c-6e917e8a6a0e/grumi-ip.js",
+                        null,
+                        s
+                      ),
+                        (window.grumi = {
+                            key: "b3960cc6-bfd2-4adc-910c-6e917e8a6a0e",
+                            cfg: { advs: v },
+                        }))
+                    );
+                }
+                function m() {
+                    var e;
+                    window.apstag ||
+                    ((e = "".concat(b, " not loading properly")), console.warn(e));
+                }
+                function f() {
+                    a().cmd.push(function () {
+                        var e = "".concat(b, " failed to load");
+                        a().events.publish({ name: U, value: { type: b, message: e } });
+                    });
+                }
+                function w() {
+                    var e =
+                      0 < arguments.length && void 0 !== arguments[0]
+                        ? arguments[0]
+                        : window;
+                    return (
+                      (e.googletag = e.googletag || {}),
+                        (e.googletag.cmd = e.googletag.cmd || []),
+                        e.googletag
+                    );
+                }
+                function g(e) {
+                    return (
+                      !(!window.apstag || !window.apstag.fetchBids) &&
+                      (window.apstag.fetchBids(
+                        { slots: e },
+                        void (
+                          window.apstag &&
+                          window.apstag.setDisplayBids &&
+                          w().cmd.push(window.apstag.setDisplayBids())
+                        )
+                      ),
+                        !0)
+                    );
+                }
+                var v = {
+                      32074718: !0,
+                      4792640386: !0,
+                      21966278: !0,
+                      4558311760: !0,
+                      4552626466: !0,
+                      4400775978: !0,
+                      39318518: !0,
+                      4874174581: !0,
+                      33597638: !0,
+                      38636678: !0,
+                      38637278: !0,
+                      33597998: !0,
+                      33613118: !0,
+                  },
+                  h = "script_loader_error",
+                  b = "A9",
+                  _ = [
+                      [300, 250],
+                      [728, 90],
+                      [970, 90],
+                      [970, 250],
+                  ],
+                  R = "large",
+                  P = "medium",
+                  y = "small",
+                  U = "BidderError",
+                  A = "AdEmpty",
+                  k = "AdBlockOn",
+                  x = "AdDefined",
+                  I = "AdRefreshed";
+                function C(e, n) {
+                    var t;
+                    return (e = []
+                      .concat(
+                        ((t = n),
+                          []
+                            .concat(e)
+                            .slice()
+                            .sort(function (e, n) {
+                                return n[0] - e[0];
+                            })
+                            .find(function (e) {
+                                return !Number.isNaN(e[0]) && e[0] < t;
+                            }))
+                      )
+                      .pop()) && e.length
+                      ? e
+                      : null;
+                }
+                function D(i) {
+                    return function () {
+                        var e,
+                          n =
+                            0 < arguments.length && void 0 !== arguments[0]
+                              ? arguments[0]
+                              : {},
+                          t = n.sizes,
+                          o = void 0 === t ? [] : t,
+                          t = n.truePosition,
+                          n = n.id,
+                          o = C(o, window.innerWidth),
+                          o =
+                            ((e = o),
+                              Array.isArray(e)
+                                ? _.filter(function (n) {
+                                    return e.some(function (e) {
+                                        return e[0] === n[0] && e[1] === n[1];
+                                    });
+                                })
+                                : (console.warn("filterSizes() did not receive an array"),
+                                  []));
+                        if (0 < o.length) {
+                            o = [
+                                {
+                                    slotID: t || n,
+                                    slotName: "".concat(t || n, "_").concat(i, "_web"),
+                                    sizes: o,
+                                },
+                            ];
+                            return g(o), !0;
+                        }
+                        return !1;
+                    };
+                }
+                function O(e, n, t) {
+                    return (
+                      n in e
+                        ? Object.defineProperty(e, n, {
+                            value: t,
+                            enumerable: !0,
+                            configurable: !0,
+                            writable: !0,
+                        })
+                        : (e[n] = t),
+                        e
+                    );
+                }
+                function z(t, o) {
+                    return E.map(function (e) {
+                        var n = e.id,
+                          e = e.sizes;
+                        return {
+                            slotID: n,
+                            slotName: "".concat(n, "_").concat(o, "_web"),
+                            sizes: (e = e)[t] || e[y],
+                        };
+                    });
+                }
+                function S(n, t) {
+                    a().cmd.push(function () {
+                        var e;
+                        n && g(z(740 < (e = window.innerWidth) ? R : 600 < e ? P : y, t)),
+                          a().events.subscribe({ name: x, scope: "all", callback: D(t) });
+                    });
+                }
+                function j(e, n, t) {
+                    (function () {
+                        var e,
+                          t =
+                            0 < arguments.length && void 0 !== arguments[0]
+                              ? arguments[0]
+                              : "apstag",
+                          o =
+                            1 < arguments.length && void 0 !== arguments[1]
+                              ? arguments[1]
+                              : window;
+                        return (
+                          o[t] ||
+                          ((e = function (e, n) {
+                              return o[t]._Q.push([e, n]);
+                          }),
+                            (o[t] = {
+                                _Q: [],
+                                init: function () {
+                                    e("i", arguments);
+                                },
+                                fetchBids: function () {
+                                    e("f", arguments);
+                                },
+                                setDisplayBids: function () {},
+                                targetingKeys: function () {
+                                    return [];
+                                },
+                            })),
+                            o[t]
+                        );
+                    })("apstag", window).init({
+                        pubID: "3030",
+                        adServer: "googletag",
+                        params: { si_section: n },
+                    }),
+                      S(e, t);
+                }
+                function T(e, n) {
+                    var t;
+                    switch (n.includes(H) ? H : n) {
+                        case q:
+                            t = e.top;
+                            break;
+                        case H:
+                            t = e.mid;
+                            break;
+                        case Q:
+                            t = e.bottom;
+                            break;
+                        default:
+                            t = e.default;
+                    }
+                    return t;
+                }
+                function M(e) {
+                    var n;
+                    switch (e) {
+                        case "livebl":
+                            n = "hp";
+                            break;
+                        case "int":
+                            n = "art";
+                            break;
+                        case "coll":
+                            n = "sf";
+                            break;
+                        default:
+                            n = e;
+                    }
+                    return n in B || (n = "default"), n;
+                }
+                var E = [
+                      {
+                          id: "dfp-ad-top",
+                          sizes:
+                            (O((ce = {}), R, [
+                                [728, 90],
+                                [970, 90],
+                                [970, 250],
+                            ]),
+                              O(ce, P, [
+                                  [728, 90],
+                                  [300, 250],
+                              ]),
+                              O(ce, y, [
+                                  [300, 250],
+                                  [300, 420],
+                              ]),
+                              ce),
+                      },
+                      {
+                          id: "top",
+                          sizes:
+                            (O((de = {}), R, [
+                                [728, 90],
+                                [970, 90],
+                                [970, 250],
+                            ]),
+                              O(de, P, [
+                                  [728, 90],
+                                  [300, 250],
+                              ]),
+                              O(de, y, [
+                                  [300, 250],
+                                  [300, 420],
+                              ]),
+                              de),
+                      },
+                  ],
+                  B = {
+                      art: {
+                          id: [
+                              "top",
+                              "story-ad-1",
+                              "story-ad-2",
+                              "story-ad-3",
+                              "story-ad-4",
+                              "story-ad-5",
+                              "story-ad-6",
+                              "bottom",
+                          ],
+                          pos: [
+                              "top",
+                              "mid1",
+                              "mid2",
+                              "mid3",
+                              "mid4",
+                              "mid5",
+                              "mid6",
+                              "bottom",
+                          ],
+                      },
+                      hp: {
+                          id: [
+                              "dfp-ad-top",
+                              "dfp-ad-mid1",
+                              "dfp-ad-mid2",
+                              "dfp-ad-mid3",
+                              "dfp-ad-bottom",
+                          ],
+                          pos: ["top", "mid1", "mid2", "mid3", "bottom"],
+                      },
+                      ss: {
+                          id: ["right-0", "right-1", "right-2", "right-3"],
+                          pos: ["mid1", "mid1", "mid1", "mid1"],
+                          size: {
+                              small: [[300, 250]],
+                              medium: [[300, 250]],
+                              large: [[300, 250]],
+                          },
+                      },
+                      sf: {
+                          id: ["top", "mid1", "mid2"],
+                          pos: ["top", "mid1", "mid2"],
+                          size: {
+                              small: [
+                                  [300, 250],
+                                  [300, 420],
+                              ],
+                              medium: [
+                                  [300, 250],
+                                  [300, 420],
+                              ],
+                              large: [
+                                  [300, 250],
+                                  [300, 420],
+                              ],
+                          },
+                      },
+                      games: { id: ["TopAd", "TopAd1"], pos: ["top", "bottom"] },
+                      default: {
+                          id: ["top", "mid1", "mid2"],
+                          pos: ["top", "mid1", "mid2"],
+                          size: {
+                              small: [
+                                  [300, 250],
+                                  [300, 420],
+                              ],
+                              medium: [[728, 90]],
+                              large: [
+                                  [728, 90],
+                                  [970, 90],
+                                  [970, 250],
+                              ],
+                          },
+                      },
+                  },
+                  N = {
+                      top: 2088370,
+                      mid: 2088372,
+                      bottom: 2088374,
+                      default: 2088376,
+                  },
+                  Y = {
+                      top: 544112060,
+                      mid: 544112063,
+                      bottom: 544112062,
+                      default: 544112065,
+                  },
+                  V = {
+                      top: 684296214,
+                      mid: 190706820,
+                      bottom: 932254072,
+                      default: 153468583,
+                  },
+                  F = {
+                      top: "NYTimes_728x90_970_top_PB",
+                      mid: "NYTimes_728x90_970_mid_PB",
+                      botom: "NYTimes_728x90_970_bot_PB",
+                      default: "NYTimes_728x90_970_mid_PB",
+                  },
+                  G = {
+                      buckets: [
+                          { max: 10, increment: 0.05 },
+                          { max: 20, increment: 0.1 },
+                          { max: 50, increment: 0.5 },
+                          { max: 101, increment: 1 },
+                      ],
+                  },
+                  q = "top",
+                  H = "mid",
+                  Q = "bottom";
+                function W(o, e, i) {
+                    var a = M(e),
+                      r = B[a].size ? a : "default";
+                    return B[a].pos.reduce(function (e, n, t) {
+                        (t = B[a].id[t]),
+                          (t = {
+                              code: t,
+                              mediaTypes: {
+                                  banner: {
+                                      sizeConfig: [
+                                          {
+                                              minViewPort: [970, 0],
+                                              sizes: (i && i[t] ? i[t] : B[r]).size.large,
+                                          },
+                                          {
+                                              minViewPort: [728, 0],
+                                              sizes: (i && i[t] ? i[t] : B[r]).size.medium,
+                                          },
+                                          { minViewPort: [0, 0], sizes: B[r].size.small },
+                                      ],
+                                  },
+                              },
+                              bids:
+                                ((t = n),
+                                  [
+                                      {
+                                          bidder: "appnexus",
+                                          params: {
+                                              member: 3661,
+                                              invCode: "nyt_".concat((n = o), "_").concat(t),
+                                          },
+                                      },
+                                      {
+                                          bidder: "medianet",
+                                          params: { cid: "8CU4WQK98", crid: T(V, t) },
+                                      },
+                                      {
+                                          bidder: "rubicon",
+                                          params: {
+                                              accountId: 12330,
+                                              siteId: 378266,
+                                              inventory: {
+                                                  invCode: ["nyt_".concat(n, "_").concat(t)],
+                                              },
+                                              zoneId: T(N, t),
+                                              position: "top" === t ? "atf" : "btf",
+                                          },
+                                      },
+                                      {
+                                          bidder: "openx",
+                                          params: {
+                                              unit: T(Y, t),
+                                              delDomain: "nytimes-d.openx.net",
+                                              customParams: {
+                                                  invCode: "nyt_".concat(n, "_").concat(t),
+                                              },
+                                          },
+                                      },
+                                      {
+                                          bidder: "triplelift",
+                                          params: { inventoryCode: T(F, t) },
+                                      },
+                                  ]),
+                          });
+                        return e.push(t), e;
+                    }, []);
+                }
+                function Z(t) {
+                    (window.pbjs = window.pbjs || {}),
+                    window.pbjs.initAdserverSet ||
+                    ((window.pbjs.initAdserverSet = !0),
+                      a().cmd.push(function () {
+                          a().events.subscribe({
+                              name: x,
+                              scope: "all",
+                              callback: function (n) {
+                                  w().cmd.push(function () {
+                                      var e;
+                                      ((e = M((e = t))), B[e].id).includes(n.id) &&
+                                      window.pbjs.setTargetingForGPTAsync([n.id]);
+                                  });
+                              },
+                          });
+                      }));
+                }
+                function K(t, e, n, o) {
+                    function i(e, n) {
+                        (window.pbjs.initAdserverSet = !1),
+                          t.requestBids({
+                              bidsBackHandler: function () {
+                                  Z(e);
+                              },
+                              timeout: n,
+                          });
+                    }
+                    a().cmd.push(function () {
+                        t.que.push(function () {
+                            t.addAdUnits(W(e, n, o)),
+                              i(n, 1e4),
+                              a().events.subscribe({
+                                  name: I,
+                                  scope: "all",
+                                  callback: function () {
+                                      i(n, 800);
+                                  },
+                              });
+                        });
+                    });
+                }
+                function L(e, n) {
+                    var t =
+                        2 < arguments.length && void 0 !== arguments[2]
+                          ? arguments[2]
+                          : {},
+                      o = (function () {
+                          var e =
+                            0 < arguments.length && void 0 !== arguments[0]
+                              ? arguments[0]
+                              : window;
+                          return (
+                            (e.pbjs = e.pbjs || {}),
+                              (e.pbjs.que = e.pbjs.que || []),
+                              e.pbjs
+                          );
+                      })(),
+                      i = t.priceGranularity,
+                      t = t.sizeConfig;
+                    o.setConfig({ priceGranularity: i || G }), K(o, e, n, t);
+                }
+                function J() {
+                    a().cmd.push(function () {
+                        var e = "".concat("PreBid", " failed to load");
+                        a().events.publish({
+                            name: U,
+                            value: { type: "PreBid", message: e },
+                        });
+                    });
+                }
+                function X(e, n, t) {
+                    return (
+                      !window.pbjs &&
+                      (l(
+                        "https://www.nytimes.com/ads/prebid6.8.0.js",
+                        ((o = e),
+                          (i = n),
+                          (a = t),
+                          function () {
+                              window.pbjs || console.log("prebid did not load"), L(o, i, a);
+                          }),
+                        J
+                      ),
+                        !0)
+                    );
+                    var o, i, a;
+                }
+                function $() {
+                    try {
+                        var e =
+                            (((n = document.createElement("div")).innerHTML = "&nbsp;"),
+                              (n.className =
+                                "ad adsbox pub_300x250 pub_300x250m pub_728x90 text-ad textAd text_ad ad-server"),
+                              (n.style =
+                                "width: 1px !important; height: 1px !important; position: absolute !important; left: -10000px !important; top: -1000px !important;"),
+                              document.body.prepend(n),
+                              document.getElementsByClassName("ad adsbox")[0]),
+                          n =
+                            !(
+                              !(n = e) ||
+                              (0 !== n.offsetHeight && 0 !== n.clientHeight)
+                            ) ||
+                            (function (e) {
+                                if (void 0 !== window.getComputedStyle) {
+                                    e = window.getComputedStyle(e, null);
+                                    if (
+                                      e &&
+                                      ("none" === e.getPropertyValue("display") ||
+                                        "hidden" === e.getPropertyValue("visibility"))
+                                    )
+                                        return !0;
+                                }
+                                return !1;
+                            })(e);
+                        return (e = e), document.body.removeChild(e), n;
+                    } catch (e) {
+                        console.error("ad class check failed", e);
+                    }
+                    var n;
+                    return !1;
+                }
+                function ee() {
+                    return (
+                      !(window && window.AdSlot && window.AdSlot.AdSlotReady) ||
+                      !(window && window.googletag && window.googletag.apiReady) ||
+                      $()
+                    );
+                }
+                function ne() {
+                    var e =
+                      window &&
+                      window.nyt_et &&
+                      window.nyt_et.get_host &&
+                      window.nyt_et.get_host();
+                    return e
+                      ? fetch("".concat(e, "/.status"), {
+                          credentials: "include",
+                          headers: {
+                              accept: "*/*",
+                              "content-type": "text/plain;charset=UTF-8",
+                          },
+                          mode: "no-cors",
+                      })
+                        .then(function () {
+                            return { success: !0 };
+                        })
+                        .catch(function (e) {
+                            return (
+                              console.error("et track blocked", e), { success: !1 }
+                            );
+                        })
+                      : Promise.resolve({ success: !1 });
+                }
+                function te(e, n, t) {
+                    var o =
+                        ((i = "nyt-a"),
+                        (document &&
+                        document.cookie &&
+                        document.cookie.match &&
+                        (i = document.cookie.match(
+                          new RegExp("".concat(i, "=([^;]+)"))
+                        ))
+                          ? i[1]
+                          : "") || null),
+                      i = !!(
+                        window &&
+                        window.matchMedia &&
+                        window.matchMedia("(max-width: 739px)").matches
+                      );
+                    return ""
+                      .concat("https://a-reporting.nytimes.com/report.jpg", "?mobile=")
+                      .concat(i, "&block=")
+                      .concat(t, "&aid=")
+                      .concat(o, "&pvid=")
+                      .concat(e, "&et=")
+                      .concat(n);
+                }
+                function oe(e, n, t) {
+                    return (
+                      !!(
+                        window &&
+                        window.NYTD &&
+                        window.NYTD.Abra &&
+                        "1_network_detection" ===
+                        window.NYTD.Abra("DFP_blockDetect_0221")
+                      ) && ((new Image().src = te(e, n, t)), !0)
+                    );
+                }
+                function ie(e, n) {
+                    n &&
+                    a().cmd.push(function () {
+                        var e = a();
+                        e.events && e.events.publish({ name: A, value: { type: k } });
+                    });
+                    var t = !1;
+                    return ne()
+                      .then(function () {
+                          t = (
+                            0 < arguments.length && void 0 !== arguments[0]
+                              ? arguments[0]
+                              : { success: !1 }
+                          ).success;
+                      })
+                      .catch(function () {})
+                      .finally(function () {
+                          oe(e, t, n);
+                      });
+                }
+                function ae(e) {
+                    var n;
+                    window.addEventListener(
+                      "load",
+                      ((n = e),
+                        function () {
+                            ie(n, ee());
+                        })
+                    );
+                }
+                var re,
+                  de,
+                  ce = function () {
+                      var e =
+                        0 < arguments.length && void 0 !== arguments[0]
+                          ? arguments[0]
+                          : {};
+                      if (re) return !1;
+                      var n = e.loadAmazon,
+                        t = void 0 === n || n,
+                        o = e.loadPrebid,
+                        i = void 0 === o || o,
+                        a = e.setFastFetch,
+                        r = void 0 !== a && a,
+                        d = e.loadGeoEdge,
+                        c = void 0 === d || d,
+                        s = e.section,
+                        n = void 0 === s ? "none" : s,
+                        o = e.pageViewId,
+                        a = void 0 === o ? "" : o,
+                        d = e.pageType,
+                        s = void 0 === d ? "" : d,
+                        o = e.prebidOverrides,
+                        d = void 0 === o ? {} : o;
+                      return (
+                        (e = document.referrer || ""),
+                        !(o =
+                          /([a-zA-Z0-9_\-.]+)(@|%40)([a-zA-Z0-9_\-.]+).([a-zA-Z]{2,5})/).test(
+                          e
+                        ) &&
+                        !o.test(window.location.href) &&
+                        (u() &&
+                        ((s = new RegExp(/art/).test(s) ? "art" : s),
+                        c && p(),
+                        t &&
+                        ((c = r),
+                          (t = n),
+                          (r = s),
+                        window.apstag ||
+                        (l("//c.amazon-adsystem.com/aax2/apstag.js", m, f),
+                          j(c, t, r))),
+                        i && X(n, s, d)),
+                          ae(a),
+                          (re = !0))
+                      );
+                  };
+                return (
+                  ((de = a()).loadScripts = de.loadScripts || ce),
+                    (window.AdSlot4 = de)
+                );
+            })();
+            (function () {
+                var _f = function (e = {}) {
+                    const i = window && window.AdSlot4;
+                    try {
+                        const {
+                              adToggleMap: n,
+                              pageType: t,
+                              prebidOverrides: o,
+                              section: d,
+                              isSectionHbEligible: a,
+                              setFastFetch: r,
+                          } = e,
+                          c = Object.keys(n).reduce((e, i) => {
+                              const t = n[i] || "";
+                              return (
+                                (e[i] = (function (e) {
+                                    return (
+                                      !!(
+                                        window &&
+                                        window.adClientUtils &&
+                                        window.adClientUtils.hasActiveToggle
+                                      ) && window.adClientUtils.hasActiveToggle(e)
+                                    );
+                                })(t)),
+                                  e
+                              );
+                          }, {}),
+                          { amazon: w, geoedge: s } = c,
+                          l = w && a,
+                          g = {
+                              buckets: [
+                                  { max: 3, increment: 0.05 },
+                                  { max: 10, increment: 0.01 },
+                                  { max: 20, increment: 0.1 },
+                                  { max: 50, increment: 0.5 },
+                                  { max: 101, increment: 1 },
+                              ],
+                          };
+                        "function" == typeof i.loadScripts &&
+                        i.loadScripts({
+                            loadAmazon: l,
+                            loadPrebid: a,
+                            setFastFetch: r,
+                            section: d,
+                            prebidOverrides: { ...o, priceGranularity: g },
+                            pageType: t,
+                            pageViewId:
+                              window &&
+                              window.NYTD &&
+                              window.NYTD.PageViewId &&
+                              window.NYTD.PageViewId.current
+                                ? window.NYTD.PageViewId.current
+                                : "",
+                            loadGeoEdge: s,
+                        });
+                    } catch (e) {
+                        console.error(e);
+                    }
+                };
+                _f.apply(null, [
+                    {
+                        adToggleMap: {
+                            amazon: "amazon_story_toggle",
+                            medianet: "medianet_story_toggle",
+                            dfp: "dfp_story_toggle",
+                            geoedge: "geoedge_toggle",
+                        },
+                        pageType: "art",
+                        section: "technology",
+                        isSectionHbEligible: true,
+                        setFastFetch: true,
+                        prebidOverrides: {},
+                    },
+                ]);
+            })();
+            (function () {
+                var _f = function (t = {}) {
+                    (window.AdSlot4 = window.AdSlot4 || {}),
+                      (window.AdSlot4.cmd = window.AdSlot4.cmd || []),
+                      (window.AdSlot4.clientRequirements = {
+                          mergeObjects: function (t, ...e) {
+                              return e.reduce(function (t, e) {
+                                  return Object.entries(e).reduce(function (t, [e, n]) {
+                                      return t[e] && null == n
+                                        ? t
+                                        : Object.assign({}, t, { [e]: n });
+                                  }, t);
+                              }, t);
+                          },
+                          isFunction: function (t) {
+                              return (
+                                "[object Function]" === Object.prototype.toString.call(t)
+                              );
+                          },
+                          getAbraVariant: function (t) {
+                              if (
+                                !(
+                                  window.NYTD &&
+                                  window.NYTD.Abra &&
+                                  window.NYTD.Abra.getAbraSync &&
+                                  this.isFunction(window.NYTD.Abra.getAbraSync)
+                                )
+                              )
+                                  return void console.warn(
+                                    "Abra does not exist or is not a function"
+                                  );
+                              const e = window.NYTD.Abra.getAbraSync(t);
+                              return e && e.variant;
+                          },
+                          shouldHaltDFP: function (t) {
+                              return "1_block" === this.getAbraVariant(t);
+                          },
+                          isAdsDisabled: function ({ section: t } = { section: "" }) {
+                              return "learning" === t;
+                          },
+                          getSov: function (t = {}) {
+                              return (
+                                (t.sov =
+                                  t.sov || (Math.floor(4 * Math.random()) + 1).toString()),
+                                  { sov: t.sov }
+                              );
+                          },
+                          getPageViewId: function (t) {
+                              return { page_view_id: t && t.current };
+                          },
+                          getUserData: function (t = "{}") {
+                              try {
+                                  const e = JSON.parse(t).data;
+                                  return e && e.user;
+                              } catch (t) {
+                                  console.warn("userinfo data unavailable");
+                              }
+                          },
+                          getEm: function (t) {
+                              return t && t.length
+                                ? { em: t.toString().toLowerCase() }
+                                : {};
+                          },
+                          getWat: function (t) {
+                              return t ? { wat: t.toLowerCase() } : {};
+                          },
+                          getDemographics: function (t) {
+                              return this.mergeObjects(
+                                this.getEm(t && t.emailSubscriptions),
+                                this.getWat(t && t.wat)
+                              );
+                          },
+                          isValidDfpVariant: function (t) {
+                              return (
+                                t.toLowerCase().indexOf("dfp") > -1 ||
+                                t.indexOf("redbird") > -1
+                              );
+                          },
+                          joinArgumentsForVariant: function () {
+                              if (arguments.length)
+                                  return [].slice.call(arguments).join("_").toLowerCase();
+                          },
+                          reduceAbraConfigKeysToDfpVariants: function (t = [], e = "") {
+                              const n = this.getAbraVariant(e),
+                                i = this.joinArgumentsForVariant(e, n);
+                              return n && i ? t.concat(i) : t;
+                          },
+                          getDFPTestNames: function (t = {}) {
+                              if (!t) return [];
+                              const e = this.isValidDfpVariant;
+                              return Object.keys(t).filter(function (t) {
+                                  return e(t);
+                              });
+                          },
+                          getAbraDfpVariants: function (t = {}) {
+                              this.isValidDfpVariant;
+                              let e = "";
+                              if (t.config) {
+                                  e = this.getDFPTestNames(t.config).reduce(
+                                    this.reduceAbraConfigKeysToDfpVariants,
+                                    []
+                                  );
+                              }
+                              return { abra_dfp: e };
+                          },
+                          isMobile: function (t) {
+                              const e = t.matchMedia("(max-width: 739px)");
+                              return e && e.matches;
+                          },
+                          isManualRefresh: function (t = {}) {
+                              return !(!t.navigation || 1 !== t.navigation.type);
+                          },
+                          getAltLangFromPathname: function (t = "") {
+                              return 0 === t.indexOf("/es/") ? "es" : "";
+                          },
+                          getAdTargetingProperty: function (t = !1, e = "") {
+                              let n = t ? "m" : "";
+                              return { prop: (n += e) + "nyt" };
+                          },
+                          getAdTargetingPlatform: function (t = !1) {
+                              return { plat: (t ? "m" : "") + "web" };
+                          },
+                          getAdTargetingEdition: function (t = "") {
+                              return t.length ? { edn: t } : {};
+                          },
+                          getAdTargetingVersion: function (t = !1) {
+                              return { ver: (t ? "m" : "") + "vi" };
+                          },
+                          getAdTargetingHome: function (t, e, n) {
+                              let i = {},
+                                o = {};
+                              return (
+                                "hp" === t &&
+                                ((i = e ? { topRef: e } : {}),
+                                  (o = n ? { refresh: "manual" } : {})),
+                                  this.mergeObjects(i, o)
+                              );
+                          },
+                          getAdTargeting: function (t = {}, e = {}) {
+                              const n = this.isMobile(window),
+                                i = this.getAltLangFromPathname(window.location.pathname),
+                                o = this.isManualRefresh(performance);
+                              return this.mergeObjects(
+                                t,
+                                this.getDemographics(e),
+                                this.getAdTargetingProperty(n, i),
+                                this.getAdTargetingPlatform(n),
+                                this.getAdTargetingEdition(i),
+                                this.getAdTargetingVersion(n),
+                                this.getAdTargetingHome(t.typ, document.referrer, o),
+                                this.getAbraDfpVariants(window.NYTD.Abra),
+                                this.getSov(window),
+                                this.getPageViewId(window.NYTD.PageViewId)
+                              );
+                          },
+                          init: function (t) {
+                              window.AdSlot4.init && this.isFunction(window.AdSlot4.init)
+                                ? window.AdSlot4.init && window.AdSlot4.init(t)
+                                : console.warn(
+                                  "AdSlot4.init does not exist or is not a function"
+                                );
+                          },
+                          reportExposure: function (t) {
+                              window.NYTD.Abra &&
+                              this.isFunction(window.NYTD.Abra.reportExposure)
+                                ? window.NYTD.Abra.reportExposure(t)
+                                : console.warn(
+                                  "Abra.reportExposure does not exist or is not a function"
+                                );
+                          },
+                          generateConfig: function (t = {}, e = {}, n = {}) {
+                              const i = n && n.userInfo && n.userInfo.demographics;
+                              return this.mergeObjects(t, e, {
+                                  adTargeting: this.getAdTargeting(e.adTargeting, i),
+                                  haltDFP: this.shouldHaltDFP(
+                                    e.dfpToggleName || t.dfpToggleName
+                                  ),
+                                  adsDisabled: this.isAdsDisabled(e.adTargeting),
+                              });
+                          },
+                      });
+                    for (let t in window.AdSlot4.clientRequirements)
+                        window.AdSlot4.clientRequirements[t] =
+                          window.AdSlot4.clientRequirements[t].bind(
+                            window.AdSlot4.clientRequirements
+                          );
+                    const e = {
+                        adUnitPath: "/29390238/nyt/homepage",
+                        offset: 400,
+                        hideTopAd: AdSlot4.clientRequirements.isMobile(window),
+                        lockdownAds: !1,
+                        sizeMapping: {
+                            top: [
+                                [
+                                    970,
+                                    ["fluid", [728, 90], [970, 90], [970, 250], [1605, 300]],
+                                ],
+                                [728, ["fluid", [728, 90], [1605, 300]]],
+                                [0, []],
+                            ],
+                            fp1: [
+                                [
+                                    0,
+                                    [
+                                        [195, 250],
+                                        [215, 270],
+                                    ],
+                                ],
+                            ],
+                            fp2: [
+                                [
+                                    0,
+                                    [
+                                        [195, 250],
+                                        [215, 270],
+                                    ],
+                                ],
+                            ],
+                            fp3: [
+                                [
+                                    0,
+                                    [
+                                        [195, 250],
+                                        [215, 270],
+                                    ],
+                                ],
+                            ],
+                            feat1: [[0, ["fluid"]]],
+                            feat2: [[0, ["fluid"]]],
+                            feat3: [[0, ["fluid"]]],
+                            feat4: [[0, ["fluid"]]],
+                            mktg: [
+                                [1020, [300, 250]],
+                                [0, []],
+                            ],
+                            pencil: [[728, [[336, 46]], [0, []]]],
+                            pp_edpick: [[0, ["fluid"]]],
+                            pp_morein: [[0, ["fluid"], [210, 218]]],
+                            ribbon: [[0, ["fluid"]]],
+                            sponsor: [
+                                [765, [150, 50]],
+                                [0, [320, 25]],
+                            ],
+                            supplemental: [
+                                [
+                                    1020,
+                                    [
+                                        [300, 250],
+                                        [300, 600],
+                                    ],
+                                ],
+                                [0, []],
+                            ],
+                            chat: [
+                                [
+                                    0,
+                                    [
+                                        [300, 250],
+                                        [300, 420],
+                                    ],
+                                ],
+                            ],
+                            column: [
+                                [
+                                    0,
+                                    [
+                                        [300, 250],
+                                        [300, 420],
+                                    ],
+                                ],
+                            ],
+                            default: [
+                                [
+                                    970,
+                                    ["fluid", [728, 90], [970, 90], [970, 250], [1605, 300]],
+                                ],
+                                [728, ["fluid", [728, 90], [300, 250], [1605, 300]]],
+                                [0, ["fluid", [300, 250], [300, 420]]],
+                            ],
+                        },
+                        adTargeting: {},
+                        haltDFP: !1,
+                        dfpToggleName: t.dfpToggleName || "dfp_home_toggle",
+                        lazyApi: t.lazyApi || {},
+                    };
+                    window.AdSlot4.cmd.push(function () {
+                        const n = window.AdSlot4.clientRequirements,
+                          i = n.getUserData(
+                            window &&
+                            window.userXhrObject &&
+                            window.userXhrObject.responseText
+                          ),
+                          o = n.generateConfig(e, t, i);
+                        n.init(o), n.reportExposure("dfp_adslot4v2");
+                    });
+                };
+                _f.apply(null, [
+                    {
+                        adTargeting: {
+                            edn: "us",
+                            test: "projectvi",
+                            ver: "vi",
+                            template: "article",
+                            hasVideo: "false",
+                            vp: "small",
+                            als_test: "1669715959686",
+                            prop: "mnyt",
+                            plat: "mweb",
+                            brandsensitive: "false",
+                            per: "muskelon,agrawalparag",
+                            org: "twitter",
+                            des: "socialmedia,mergersacquisitionsanddivestit,stocksandbonds,computersandtheinternet,boardsofdirectors,appointmentsandexecutivechange,stockoptionsandpurchaseplans",
+                            auth: "kateconger",
+                            coll: "technology,media,business,dealbook",
+                            artlen: "medium",
+                            ledemedsz: "none",
+                            typ: "art",
+                            section: "technology",
+                            si_section: "technology",
+                            id: "100000008591603",
+                            pt: "nt10,nt14,nt16,nt17,nt18,nt2,nt3,nt4,nt5,nt6,nt7,pt11,pt13,pt21",
+                            gscat:
+                              "neg_citi_aa,neg_ibmtest,neg_mastercard,cc_business_lead_boards,neg_capitalone,neg_google,neg_ibm,neg_chan2,neg_chanel,neg_hms,gs_business,gs_economy,gs_economy_markets,gb_safe,ggl_wrk_collab,neg_racism,neg_samsung,neg_bofa,neg_aramco,neg_gg1,gs_tech_social,gs_tech,gs_finance_loans,gs_business_management,gs_business_careers,gv_safe,gs_t",
+                            tt: "7",
+                            mt: "MT10,MT3,MT7",
+                        },
+                        adUnitPath: "/29390238/nyt/technology",
+                        dfpToggleName: "dfp_story_toggle",
+                    },
+                ]);
+            })();
+        })();
+    </script>
+</head>
+<body>
+<div id="app">
+    <div>
+        <div class="">
+            <div>
+                <div class="NYTAppHideMasthead css-1q2w90k e1m0pzr40">
+                    <header class="css-1bymuyk e1m0pzr41">
+                        <section class="css-ui9rw0 e1m0pzr42">
+                            <div class="css-1f7ibof ea180rp0">
+                                <div class="css-6n7j50">
+                                    <button
+                                      aria-haspopup="true"
+                                      aria-expanded="false"
+                                      aria-label="Sections Navigation &amp; Search"
+                                      class="ea180rp1 css-fzvsed"
+                                      data-testid="nav-button"
+                                      type="button"
+                                    >
+                                        <svg class="css-1fe7a5q" viewBox="0 0 16 16">
+                                            <rect
+                                              x="1"
+                                              y="3"
+                                              fill="#333"
+                                              width="14"
+                                              height="2"
+                                            ></rect>
+                                            <rect
+                                              x="1"
+                                              y="7"
+                                              fill="#333"
+                                              width="14"
+                                              height="2"
+                                            ></rect>
+                                            <rect
+                                              x="1"
+                                              y="11"
+                                              fill="#333"
+                                              width="14"
+                                              height="2"
+                                            ></rect>
+                                        </svg>
+                                    </button>
+                                </div>
+                                <button
+                                  id="desktop-sections-button"
+                                  data-testid="desktop-section-button"
+                                  aria-label="Sections Navigation"
+                                  class="css-123u7tk ea180rp2"
+                                >
+                      <span class="css-1dv1kvn">Sections</span
+                      ><svg class="css-1fe7a5q" viewBox="0 0 16 16">
+                                    <rect
+                                      x="1"
+                                      y="3"
+                                      fill="#333"
+                                      width="14"
+                                      height="2"
+                                    ></rect>
+                                    <rect
+                                      x="1"
+                                      y="7"
+                                      fill="#333"
+                                      width="14"
+                                      height="2"
+                                    ></rect>
+                                    <rect
+                                      x="1"
+                                      y="11"
+                                      fill="#333"
+                                      width="14"
+                                      height="2"
+                                    ></rect>
+                                </svg>
+                                </button>
+                                <div class="css-10488qs">
+                                    <button
+                                      class="css-tkwi90 e1iflr850"
+                                      data-test-id="search-button"
+                                    >
+                        <span class="css-1dv1kvn">SEARCH</span
+                        ><svg class="css-1fe7a5q" viewBox="0 0 16 16">
+                                        <path
+                                          fill="#333"
+                                          d="M11.3,9.2C11.7,8.4,12,7.5,12,6.5C12,3.5,9.5,1,6.5,1S1,3.5,1,6.5S3.5,12,6.5,12c1,0,1.9-0.3,2.7-0.7l3.3,3.3c0.3,0.3,0.7,0.4,1.1,0.4s0.8-0.1,1.1-0.4c0.6-0.6,0.6-1.5,0-2.1L11.3,9.2zM6.5,10.3c-2.1,0-3.8-1.7-3.8-3.8c0-2.1,1.7-3.8,3.8-3.8c2.1,0,3.8,1.7,3.8,3.8C10.3,8.6,8.6,10.3,6.5,10.3z"
+                                        ></path>
+                                    </svg>
+                                    </button>
+                                </div>
+                                <a class="css-1f8er69" href="#site-content"
+                                >Skip to content</a
+                                ><a class="css-1f8er69" href="#site-index"
+                            >Skip to site index</a
+                            >
+                            </div>
+                            <div id="masthead-section-label" class="css-1wr3we4 ek6sfxi0">
+                                <a
+                                  href="https://www.nytimes.com/section/technology"
+                                  class="css-nuvmzp"
+                                >Technology</a
+                                >
+                            </div>
+                            <div class="css-10698na ell52qj0">
+                                <a
+                                  data-testid="masthead-mobile-logo"
+                                  aria-label="New York Times Logo. Click to visit the homepage"
+                                  class="css-nhjhh0 ell52qj1"
+                                  href="/"
+                                ><svg viewBox="0 0 184 25" fill="#000">
+                                    <path
+                                      d="M13.8 2.9c0-2-1.9-2.5-3.4-2.5v.3c.9 0 1.6.3 1.6 1 0 .4-.3 1-1.2 1-.7 0-2.2-.4-3.3-.8C6.2 1.4 5 1 4 1 2 1 .6 2.5.6 4.2c0 1.5 1.1 2 1.5 2.2l.1-.2c-.2-.2-.5-.4-.5-1 0-.4.4-1.1 1.4-1.1.9 0 2.1.4 3.7.9 1.4.4 2.9.7 3.7.8v3.1L9 10.2v.1l1.5 1.3v4.3c-.8.5-1.7.6-2.5.6-1.5 0-2.8-.4-3.9-1.6l4.1-2V6l-5 2.2C3.6 6.9 4.7 6 5.8 5.4l-.1-.3c-3 .8-5.7 3.6-5.7 7 0 4 3.3 7 7 7 4 0 6.6-3.2 6.6-6.5h-.2c-.6 1.3-1.5 2.5-2.6 3.1v-4.1l1.6-1.3v-.1l-1.6-1.3V5.8c1.5 0 3-1 3-2.9zm-8.7 11l-1.2.6c-.7-.9-1.1-2.1-1.1-3.8 0-.7 0-1.5.2-2.1l2.1-.9v6.2zm10.6 2.3l-1.3 1 .2.2.6-.5 2.2 2 3-2-.1-.2-.8.5-1-1V9.4l.8-.6 1.7 1.4v6.1c0 3.8-.8 4.4-2.5 5v.3c2.8.1 5.4-.8 5.4-5.7V9.3l.9-.7-.2-.2-.8.6-2.5-2.1L18.5 9V.8h-.2l-3.5 2.4v.2c.4.2 1 .4 1 1.5l-.1 11.3zM34 15.1L31.5 17 29 15v-1.2l4.7-3.2v-.1l-2.4-3.6-5.2 2.8v6.6l-1 .8.2.2.9-.7 3.4 2.5 4.5-3.6-.1-.4zm-5-1.7V8.5l.2-.1 2.2 3.5-2.4 1.5zM53.1 2c0-.3-.1-.6-.2-.9h-.2c-.3.8-.7 1.2-1.7 1.2-.9 0-1.5-.5-1.9-.9l-2.9 3.3.2.2 1-.9c.6.5 1.1.9 2.5 1v8.3L44 3.2c-.5-.8-1.2-1.9-2.6-1.9-1.6 0-3 1.4-2.8 3.6h.3c.1-.6.4-1.3 1.1-1.3.5 0 1 .5 1.3 1v3.3c-1.8 0-3 .8-3 2.3 0 .8.4 2 1.6 2.3v-.2c-.2-.2-.3-.4-.3-.7 0-.5.4-.9 1.1-.9h.5v4.2c-2.1 0-3.8 1.2-3.8 3.2 0 1.9 1.6 2.8 3.4 2.7v-.2c-1.1-.1-1.6-.6-1.6-1.3 0-.9.6-1.3 1.4-1.3.8 0 1.5.5 2 1.1l2.9-3.2-.2-.2-.7.8c-1.1-1-1.7-1.3-3-1.5V5l8 14h.6V5c1.5-.1 2.9-1.3 2.9-3zm7.3 13.1L57.9 17l-2.5-2v-1.2l4.7-3.2v-.1l-2.4-3.6-5.2 2.8v6.6l-1 .8.2.2.9-.7 3.4 2.5 4.5-3.6-.1-.4zm-5-1.7V8.5l.2-.1 2.2 3.5-2.4 1.5zM76.7 8l-.7.5-1.9-1.6-2.2 2 .9.9v7.5l-2.4-1.5V9.6l.8-.5-2.3-2.2-2.2 2 .9.9V17l-.3.2-2.1-1.5v-6c0-1.4-.7-1.8-1.5-2.3-.7-.5-1.1-.8-1.1-1.5 0-.6.6-.9.9-1.1v-.2c-.8 0-2.9.8-2.9 2.7 0 1 .5 1.4 1 1.9s1 .9 1 1.8v5.8l-1.1.8.2.2 1-.8 2.3 2 2.5-1.7 2.8 1.7 5.3-3.1V9.2l1.3-1-.2-.2zm18.6-5.5l-1 .9-2.2-2-3.3 2.4V1.6h-.3l.1 16.2c-.3 0-1.2-.2-1.9-.4l-.2-13.5c0-1-.7-2.4-2.5-2.4s-3 1.4-3 2.8h.3c.1-.6.4-1.1 1-1.1s1.1.4 1.1 1.7v3.9c-1.8.1-2.9 1.1-2.9 2.4 0 .8.4 2 1.6 2V13c-.4-.2-.5-.5-.5-.7 0-.6.5-.8 1.3-.8h.4v6.2c-1.5.5-2.1 1.6-2.1 2.8 0 1.7 1.3 2.9 3.3 2.9 1.4 0 2.6-.2 3.8-.5 1-.2 2.3-.5 2.9-.5.8 0 1.1.4 1.1.9 0 .7-.3 1-.7 1.1v.2c1.6-.3 2.6-1.3 2.6-2.8s-1.5-2.4-3.1-2.4c-.8 0-2.5.3-3.7.5-1.4.3-2.8.5-3.2.5-.7 0-1.5-.3-1.5-1.3 0-.8.7-1.5 2.4-1.5.9 0 2 .1 3.1.4 1.2.3 2.3.6 3.3.6 1.5 0 2.8-.5 2.8-2.6V3.7l1.2-1-.2-.2zm-4.1 6.1c-.3.3-.7.6-1.2.6s-1-.3-1.2-.6V4.2l1-.7 1.4 1.3v3.8zm0 3c-.2-.2-.7-.5-1.2-.5s-1 .3-1.2.5V9c.2.2.7.5 1.2.5s1-.3 1.2-.5v2.6zm0 4.7c0 .8-.5 1.6-1.6 1.6h-.8V12c.2-.2.7-.5 1.2-.5s.9.3 1.2.5v4.3zm13.7-7.1l-3.2-2.3-4.9 2.8v6.5l-1 .8.1.2.8-.6 3.2 2.4 5-3V9.2zm-5.4 6.3V8.3l2.5 1.8v7.1l-2.5-1.7zm14.9-8.4h-.2c-.3.2-.6.4-.9.4-.4 0-.9-.2-1.1-.5h-.2l-1.7 1.9-1.7-1.9-3 2 .1.2.8-.5 1 1.1v6.3l-1.3 1 .2.2.6-.5 2.4 2 3.1-2.1-.1-.2-.9.5-1.2-1V9c.5.5 1.1 1 1.8 1 1.4.1 2.2-1.3 2.3-2.9zm12 9.6L123 19l-4.6-7 3.3-5.1h.2c.4.4 1 .8 1.7.8s1.2-.4 1.5-.8h.2c-.1 2-1.5 3.2-2.5 3.2s-1.5-.5-2.1-.8l-.3.5 5 7.4 1-.6v.1zm-11-.5l-1.3 1 .2.2.6-.5 2.2 2 3-2-.2-.2-.8.5-1-1V.8h-.1l-3.6 2.4v.2c.4.2 1 .3 1 1.5v11.3zM143 2.9c0-2-1.9-2.5-3.4-2.5v.3c.9 0 1.6.3 1.6 1 0 .4-.3 1-1.2 1-.7 0-2.2-.4-3.3-.8-1.3-.4-2.5-.8-3.5-.8-2 0-3.4 1.5-3.4 3.2 0 1.5 1.1 2 1.5 2.2l.1-.2c-.3-.2-.6-.4-.6-1 0-.4.4-1.1 1.4-1.1.9 0 2.1.4 3.7.9 1.4.4 2.9.7 3.7.8V9l-1.5 1.3v.1l1.5 1.3V16c-.8.5-1.7.6-2.5.6-1.5 0-2.8-.4-3.9-1.6l4.1-2V6l-5 2.2c.5-1.3 1.6-2.2 2.6-2.9l-.1-.2c-3 .8-5.7 3.5-5.7 6.9 0 4 3.3 7 7 7 4 0 6.6-3.2 6.6-6.5h-.2c-.6 1.3-1.5 2.5-2.6 3.1v-4.1l1.6-1.3v-.1L140 8.8v-3c1.5 0 3-1 3-2.9zm-8.7 11l-1.2.6c-.7-.9-1.1-2.1-1.1-3.8 0-.7.1-1.5.3-2.1l2.1-.9-.1 6.2zm12.2-12h-.1l-2 1.7v.1l1.7 1.9h.2l2-1.7v-.1l-1.8-1.9zm3 14.8l-.8.5-1-1V9.3l1-.7-.2-.2-.7.6-1.8-2.1-2.9 2 .2.3.7-.5.9 1.1v6.5l-1.3 1 .1.2.7-.5 2.2 2 3-2-.1-.3zm16.7-.1l-.7.5-1.1-1V9.3l1-.8-.2-.2-.8.7-2.3-2.1-3 2.1-2.3-2.1L154 9l-1.8-2.1-2.9 2 .1.3.7-.5 1 1.1v6.5l-.8.8 2.3 1.9 2.2-2-.9-.9V9.3l.9-.6 1.5 1.4v6l-.8.8 2.3 1.9 2.2-2-.9-.9V9.3l.8-.5 1.6 1.4v6l-.7.7 2.3 2.1 3.1-2.1v-.3zm8.7-1.5l-2.5 1.9-2.5-2v-1.2l4.7-3.2v-.1l-2.4-3.6-5.2 2.8v6.8l3.5 2.5 4.5-3.6-.1-.3zm-5-1.7V8.5l.2-.1 2.2 3.5-2.4 1.5zm14.1-.9l-1.9-1.5c1.3-1.1 1.8-2.6 1.8-3.6v-.6h-.2c-.2.5-.6 1-1.4 1-.8 0-1.3-.4-1.8-1L176 9.3v3.6l1.7 1.3c-1.7 1.5-2 2.5-2 3.3 0 1 .5 1.7 1.3 2l.1-.2c-.2-.2-.4-.3-.4-.8 0-.3.4-.8 1.2-.8 1 0 1.6.7 1.9 1l4.3-2.6v-3.6h-.1zm-1.1-3c-.7 1.2-2.2 2.4-3.1 3l-1.1-.9V8.1c.4 1 1.5 1.8 2.6 1.8.7 0 1.1-.1 1.6-.4zm-1.7 8c-.5-1.1-1.7-1.9-2.9-1.9-.3 0-1.1 0-1.9.5.5-.8 1.8-2.2 3.5-3.2l1.2 1 .1 3.6z"
+                                    ></path></svg
+                                ></a>
+                            </div>
+                            <div class="css-y3sf94 e1j3jvdr1"></div>
+                        </section>
+                        <section
+                          id="masthead-bar-one"
+                          class="hasLinks css-1r0gz1j e1pjtsj63"
+                        >
+                            <div>
+                                <div class="css-1o0kkht e1pjtsj60"></div>
+                                <div class="css-1bvtpon e1pjtsj62">
+                                    <a
+                                      href="https://www.nytimes.com/section/todayspaper"
+                                      class="css-hnzl8o"
+                                    >Today’s Paper</a
+                                    >
+                                </div>
+                            </div>
+                            <div class="css-9e9ivx"></div>
+                        </section>
+                    </header>
+                </div>
+            </div>
+            <div aria-hidden="false">
+                <main id="site-content">
+                    <div>
+                        <div
+                          class="css-1aor85t"
+                          style="opacity: 0.000000001; z-index: -1; visibility: hidden"
+                          id="in-story-masthead"
+                        >
+                            <div class="css-1hqnpie">
+                                <div class="css-epjblv">
+                      <span class="css-1u4hfeb"
+                      ><a href="/section/technology">Technology</a></span
+                      ><span class="css-x15j1o">|</span
+                                ><span class="css-fwqvlz"
+                                >How Twitter Will Change as a Private Company</span
+                                >
+                                </div>
+                                <div class="css-k008qs">
+                                    <div class="css-1iwv8en">
+                                        <a href="/"
+                                        ><svg class="css-1tel06d" viewBox="0 0 16 22">
+                                            <path
+                                              d="M15.863 13.08c-.687 1.818-1.923 3.147-3.64 3.916v-3.917l2.129-1.958-2.129-1.889V6.505c1.923-.14 3.228-1.609 3.228-3.358C15.45.84 13.32 0 12.086 0c-.275 0-.55 0-.962.14v.14h.481c.824 0 1.51.42 1.51 1.189 0 .63-.48 1.189-1.304 1.189-2.129 0-4.6-1.749-7.279-1.749C2.13.91.481 2.728.481 4.546c0 1.819 1.03 2.448 2.128 2.798v-.14c-.343-.21-.618-.63-.618-1.189 0-.84.756-1.469 1.648-1.469 2.267 0 5.906 1.959 8.172 1.959h.206v2.727l-2.129 1.889 2.13 1.958v3.987c-.894.35-1.786.49-2.748.49-3.502 0-5.768-2.169-5.768-5.806 0-.839.137-1.678.344-2.518l1.785-.769v7.973l3.57-1.608V6.575L3.984 8.953c.55-1.61 1.648-2.728 2.953-3.358v-.07C3.433 6.295 0 9.023 0 13.08c0 4.686 3.914 7.974 8.446 7.974 4.807 0 7.485-3.288 7.554-7.974h-.137z"
+                                              fill="#000"
+                                            ></path></svg></a
+                                        ><span class="css-18z7m18"
+                                    ><a
+                                      href="/"
+                                      data-testid="masthead-logo"
+                                      aria-label="New York Times Logo. Click to visit the homepage"
+                                    ><svg
+                                      class="css-12fr9lp"
+                                      viewBox="0 0 184 25"
+                                      fill="#000"
+                                    >
+                              <path
+                                d="M13.8 2.9c0-2-1.9-2.5-3.4-2.5v.3c.9 0 1.6.3 1.6 1 0 .4-.3 1-1.2 1-.7 0-2.2-.4-3.3-.8C6.2 1.4 5 1 4 1 2 1 .6 2.5.6 4.2c0 1.5 1.1 2 1.5 2.2l.1-.2c-.2-.2-.5-.4-.5-1 0-.4.4-1.1 1.4-1.1.9 0 2.1.4 3.7.9 1.4.4 2.9.7 3.7.8v3.1L9 10.2v.1l1.5 1.3v4.3c-.8.5-1.7.6-2.5.6-1.5 0-2.8-.4-3.9-1.6l4.1-2V6l-5 2.2C3.6 6.9 4.7 6 5.8 5.4l-.1-.3c-3 .8-5.7 3.6-5.7 7 0 4 3.3 7 7 7 4 0 6.6-3.2 6.6-6.5h-.2c-.6 1.3-1.5 2.5-2.6 3.1v-4.1l1.6-1.3v-.1l-1.6-1.3V5.8c1.5 0 3-1 3-2.9zm-8.7 11l-1.2.6c-.7-.9-1.1-2.1-1.1-3.8 0-.7 0-1.5.2-2.1l2.1-.9v6.2zm10.6 2.3l-1.3 1 .2.2.6-.5 2.2 2 3-2-.1-.2-.8.5-1-1V9.4l.8-.6 1.7 1.4v6.1c0 3.8-.8 4.4-2.5 5v.3c2.8.1 5.4-.8 5.4-5.7V9.3l.9-.7-.2-.2-.8.6-2.5-2.1L18.5 9V.8h-.2l-3.5 2.4v.2c.4.2 1 .4 1 1.5l-.1 11.3zM34 15.1L31.5 17 29 15v-1.2l4.7-3.2v-.1l-2.4-3.6-5.2 2.8v6.6l-1 .8.2.2.9-.7 3.4 2.5 4.5-3.6-.1-.4zm-5-1.7V8.5l.2-.1 2.2 3.5-2.4 1.5zM53.1 2c0-.3-.1-.6-.2-.9h-.2c-.3.8-.7 1.2-1.7 1.2-.9 0-1.5-.5-1.9-.9l-2.9 3.3.2.2 1-.9c.6.5 1.1.9 2.5 1v8.3L44 3.2c-.5-.8-1.2-1.9-2.6-1.9-1.6 0-3 1.4-2.8 3.6h.3c.1-.6.4-1.3 1.1-1.3.5 0 1 .5 1.3 1v3.3c-1.8 0-3 .8-3 2.3 0 .8.4 2 1.6 2.3v-.2c-.2-.2-.3-.4-.3-.7 0-.5.4-.9 1.1-.9h.5v4.2c-2.1 0-3.8 1.2-3.8 3.2 0 1.9 1.6 2.8 3.4 2.7v-.2c-1.1-.1-1.6-.6-1.6-1.3 0-.9.6-1.3 1.4-1.3.8 0 1.5.5 2 1.1l2.9-3.2-.2-.2-.7.8c-1.1-1-1.7-1.3-3-1.5V5l8 14h.6V5c1.5-.1 2.9-1.3 2.9-3zm7.3 13.1L57.9 17l-2.5-2v-1.2l4.7-3.2v-.1l-2.4-3.6-5.2 2.8v6.6l-1 .8.2.2.9-.7 3.4 2.5 4.5-3.6-.1-.4zm-5-1.7V8.5l.2-.1 2.2 3.5-2.4 1.5zM76.7 8l-.7.5-1.9-1.6-2.2 2 .9.9v7.5l-2.4-1.5V9.6l.8-.5-2.3-2.2-2.2 2 .9.9V17l-.3.2-2.1-1.5v-6c0-1.4-.7-1.8-1.5-2.3-.7-.5-1.1-.8-1.1-1.5 0-.6.6-.9.9-1.1v-.2c-.8 0-2.9.8-2.9 2.7 0 1 .5 1.4 1 1.9s1 .9 1 1.8v5.8l-1.1.8.2.2 1-.8 2.3 2 2.5-1.7 2.8 1.7 5.3-3.1V9.2l1.3-1-.2-.2zm18.6-5.5l-1 .9-2.2-2-3.3 2.4V1.6h-.3l.1 16.2c-.3 0-1.2-.2-1.9-.4l-.2-13.5c0-1-.7-2.4-2.5-2.4s-3 1.4-3 2.8h.3c.1-.6.4-1.1 1-1.1s1.1.4 1.1 1.7v3.9c-1.8.1-2.9 1.1-2.9 2.4 0 .8.4 2 1.6 2V13c-.4-.2-.5-.5-.5-.7 0-.6.5-.8 1.3-.8h.4v6.2c-1.5.5-2.1 1.6-2.1 2.8 0 1.7 1.3 2.9 3.3 2.9 1.4 0 2.6-.2 3.8-.5 1-.2 2.3-.5 2.9-.5.8 0 1.1.4 1.1.9 0 .7-.3 1-.7 1.1v.2c1.6-.3 2.6-1.3 2.6-2.8s-1.5-2.4-3.1-2.4c-.8 0-2.5.3-3.7.5-1.4.3-2.8.5-3.2.5-.7 0-1.5-.3-1.5-1.3 0-.8.7-1.5 2.4-1.5.9 0 2 .1 3.1.4 1.2.3 2.3.6 3.3.6 1.5 0 2.8-.5 2.8-2.6V3.7l1.2-1-.2-.2zm-4.1 6.1c-.3.3-.7.6-1.2.6s-1-.3-1.2-.6V4.2l1-.7 1.4 1.3v3.8zm0 3c-.2-.2-.7-.5-1.2-.5s-1 .3-1.2.5V9c.2.2.7.5 1.2.5s1-.3 1.2-.5v2.6zm0 4.7c0 .8-.5 1.6-1.6 1.6h-.8V12c.2-.2.7-.5 1.2-.5s.9.3 1.2.5v4.3zm13.7-7.1l-3.2-2.3-4.9 2.8v6.5l-1 .8.1.2.8-.6 3.2 2.4 5-3V9.2zm-5.4 6.3V8.3l2.5 1.8v7.1l-2.5-1.7zm14.9-8.4h-.2c-.3.2-.6.4-.9.4-.4 0-.9-.2-1.1-.5h-.2l-1.7 1.9-1.7-1.9-3 2 .1.2.8-.5 1 1.1v6.3l-1.3 1 .2.2.6-.5 2.4 2 3.1-2.1-.1-.2-.9.5-1.2-1V9c.5.5 1.1 1 1.8 1 1.4.1 2.2-1.3 2.3-2.9zm12 9.6L123 19l-4.6-7 3.3-5.1h.2c.4.4 1 .8 1.7.8s1.2-.4 1.5-.8h.2c-.1 2-1.5 3.2-2.5 3.2s-1.5-.5-2.1-.8l-.3.5 5 7.4 1-.6v.1zm-11-.5l-1.3 1 .2.2.6-.5 2.2 2 3-2-.2-.2-.8.5-1-1V.8h-.1l-3.6 2.4v.2c.4.2 1 .3 1 1.5v11.3zM143 2.9c0-2-1.9-2.5-3.4-2.5v.3c.9 0 1.6.3 1.6 1 0 .4-.3 1-1.2 1-.7 0-2.2-.4-3.3-.8-1.3-.4-2.5-.8-3.5-.8-2 0-3.4 1.5-3.4 3.2 0 1.5 1.1 2 1.5 2.2l.1-.2c-.3-.2-.6-.4-.6-1 0-.4.4-1.1 1.4-1.1.9 0 2.1.4 3.7.9 1.4.4 2.9.7 3.7.8V9l-1.5 1.3v.1l1.5 1.3V16c-.8.5-1.7.6-2.5.6-1.5 0-2.8-.4-3.9-1.6l4.1-2V6l-5 2.2c.5-1.3 1.6-2.2 2.6-2.9l-.1-.2c-3 .8-5.7 3.5-5.7 6.9 0 4 3.3 7 7 7 4 0 6.6-3.2 6.6-6.5h-.2c-.6 1.3-1.5 2.5-2.6 3.1v-4.1l1.6-1.3v-.1L140 8.8v-3c1.5 0 3-1 3-2.9zm-8.7 11l-1.2.6c-.7-.9-1.1-2.1-1.1-3.8 0-.7.1-1.5.3-2.1l2.1-.9-.1 6.2zm12.2-12h-.1l-2 1.7v.1l1.7 1.9h.2l2-1.7v-.1l-1.8-1.9zm3 14.8l-.8.5-1-1V9.3l1-.7-.2-.2-.7.6-1.8-2.1-2.9 2 .2.3.7-.5.9 1.1v6.5l-1.3 1 .1.2.7-.5 2.2 2 3-2-.1-.3zm16.7-.1l-.7.5-1.1-1V9.3l1-.8-.2-.2-.8.7-2.3-2.1-3 2.1-2.3-2.1L154 9l-1.8-2.1-2.9 2 .1.3.7-.5 1 1.1v6.5l-.8.8 2.3 1.9 2.2-2-.9-.9V9.3l.9-.6 1.5 1.4v6l-.8.8 2.3 1.9 2.2-2-.9-.9V9.3l.8-.5 1.6 1.4v6l-.7.7 2.3 2.1 3.1-2.1v-.3zm8.7-1.5l-2.5 1.9-2.5-2v-1.2l4.7-3.2v-.1l-2.4-3.6-5.2 2.8v6.8l3.5 2.5 4.5-3.6-.1-.3zm-5-1.7V8.5l.2-.1 2.2 3.5-2.4 1.5zm14.1-.9l-1.9-1.5c1.3-1.1 1.8-2.6 1.8-3.6v-.6h-.2c-.2.5-.6 1-1.4 1-.8 0-1.3-.4-1.8-1L176 9.3v3.6l1.7 1.3c-1.7 1.5-2 2.5-2 3.3 0 1 .5 1.7 1.3 2l.1-.2c-.2-.2-.4-.3-.4-.8 0-.3.4-.8 1.2-.8 1 0 1.6.7 1.9 1l4.3-2.6v-3.6h-.1zm-1.1-3c-.7 1.2-2.2 2.4-3.1 3l-1.1-.9V8.1c.4 1 1.5 1.8 2.6 1.8.7 0 1.1-.1 1.6-.4zm-1.7 8c-.5-1.1-1.7-1.9-2.9-1.9-.3 0-1.1 0-1.9.5.5-.8 1.8-2.2 3.5-3.2l1.2 1 .1 3.6z"
+                              ></path></svg></a
+                                    ></span>
+                                    </div>
+                                    <span class="css-1n6z4y"
+                                    >https://www.nytimes.com/2022/10/28/technology/twitter-changes.html</span
+                                    >
+                                    <div class="css-tvohiw">
+                                        <div
+                                          role="toolbar"
+                                          data-testid="share-tools"
+                                          aria-label="Social Media Share buttons, Save button, and Comments Panel with current comment count"
+                                        >
+                                            <div class="css-4skfbu">
+                                                <ul class="css-1sirvy4">
+                                                    <li class="css-9eyi4s">
+                                                        <div class="css-vxcmzt">
+                                                            <div class="css-113xjf1">
+                                                                <button
+                                                                  type="button"
+                                                                  aria-haspopup="true"
+                                                                  aria-label=""
+                                                                  aria-describedby="ap-gift-article-tooltip"
+                                                                  aria-expanded="false"
+                                                                  class="css-q1aqo6"
+                                                                >
+                                      <span
+                                        class="gift-article-button css-aulw98"
+                                      ><svg
+                                        width="19"
+                                        height="19"
+                                        viewBox="0 0 19 19"
+                                      >
+                                          <path
+                                            d="M18.04 5.293h-2.725c.286-.34.493-.74.606-1.17a2.875 2.875 0 0 0-.333-2.322A2.906 2.906 0 0 0 13.64.48a3.31 3.31 0 0 0-2.372.464 3.775 3.775 0 0 0-1.534 2.483l-.141.797-.142-.847A3.745 3.745 0 0 0 7.927.923 3.31 3.31 0 0 0 5.555.459 2.907 2.907 0 0 0 3.607 1.78a2.877 2.877 0 0 0-.333 2.321c.117.429.324.828.606 1.171H1.155a.767.767 0 0 0-.757.757v3.674a.767.767 0 0 0 .757.757h.424v7.53A1.01 1.01 0 0 0 2.588 19h14.13a1.01 1.01 0 0 0 1.01-.959v-7.56h.424a.758.758 0 0 0 .757-.757V6.05a.759.759 0 0 0-.868-.757Zm-7.196-1.625a2.665 2.665 0 0 1 1.01-1.736 2.24 2.24 0 0 1 1.574-.313 1.817 1.817 0 0 1 1.211.818 1.857 1.857 0 0 1 .202 1.453 2.2 2.2 0 0 1-.838 1.191h-3.431l.272-1.413ZM4.576 2.386a1.837 1.837 0 0 1 1.221-.817 2.23 2.23 0 0 1 1.565.313 2.624 2.624 0 0 1 1.01 1.736l.242 1.453H5.182a2.2 2.2 0 0 1-.838-1.19 1.857 1.857 0 0 1 .202-1.495h.03ZM1.548 6.424h7.54V9.39h-7.58l.04-2.967Zm1.181 4.128h6.359v7.287H2.729v-7.287Zm13.777 7.287h-6.348v-7.307h6.348v7.307Zm1.181-8.468h-7.53V6.404h7.53V9.37Z"
+                                            fill="#121212"
+                                            fill-rule="nonzero"
+                                          ></path></svg
+                                      ><span class="css-1egxmzr"
+                                      >Give this article</span
+                                      ><span class="css-11s78ai"
+                                      >Give this article</span
+                                      ><span class="css-1u3tlb2"
+                                      >Give this article</span
+                                      ></span
+                                      >
+                                                                </button>
+                                                            </div>
+                                                        </div>
+                                                    </li>
+                                                    <li class="css-1xlo06v">
+                                                        <div class="css-vxcmzt">
+                                                            <div class="css-113xjf1">
+                                                                <button
+                                                                  type="button"
+                                                                  aria-haspopup="true"
+                                                                  aria-label="More sharing options ..."
+                                                                  aria-describedby=""
+                                                                  aria-expanded="false"
+                                                                  class="css-1uhsiac"
+                                                                >
+                                                                    <svg
+                                                                      width="23"
+                                                                      height="18"
+                                                                      viewBox="0 0 23 18"
+                                                                      class="css-1wb2lb"
+                                                                    >
+                                                                        <path
+                                                                          d="M1.357 17.192a.663.663 0 0 1-.642-.81c1.82-7.955 6.197-12.068 12.331-11.68V1.127a.779.779 0 0 1 .42-.653.726.726 0 0 1 .78.106l8.195 6.986a.81.81 0 0 1 .253.557.82.82 0 0 1-.263.547l-8.196 6.955a.83.83 0 0 1-.779.105.747.747 0 0 1-.42-.663V11.29c-8.418-.905-10.974 5.177-11.08 5.45a.662.662 0 0 1-.6.453Zm10.048-7.26a16.37 16.37 0 0 1 2.314.158.81.81 0 0 1 .642.726v3.02l6.702-5.682-6.702-5.692v2.883a.767.767 0 0 1-.242.536.747.747 0 0 1-.547.18c-4.808-.537-8.364 1.85-10.448 6.922a11.679 11.679 0 0 1 8.28-3.093v.042Z"
+                                                                          fill="#000"
+                                                                          fill-rule="nonzero"
+                                                                        ></path>
+                                                                    </svg>
+                                                                </button>
+                                                            </div>
+                                                        </div>
+                                                    </li>
+                                                    <li class="css-1xlo06v save-button">
+                                                        <button
+                                                          type="button"
+                                                          role="switch"
+                                                          class="css-1yccqtv"
+                                                          aria-label="Save article for reading later..."
+                                                          aria-checked="false"
+                                                          disabled=""
+                                                        >
+                                                            <svg
+                                                              width="12"
+                                                              height="18"
+                                                              viewBox="0 0 12 18"
+                                                              class="css-swbuts"
+                                                            >
+                                                                <g
+                                                                  fill-rule="nonzero"
+                                                                  stroke="#666"
+                                                                  fill="none"
+                                                                >
+                                                                    <path
+                                                                      fill="none"
+                                                                      d="M1.157 1.268v14.288l4.96-3.813 4.753 3.843V1.268z"
+                                                                    ></path>
+                                                                    <path
+                                                                      d="m12 18-5.9-4.756L0 17.98V1.014C0 .745.095.487.265.297.435.107.664 0 .904 0h10.192c.24 0 .47.107.64.297.169.19.264.448.264.717V18ZM1.157 1.268v14.288l4.96-3.813 4.753 3.843V1.268H1.158Z"
+                                                                      fill="#121212"
+                                                                    ></path>
+                                                                </g>
+                                                            </svg>
+                                                        </button>
+                                                    </li>
+                                                </ul>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <article id="story" class="css-1vxca1d e1lmdhsb0">
+                            <div class="css-1r2mflq">
+                                <div>
+                                    <div class="css-rrnxp3">
+                                        <style>
+                                            #masthead-section-label,
+                                            #masthead-bar-one {
+                                                display: none;
+                                            }
+                                        </style>
+                                        <div class="css-7v35jk">
+                          <span class="css-136d4fr"
+                          ><a
+                            href="/?name=styln-elon-musk&amp;region=TOP_BANNER&amp;block=storyline_menu_home_logo&amp;action=click&amp;pgtype=Article"
+                            data-testid="tlogo-home-link"
+                            aria-label="The New York Times Home Page"
+                          ><svg viewBox="0 0 44 57" class="css-1nkuxcu">
+                                <defs></defs>
+                                <g
+                                  stroke="none"
+                                  stroke-width="1"
+                                  fill="none"
+                                  fill-rule="evenodd"
+                                >
+                                  <g fill="#000">
+                                    <path
+                                      d="M43.6284633,34.8996508 C41.83393,39.6379642 38.53153,43.2989842 33.7932167,45.2371375 L33.7932167,34.8996508 L39.46463,29.8027175 L33.7932167,24.7777375 L33.7932167,17.6709842 C38.9621033,17.3120775 42.5514567,13.5074375 42.5514567,8.84136417 C42.5514567,2.73966417 36.7369967,0.5859375 33.4345967,0.5859375 C32.71707,0.5859375 31.9270167,0.5859375 30.7789167,0.872890833 L30.7789167,1.16013083 C31.20949,1.16013083 31.8550633,1.08846417 32.0709233,1.08846417 C34.36827,1.08846417 36.0911367,2.16518417 36.0911367,4.2469575 C36.0911367,5.82620417 34.7988433,7.40545083 32.5017833,7.40545083 C26.83037,7.40545083 20.15419,2.81133083 12.9038167,2.81133083 C6.44292333,2.81133083 1.99242333,7.6207375 1.99242333,12.5023842 C1.99242333,17.3120775 4.79201,18.8913242 7.73521667,19.9680442 L7.80717,19.6808042 C6.87378333,19.1066108 6.22763667,18.1018442 6.22763667,16.5223108 C6.22763667,14.3688708 8.23774333,12.5743375 10.7503767,12.5743375 C16.8520767,12.5743375 26.68675,17.6709842 32.7887367,17.6709842 L33.36293,17.6709842 L33.36293,24.8496908 L27.6918033,29.8027175 L33.36293,34.8996508 L33.36293,45.3804708 C30.9942033,46.2416175 28.5532367,46.6010975 26.0406033,46.6010975 C16.5648367,46.6010975 10.53509,40.8577308 10.53509,31.3102975 C10.53509,29.0135242 10.8220433,26.7878442 11.46819,24.6341175 L16.20593,22.5526308 L16.20593,43.6576042 L25.8253167,39.4226775 L25.8253167,17.8146042 L11.6834767,24.1315908 C13.1191033,19.9680442 16.06231,16.9531708 19.5799967,15.2303042 L19.50833,15.0150175 C10.0322767,17.0967908 0.84375,24.2754975 0.84375,35.0432708 C0.84375,47.4622442 11.32457,56.0768642 23.5285433,56.0768642 C36.4497567,56.0768642 43.7720833,47.4622442 43.84375,34.8996508 L43.6284633,34.8996508 Z"
+                                    ></path>
+                                  </g>
+                                </g></svg></a
+                          ></span>
+                                            <nav
+                                              class="css-m3796d"
+                                              aria-labelledby="storyline-menu-title"
+                                              role="navigation"
+                                            >
+                                                <h3 id="storyline-menu-title" class="">
+                              <span class="css-11rqvxt"
+                              ><span
+                              ><span
+                                class="css-1rxm0ex"
+                                data-testid="text-balancer"
+                              >Elon Musk’s</span
+                              ><span
+                                class="css-1rxm0ex"
+                                data-testid="text-balancer"
+                              >
+                                    Twitter Takeover</span
+                              ></span
+                              ></span
+                              >
+                                                </h3>
+                                                <ul class="css-go3nob" role="menu">
+                                                    <li class="css-1qej4jr">
+                                <span class="css-fi5tub" data-testid="menu-link"
+                                ><a
+                                  class="css-etxl5s"
+                                  role="menuitem"
+                                  href="https://www.nytimes.com/interactive/2022/11/23/technology/twitter-elon-musk-twitter-blue-check-verification.html"
+                                ><span class="css-knunh2"
+                                >Who Is Paying for Twitter?</span
+                                ></a
+                                ></span
+                                >
+                                                    </li>
+                                                    <li class="css-1qej4jr">
+                                <span class="css-fi5tub" data-testid="menu-link"
+                                ><a
+                                  class="css-etxl5s"
+                                  role="menuitem"
+                                  href="https://www.nytimes.com/2022/11/11/technology/elon-musk-twitter-takeover.html"
+                                ><span class="css-knunh2"
+                                >Inside the Takeover</span
+                                ></a
+                                ></span
+                                >
+                                                    </li>
+                                                    <li class="css-1qej4jr">
+                                <span class="css-fi5tub" data-testid="menu-link"
+                                ><a
+                                  class="css-etxl5s"
+                                  role="menuitem"
+                                  href="https://www.nytimes.com/2022/11/18/technology/twitter-employees-needed.html"
+                                ><span class="css-knunh2"
+                                >Twitter’s Essential Workers</span
+                                ></a
+                                ></span
+                                >
+                                                    </li>
+                                                    <li class="css-1qej4jr">
+                                <span class="css-fi5tub" data-testid="menu-link"
+                                ><a
+                                  class="css-etxl5s"
+                                  role="menuitem"
+                                  href="https://www.nytimes.com/2022/11/18/technology/how-to-download-your-twitter-archive.html"
+                                ><span class="css-knunh2"
+                                >Download Your Twitter Data</span
+                                ></a
+                                ></span
+                                >
+                                                    </li>
+                                                </ul>
+                                            </nav>
+                                        </div>
+                                        <span
+                                          style="position: relative"
+                                          class="styln-edit-storyline"
+                                          data-storyline-uri="nyt://storyline/1a6f39b1-d67c-47a1-a51a-db0640037643"
+                                          data-storyline-module-name="menu"
+                                        ></span>
+                                    </div>
+                                </div>
+                            </div>
+                            <div id="top-wrapper" class="css-z1t82k">
+                                <div id="top-slug" class="css-l9onyx">
+                                    <p>Advertisement</p>
+                                </div>
+                                <a href="#after-top" class="css-1ly73wi"
+                                >Continue reading the main story</a
+                                >
+                                <div
+                                  class="ad top-wrapper css-rfqw0c"
+                                  style="min-height: 90px"
+                                >
+                                    <div
+                                      id="top"
+                                      class="place-ad"
+                                      data-position="top"
+                                      data-size-key="top"
+                                    ></div>
+                                </div>
+                                <div id="after-top"></div>
+                            </div>
+                            <header class="css-8z235g euiyums1">
+                                <div id="sponsor-wrapper" class="css-1hyfx7x">
+                                    <div id="sponsor-slug" class="css-19vbshk">
+                                        <p>Supported by</p>
+                                    </div>
+                                    <a href="#after-sponsor" class="css-1ly73wi"
+                                    >Continue reading the main story</a
+                                    >
+                                    <div
+                                      class="ad sponsor-wrapper css-rfqw0c"
+                                      id="sponsor"
+                                    ></div>
+                                    <div id="after-sponsor"></div>
+                                </div>
+                                <div class="css-hme5ai euiyums0"></div>
+                                <div class="css-1vkm6nb ehdk2mb0">
+                                    <h1
+                                      id="link-48102664"
+                                      class="css-1l8buln e1h9rw200"
+                                      data-testid="headline"
+                                    >
+                                        How Twitter Will Change as a Private Company
+                                    </h1>
+                                </div>
+                                <p id="article-summary" class="css-1n0orw4 e1wiw3jv0">
+                                    The social media company went public in 2013. But Elon
+                                    Musk is taking it private as part of his acquisition of
+                                    the firm. Here’s what that means.
+                                </p>
+                                <div class="css-10cldcv">
+                                    <div
+                                      role="toolbar"
+                                      data-testid="share-tools"
+                                      aria-label="Social Media Share buttons, Save button, and Comments Panel with current comment count"
+                                    >
+                                        <div class="css-9hm018">
+                                            <ul class="css-1sirvy4">
+                                                <li class="css-9eyi4s">
+                                                    <div
+                                                      role="tooltip"
+                                                      class="css-1ch24e9"
+                                                      aria-hidden="true"
+                                                      aria-labelledby="dialogMessage"
+                                                      tabindex="0"
+                                                      id="ap-gift-article-tooltip"
+                                                    >
+                                                        <div class="css-pga13o">
+                                                            <p class="css-6yj280">
+                                                                <strong>Send any friend a story</strong>
+                                                            </p>
+                                                            <p class="css-4m7ryc" id="dialogMessage">
+                                                                As a subscriber, you have
+                                                                <strong class="css-8qgvsz ebyp5n10"
+                                                                >10 gift articles</strong
+                                                                >
+                                                                to give each month. Anyone can read what you
+                                                                share.
+                                                            </p>
+                                                        </div>
+                                                        <button
+                                                          type="button"
+                                                          aria-label="close sharing tooltip"
+                                                        >
+                                                            <svg
+                                                              class=""
+                                                              viewBox="0 0 12 12"
+                                                              stroke="#000"
+                                                              stroke-width="1.5"
+                                                              stroke-linecap="round"
+                                                              style="opacity: 0.95"
+                                                            >
+                                                                <line x1="11" y1="1" x2="1" y2="11"></line>
+                                                                <line x1="1" y1="1" x2="11" y2="11"></line>
+                                                            </svg>
+                                                        </button>
+                                                        <div class="css-1n1thlk">
+                                                            <div class="css-1w019mi"></div>
+                                                        </div>
+                                                    </div>
+                                                    <div class="css-vxcmzt">
+                                                        <div class="css-113xjf1">
+                                                            <button
+                                                              type="button"
+                                                              aria-haspopup="true"
+                                                              aria-label=""
+                                                              aria-describedby="ap-gift-article-tooltip"
+                                                              aria-expanded="false"
+                                                              class="css-q1aqo6"
+                                                            >
+                                    <span class="gift-article-button css-aulw98"
+                                    ><svg
+                                      width="19"
+                                      height="19"
+                                      viewBox="0 0 19 19"
+                                    >
+                                        <path
+                                          d="M18.04 5.293h-2.725c.286-.34.493-.74.606-1.17a2.875 2.875 0 0 0-.333-2.322A2.906 2.906 0 0 0 13.64.48a3.31 3.31 0 0 0-2.372.464 3.775 3.775 0 0 0-1.534 2.483l-.141.797-.142-.847A3.745 3.745 0 0 0 7.927.923 3.31 3.31 0 0 0 5.555.459 2.907 2.907 0 0 0 3.607 1.78a2.877 2.877 0 0 0-.333 2.321c.117.429.324.828.606 1.171H1.155a.767.767 0 0 0-.757.757v3.674a.767.767 0 0 0 .757.757h.424v7.53A1.01 1.01 0 0 0 2.588 19h14.13a1.01 1.01 0 0 0 1.01-.959v-7.56h.424a.758.758 0 0 0 .757-.757V6.05a.759.759 0 0 0-.868-.757Zm-7.196-1.625a2.665 2.665 0 0 1 1.01-1.736 2.24 2.24 0 0 1 1.574-.313 1.817 1.817 0 0 1 1.211.818 1.857 1.857 0 0 1 .202 1.453 2.2 2.2 0 0 1-.838 1.191h-3.431l.272-1.413ZM4.576 2.386a1.837 1.837 0 0 1 1.221-.817 2.23 2.23 0 0 1 1.565.313 2.624 2.624 0 0 1 1.01 1.736l.242 1.453H5.182a2.2 2.2 0 0 1-.838-1.19 1.857 1.857 0 0 1 .202-1.495h.03ZM1.548 6.424h7.54V9.39h-7.58l.04-2.967Zm1.181 4.128h6.359v7.287H2.729v-7.287Zm13.777 7.287h-6.348v-7.307h6.348v7.307Zm1.181-8.468h-7.53V6.404h7.53V9.37Z"
+                                          fill="#121212"
+                                          fill-rule="nonzero"
+                                        ></path></svg
+                                    ><span class="css-1egxmzr"
+                                    >Give this article</span
+                                    ><span class="css-11s78ai"
+                                    >Give this article</span
+                                    ><span class="css-1u3tlb2"
+                                    >Give this article</span
+                                    ></span
+                                    >
+                                                            </button>
+                                                        </div>
+                                                    </div>
+                                                </li>
+                                                <li class="css-1xlo06v">
+                                                    <div class="css-vxcmzt">
+                                                        <div class="css-113xjf1">
+                                                            <button
+                                                              type="button"
+                                                              aria-haspopup="true"
+                                                              aria-label="More sharing options ..."
+                                                              aria-describedby=""
+                                                              aria-expanded="false"
+                                                              class="css-1uhsiac"
+                                                            >
+                                                                <svg
+                                                                  width="23"
+                                                                  height="18"
+                                                                  viewBox="0 0 23 18"
+                                                                  class="css-1wb2lb"
+                                                                >
+                                                                    <path
+                                                                      d="M1.357 17.192a.663.663 0 0 1-.642-.81c1.82-7.955 6.197-12.068 12.331-11.68V1.127a.779.779 0 0 1 .42-.653.726.726 0 0 1 .78.106l8.195 6.986a.81.81 0 0 1 .253.557.82.82 0 0 1-.263.547l-8.196 6.955a.83.83 0 0 1-.779.105.747.747 0 0 1-.42-.663V11.29c-8.418-.905-10.974 5.177-11.08 5.45a.662.662 0 0 1-.6.453Zm10.048-7.26a16.37 16.37 0 0 1 2.314.158.81.81 0 0 1 .642.726v3.02l6.702-5.682-6.702-5.692v2.883a.767.767 0 0 1-.242.536.747.747 0 0 1-.547.18c-4.808-.537-8.364 1.85-10.448 6.922a11.679 11.679 0 0 1 8.28-3.093v.042Z"
+                                                                      fill="#000"
+                                                                      fill-rule="nonzero"
+                                                                    ></path>
+                                                                </svg>
+                                                            </button>
+                                                        </div>
+                                                    </div>
+                                                </li>
+                                                <li class="css-1xlo06v save-button">
+                                                    <button
+                                                      type="button"
+                                                      role="switch"
+                                                      class="css-1yccqtv"
+                                                      aria-label="Save article for reading later..."
+                                                      aria-checked="false"
+                                                      disabled=""
+                                                    >
+                                                        <svg
+                                                          width="12"
+                                                          height="18"
+                                                          viewBox="0 0 12 18"
+                                                          class="css-swbuts"
+                                                        >
+                                                            <g
+                                                              fill-rule="nonzero"
+                                                              stroke="#666"
+                                                              fill="none"
+                                                            >
+                                                                <path
+                                                                  fill="none"
+                                                                  d="M1.157 1.268v14.288l4.96-3.813 4.753 3.843V1.268z"
+                                                                ></path>
+                                                                <path
+                                                                  d="m12 18-5.9-4.756L0 17.98V1.014C0 .745.095.487.265.297.435.107.664 0 .904 0h10.192c.24 0 .47.107.64.297.169.19.264.448.264.717V18ZM1.157 1.268v14.288l4.96-3.813 4.753 3.843V1.268H1.158Z"
+                                                                  fill="#121212"
+                                                                ></path>
+                                                            </g>
+                                                        </svg>
+                                                    </button>
+                                                </li>
+                                            </ul>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="css-79elbk" data-testid="photoviewer-wrapper">
+                                    <div
+                                      class="css-z3e15g"
+                                      data-testid="photoviewer-wrapper-hidden"
+                                    ></div>
+                                    <div
+                                      data-testid="photoviewer-children"
+                                      class="css-1a48zt4 e11si9ry5"
+                                    >
+                                        <figure
+                                          class="sizeMedium layoutHorizontal css-1dyerrh"
+                                          aria-label="media"
+                                          role="group"
+                                        >
+                                            <div class="css-bsn42l">
+                                                <picture
+                                                ><source
+                                                  media="(max-width: 599px) and (min-device-pixel-ratio: 3),(max-width: 599px) and (-webkit-min-device-pixel-ratio: 3),(max-width: 599px) and (min-resolution: 3dppx),(max-width: 599px) and (min-resolution: 288dpi)"
+                                                  srcset="
+                                  https://static01.nyt.com/images/2022/10/29/business/00jpTWITTER-PRIVATE2-print/merlin_214496130_63f02e73-7e2f-47ef-9597-f0b9fc9d20c3-mobileMasterAt3x.jpg?quality=75&amp;auto=webp&amp;disable=upscale&amp;width=600
+                                " />
+                                                    <source
+                                                      media="(max-width: 599px) and (min-device-pixel-ratio: 2),(max-width: 599px) and (-webkit-min-device-pixel-ratio: 2),(max-width: 599px) and (min-resolution: 2dppx),(max-width: 599px) and (min-resolution: 192dpi)"
+                                                      srcset="
+                                  https://static01.nyt.com/images/2022/10/29/business/00jpTWITTER-PRIVATE2-print/merlin_214496130_63f02e73-7e2f-47ef-9597-f0b9fc9d20c3-mobileMasterAt3x.jpg?quality=75&amp;auto=webp&amp;disable=upscale&amp;width=1200
+                                " />
+                                                    <source
+                                                      media="(max-width: 599px) and (min-device-pixel-ratio: 1),(max-width: 599px) and (-webkit-min-device-pixel-ratio: 1),(max-width: 599px) and (min-resolution: 1dppx),(max-width: 599px) and (min-resolution: 96dpi)"
+                                                      srcset="
+                                  https://static01.nyt.com/images/2022/10/29/business/00jpTWITTER-PRIVATE2-print/merlin_214496130_63f02e73-7e2f-47ef-9597-f0b9fc9d20c3-mobileMasterAt3x.jpg?quality=75&amp;auto=webp&amp;disable=upscale&amp;width=1800
+                                " />
+                                                    <img
+                                                      alt="Elon Musk plans to change Twitter from a public to a privately held company."
+                                                      class="css-rq4mmj"
+                                                      src="https://static01.nyt.com/images/2022/10/29/business/00jpTWITTER-PRIVATE2-print/merlin_214496130_63f02e73-7e2f-47ef-9597-f0b9fc9d20c3-articleLarge.jpg?quality=75&amp;auto=webp&amp;disable=upscale"
+                                                      srcset="
+                                  https://static01.nyt.com/images/2022/10/29/business/00jpTWITTER-PRIVATE2-print/merlin_214496130_63f02e73-7e2f-47ef-9597-f0b9fc9d20c3-articleLarge.jpg?quality=75&amp;auto=webp  600w,
+                                  https://static01.nyt.com/images/2022/10/29/business/00jpTWITTER-PRIVATE2-print/merlin_214496130_63f02e73-7e2f-47ef-9597-f0b9fc9d20c3-jumbo.jpg?quality=75&amp;auto=webp        1024w,
+                                  https://static01.nyt.com/images/2022/10/29/business/00jpTWITTER-PRIVATE2-print/merlin_214496130_63f02e73-7e2f-47ef-9597-f0b9fc9d20c3-superJumbo.jpg?quality=75&amp;auto=webp   2048w
+                                "
+                                                      sizes="((min-width: 600px) and (max-width: 1004px)) 84vw, (min-width: 1005px) 60vw, 100vw"
+                                                      decoding="async"
+                                                      width="600"
+                                                      height="400"
+                                                    /></picture>
+                                            </div>
+                                            <figcaption class="css-y5g5d7 e1maroi60">
+                            <span
+                              aria-hidden="true"
+                              class="css-jevhma e13ogyst0"
+                            >Elon Musk plans to change Twitter from a public
+                              to a privately held company.</span
+                            ><span class="css-1u46b97 e1z0qqy90"
+                                            ><span class="css-1ly73wi e1tej78p0"
+                                            >Credit...</span
+                                            ><span
+                                            ><span aria-hidden="false"
+                                            >Jason Henry for The New York Times</span
+                                            ></span
+                                            ></span
+                                            >
+                                            </figcaption>
+                                        </figure>
+                                    </div>
+                                </div>
+                                <div class="css-sklrp3">
+                                    <div class="css-1e2jphy epjyd6m1">
+                                        <div class="css-233int epjyd6m0">
+                                            <p class="css-4anu6l e1jsehar1">
+                            <span class="byline-prefix">By </span
+                            ><span
+                                              class="css-1baulvz last-byline"
+                                              itemProp="name"
+                                            ><a
+                                              href="https://www.nytimes.com/by/kate-conger"
+                                              class="css-n8ff4n e1jsehar0"
+                                            >Kate Conger</a
+                                            ></span
+                                            >
+                                            </p>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="css-ejne5g">
+                                    <time
+                                      datetime="2022-10-28T05:00:25-04:00"
+                                      class="css-8blifj e16638kd2"
+                                    ><span class="css-1sbuyqj e16638kd3"
+                                    >Oct. 28, 2022</span
+                                    ></time
+                                    >
+                                </div>
+                            </header>
+                            <section
+                              name="articleBody"
+                              class="meteredContent css-1r7ky0e"
+                            >
+                                <div class="css-s99gbd StoryBodyCompanionColumn">
+                                    <div class="css-53u6y8">
+                                        <p class="css-at9mc1 evys1bk0">
+                                            <em class="css-2fg4z9 e1gzwzxm0"
+                                            >Elon Musk closes his purchase of Twitter and fires
+                                                several top executives. </em
+                                            ><a
+                                          class="css-yywogo"
+                                          href="https://www.nytimes.com/live/2022/10/28/business/elon-musk-twitter"
+                                          title=""
+                                        ><em class="css-2fg4z9 e1gzwzxm0"
+                                        >Follow for the latest news updates</em
+                                        ></a
+                                        ><em class="css-2fg4z9 e1gzwzxm0">.</em>
+                                        </p>
+                                        <p class="css-at9mc1 evys1bk0">
+                                            SAN FRANCISCO — In August 2018, Elon Musk called
+                                            <a
+                                              class="css-yywogo"
+                                              href="https://www.nytimes.com/topic/person/michael-s-dell"
+                                              title=""
+                                            >Michael Dell</a
+                                            >
+                                            for advice.
+                                        </p>
+                                        <p class="css-at9mc1 evys1bk0">
+                                            Mr. Musk, who was
+                                            <a
+                                              class="css-yywogo"
+                                              href="https://www.nytimes.com/2018/08/07/business/tesla-stock-elon-musk-private.html"
+                                              title=""
+                                            >trying to take Tesla, his electric car company,
+                                                private</a
+                                            >, quizzed Mr. Dell, who had done that very thing with
+                                            <a
+                                              class="css-yywogo"
+                                              href="https://archive.nytimes.com/dealbook.nytimes.com/2013/02/05/dell-sets-23-8-billion-deal-to-go-private/"
+                                              title=""
+                                            >his eponymous computer company in 2013</a
+                                            >, about the process and the best lawyers to use for
+                                            the complicated transaction.
+                                        </p>
+                                        <p class="css-at9mc1 evys1bk0">
+                                            “I was really asking him about — did he find being
+                                            private was good?” Mr. Musk recalled in a
+                                            <a
+                                              class="css-yywogo"
+                                              href="https://storage.courtlistener.com/recap/gov.uscourts.cand.330489/gov.uscourts.cand.330489.403.0.pdf"
+                                              title=""
+                                              rel="noopener noreferrer"
+                                              target="_blank"
+                                            >deposition</a
+                                            >
+                                            about the Tesla effort. “Did he regret going private?”
+                                        </p>
+                                        <p class="css-at9mc1 evys1bk0">
+                                            Mr. Dell warned Mr. Musk that it was “a very difficult
+                                            process” but that he was glad to have done it,
+                                            according to court filings.
+                                        </p>
+                                    </div>
+                                    <aside
+                                      class="css-ew4tgv"
+                                      aria-label="companion column"
+                                    ></aside>
+                                </div>
+                                <div></div>
+                                <div class="css-s99gbd StoryBodyCompanionColumn">
+                                    <div class="css-53u6y8">
+                                        <p class="css-at9mc1 evys1bk0">
+                                            Now, Mr. Musk, who did not end up taking Tesla
+                                            private, is doing so with Twitter. As part of his $44
+                                            billion acquisition of the social media service, which
+                                            closed on Thursday, he is delisting the company’s
+                                            stock and taking it out of the hands of public
+                                            shareholders.
+                                        </p>
+                                        <p class="css-at9mc1 evys1bk0">
+                                            Making Twitter a private company gives Mr. Musk some
+                                            advantages. Unlike publicly traded companies,
+                                            privately held firms do not have to make quarterly
+                                            public disclosures about their performance. They are
+                                            also subject to less regulatory scrutiny and can be
+                                            more tightly controlled by an owner. That means Mr.
+                                            Musk can make over Twitter — including tweaking the
+                                            platform’s content rules, its finances and its
+                                            priorities — without having to consider the worries of
+                                            the investing public.
+                                        </p>
+                                        <p class="css-at9mc1 evys1bk0">
+                                            “It’s hard to run a public company if you think you
+                                            should be the one running it and you’re not open to
+                                            other views from people, like stockholders,” said
+                                            Brian J.M. Quinn, a professor at Boston College Law
+                                            School. “By taking it private, you feel like you have
+                                            a lot more flexibility.”
+                                        </p>
+                                        <p class="css-at9mc1 evys1bk0">
+                                            Here’s how Twitter is set to change as a private
+                                            company under Mr. Musk.
+                                        </p>
+                                        <h2 class="css-xactqe eoo0vm40" id="link-1449895">
+                                            How is Mr. Musk taking Twitter private?
+                                        </h2>
+                                        <p class="css-at9mc1 evys1bk0">
+                                            As part of buying Twitter, Mr. Musk is merging the
+                                            social media company with
+                                            <a
+                                              class="css-yywogo"
+                                              href="https://www.nytimes.com/2022/10/06/technology/elon-musk-x.html"
+                                              title=""
+                                            >X Holdings</a
+                                            >, a corporate entity that he established in Delaware
+                                            to handle the deal. X is buying out all of Twitter’s
+                                            stock and will control the service, and Mr. Musk will
+                                            control the holding company.
+                                        </p>
+                                    </div>
+                                    <aside
+                                      class="css-ew4tgv"
+                                      aria-label="companion column"
+                                    ></aside>
+                                </div>
+                                <div>
+                                    <div class="css-79elbk" data-testid="photoviewer-wrapper">
+                                        <div
+                                          class="css-z3e15g"
+                                          data-testid="photoviewer-wrapper-hidden"
+                                        ></div>
+                                        <div
+                                          data-testid="photoviewer-children"
+                                          class="css-1a48zt4 e11si9ry5"
+                                        >
+                                            <figure
+                                              class="img-sz-medium css-d754w4 e1g7ppur0"
+                                              aria-label="media"
+                                              role="group"
+                                            >
+                                                <div class="css-1xdhyk6 erfvjey0">
+                                                    <span class="css-1ly73wi e1tej78p0">Image</span>
+                                                    <div class="css-nwd8t8" data-testid="lazy-image">
+                                                        <div
+                                                          data-testid="lazyimage-container"
+                                                          style="height: 257.77777777777777px"
+                                                        ></div>
+                                                    </div>
+                                                </div>
+                                                <figcaption class="css-xaa95i ewdxa0s0">
+                              <span
+                                aria-hidden="true"
+                                class="css-jevhma e13ogyst0"
+                              >Twitter&rsquo;s logo on the screens of the New
+                                York Stock Exchange during the company&rsquo;s
+                                initial public offering in 2013.</span
+                              ><span class="css-1u46b97 e1z0qqy90"
+                                                ><span class="css-1ly73wi e1tej78p0"
+                                                >Credit...</span
+                                                ><span
+                                                ><span aria-hidden="false"
+                                                >Lucas Jackson/Reuters</span
+                                                ></span
+                                                ></span
+                                                >
+                                                </figcaption>
+                                            </figure>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="css-s99gbd StoryBodyCompanionColumn">
+                                    <div class="css-53u6y8">
+                                        <h2 class="css-xactqe eoo0vm40" id="link-53d6d93b">
+                                            What happens to Twitter’s stock?
+                                        </h2>
+                                        <p class="css-at9mc1 evys1bk0">
+                                            Twitter will be delisted from the New York Stock
+                                            Exchange and its shares will no longer trade on public
+                                            markets as of Nov. 8, according to
+                                            <a
+                                              class="css-yywogo"
+                                              href="https://www.sec.gov/Archives/edgar/data/876661/000087666122000890/xslF25X02/primary_doc.xml"
+                                              title=""
+                                              rel="noopener noreferrer"
+                                              target="_blank"
+                                            >a securities filing</a
+                                            >. In September, Twitter’s shareholders approved the
+                                            company’s sale to Mr. Musk and agreed to sell their
+                                            stock to him for $54.20 a share. Investors will be
+                                            able to claim the cash value of their shares.
+                                        </p>
+                                    </div>
+                                    <aside
+                                      class="css-ew4tgv"
+                                      aria-label="companion column"
+                                    ></aside>
+                                </div>
+                                <div></div>
+                                <div class="css-s99gbd StoryBodyCompanionColumn">
+                                    <div class="css-53u6y8">
+                                        <h2 class="css-xactqe eoo0vm40" id="link-cc3eb45">
+                                            What happens to Twitter’s board of directors?
+                                        </h2>
+                                        <p class="css-at9mc1 evys1bk0">
+                                            With the deal’s completion,
+                                            <a
+                                              class="css-yywogo"
+                                              href="https://www.nytimes.com/2022/10/04/technology/twitter-board-elon-musk.html"
+                                              title=""
+                                            >Twitter’s board of directors</a
+                                            >
+                                            will dissolve and its nine members will no longer
+                                            preside over the company’s operations. Mr. Musk will
+                                            most likely appoint a new board made up of friends and
+                                            investors who helped fund the acquisition. The new
+                                            board will be responsible for plotting Twitter’s
+                                            trajectory as a private company.
+                                        </p>
+                                        <div>
+                                            <section
+                                              role="complementary"
+                                              class="css-1px5j0"
+                                              aria-label="Changes at Elon Musk’s Twitter"
+                                            >
+                                                <div class="css-76fnlk">
+                                                    <h2 class="css-1gcsvhw">
+                                                        Changes at Elon Musk’s Twitter
+                                                    </h2>
+                                                </div>
+                                                <div
+                                                  id="storyline-context-container"
+                                                  aria-live="polite"
+                                                  aria-atomic="true"
+                                                >
+                              <span class="css-1ly73wi e1tej78p0"
+                              >Card 1 of 6</span
+                              >
+                                                    <div
+                                                      data-scrolled-index="0"
+                                                      class="swiper css-o7i5g3"
+                                                    >
+                                                        <div class="css-m541wo">
+                                                            <div class="css-1w3yqu0" aria-hidden="false">
+                                                                <div>
+                                                                    <div
+                                                                      class="css-1pcai02"
+                                                                      data-testid="context-card"
+                                                                    >
+                                                                        <p class="css-1t83a55">
+                                                                            <strong
+                                                                            >A swift overhaul.<!-- --> </strong
+                                                                            ><span
+                                                                        >Elon Musk has moved quickly to
+                                            revamp Twitter since he completed
+                                            his
+                                            <a
+                                              href="https://www.nytimes.com/2022/11/11/technology/elon-musk-twitter-takeover.html?action=click&pgtype=Article&state=default&module=styln-elon-musk&region=MAIN_CONTENT_1&block=storyline_levelup_swipe_recirc"
+                                            >$44 billion buyout</a
+                                            > of the social media company in
+                                            October, warning of a bleak
+                                            financial picture and a need for new
+                                            products. Here’s a look at some of
+                                            the changes so far:</span
+                                                                        >
+                                                                        </p>
+                                                                    </div>
+                                                                </div>
+                                                            </div>
+                                                        </div>
+                                                        <div class="css-m541wo">
+                                                            <div class="css-1w3yqu0" aria-hidden="true">
+                                                                <div>
+                                                                    <div
+                                                                      class="css-1pcai02"
+                                                                      data-testid="context-card"
+                                                                    >
+                                                                        <p class="css-1t83a55">
+                                                                            <strong
+                                                                            >Going private.<!-- --> </strong
+                                                                            ><span
+                                                                        >As part of Mr. Musk’s acquisition
+                                            of Twitter, he is delisting the
+                                            company’s stock and taking it out of
+                                            the hands of public shareholders.
+                                            Making Twitter a private company
+                                            <a
+                                              href="https://www.nytimes.com/2022/10/28/technology/twitter-changes.html?action=click&pgtype=Article&state=default&module=styln-elon-musk&region=MAIN_CONTENT_1&block=storyline_levelup_swipe_recirc"
+                                            >gives Mr. </a
+                                            ><a
+                                                                              href="https://www.nytimes.com/2022/10/28/technology/twitter-changes.html?action=click&pgtype=Article&state=default&module=styln-elon-musk&region=MAIN_CONTENT_1&block=storyline_levelup_swipe_recirc"
+                                                                            >Musk some</a
+                                                                            ><a
+                                                                              href="https://www.nytimes.com/2022/10/28/technology/twitter-changes.html?action=click&pgtype=Article&state=default&module=styln-elon-musk&region=MAIN_CONTENT_1&block=storyline_levelup_swipe_recirc"
+                                                                            > advantages</a
+                                                                            >, including not having to make
+                                            quarterly financial disclosures.
+                                            Private companies are also subject
+                                            to less regulatory scrutiny.</span
+                                                                        >
+                                                                        </p>
+                                                                    </div>
+                                                                </div>
+                                                            </div>
+                                                        </div>
+                                                        <div class="css-m541wo">
+                                                            <div class="css-1w3yqu0" aria-hidden="true">
+                                                                <div>
+                                                                    <div
+                                                                      class="css-1pcai02"
+                                                                      data-testid="context-card"
+                                                                    >
+                                                                        <p class="css-1t83a55">
+                                                                            <strong>Layoffs.<!-- --> </strong
+                                                                            ><span
+                                                                        >Just over a week after closing the
+                                            deal, Mr. Musk
+                                            <a
+                                              href="https://www.nytimes.com/2022/11/04/technology/elon-musk-twitter-layoffs.html?action=click&pgtype=Article&state=default&module=styln-elon-musk&region=MAIN_CONTENT_1&block=storyline_levelup_swipe_recirc"
+                                            >eliminated nearly half of
+                                              Twitter’s </a
+                                            ><a
+                                                                              href="https://www.nytimes.com/2022/11/04/technology/elon-musk-twitter-layoffs.html?action=click&pgtype=Article&state=default&module=styln-elon-musk&region=MAIN_CONTENT_1&block=storyline_levelup_swipe_recirc"
+                                                                            >work force</a
+                                                                            >, or about 3,700 jobs. The layoffs
+                                            hit many divisions across the
+                                            company, including the engineering
+                                            and machine learning units, the
+                                            teams that manage content
+                                            moderation, and the sales and
+                                            advertising departments.</span
+                                                                        >
+                                                                        </p>
+                                                                    </div>
+                                                                </div>
+                                                            </div>
+                                                        </div>
+                                                        <div class="css-m541wo">
+                                                            <div class="css-1w3yqu0" aria-hidden="true">
+                                                                <div>
+                                                                    <div
+                                                                      class="css-1pcai02"
+                                                                      data-testid="context-card"
+                                                                    >
+                                                                        <p class="css-1t83a55">
+                                                                            <strong
+                                                                            >Verification subscriptions.<!-- --> </strong
+                                                                            ><span
+                                                                        >Twitter began charging customers
+                                            <a
+                                              href="https://www.nytimes.com/2022/11/05/business/twitter-verification-check-marks.html?action=click&pgtype=Article&state=default&module=styln-elon-musk&region=MAIN_CONTENT_1&block=storyline_levelup_swipe_recirc"
+                                            >$7.99 a month to receive a
+                                              coveted verification check mark</a
+                                            > on their profiles. But the
+                                            subscription service was paused
+                                            after some users exploited it to
+                                            <a
+                                              href="https://www.nytimes.com/2022/11/11/technology/twitter-blue-fake-accounts.html?action=click&pgtype=Article&state=default&module=styln-elon-musk&region=MAIN_CONTENT_1&block=storyline_levelup_swipe_recirc"
+                                            >create havoc on the platform</a
+                                            > by pretending to be high-profile
+                                            brands and sending disruptive
+                                            tweets.</span
+                                                                        >
+                                                                        </p>
+                                                                    </div>
+                                                                </div>
+                                                            </div>
+                                                        </div>
+                                                        <div class="css-m541wo">
+                                                            <div class="css-1w3yqu0" aria-hidden="true">
+                                                                <div>
+                                                                    <div
+                                                                      class="css-1pcai02"
+                                                                      data-testid="context-card"
+                                                                    >
+                                                                        <p class="css-1t83a55">
+                                                                            <strong
+                                                                            >Content moderation.<!-- --> </strong
+                                                                            ><span
+                                                                        >Shortly after closing the deal to
+                                            buy Twitter, Mr. Musk said that the
+                                            company would form a
+                                            <a
+                                              href="https://www.nytimes.com/2022/10/28/technology/twitter-elon-musk-content-moderation.html?action=click&pgtype=Article&state=default&module=styln-elon-musk&region=MAIN_CONTENT_1&block=storyline_levelup_swipe_recirc"
+                                            >content moderation council</a
+                                            > to decide what kinds of posts to
+                                            keep up and what to take down. But
+                                            advertisers have
+                                            <a
+                                              href="https://www.nytimes.com/2022/11/04/technology/twitter-advertisers.html?action=click&pgtype=Article&state=default&module=styln-elon-musk&region=MAIN_CONTENT_1&block=storyline_levelup_swipe_recirc"
+                                            >paused their spending on
+                                              Twitter</a
+                                            > over fears that Mr. Musk will
+                                            loosen content rules on the
+                                            platform.</span
+                                                                        >
+                                                                        </p>
+                                                                    </div>
+                                                                </div>
+                                                            </div>
+                                                        </div>
+                                                        <div class="css-m541wo">
+                                                            <div class="css-1w3yqu0" aria-hidden="true">
+                                                                <div>
+                                                                    <div
+                                                                      class="css-1pcai02"
+                                                                      data-testid="context-card"
+                                                                    >
+                                                                        <p class="css-1t83a55">
+                                                                            <strong
+                                                                            >Other possible changes.<!-- --> </strong
+                                                                            ><span
+                                                                        >As Mr. Musk and his advisers look
+                                            for ways to generate more revenue at
+                                            the company, they are said to have
+                                            discussed
+                                            <a
+                                              href="https://www.nytimes.com/2022/11/03/technology/elon-musk-twitter-money-finances.html?action=click&pgtype=Article&state=default&module=styln-elon-musk&region=MAIN_CONTENT_1&block=storyline_levelup_swipe_recirc"
+                                            >adding paid direct messages</a
+                                            >, which would let users send
+                                            private messages to high-profile
+                                            users. The company has also filed
+                                            registration paperwork to pave the
+                                            way for it to
+                                            <a
+                                              href="https://www.nytimes.com/2022/11/09/technology/twitter-payments-business.html?action=click&pgtype=Article&state=default&module=styln-elon-musk&region=MAIN_CONTENT_1&block=storyline_levelup_swipe_recirc"
+                                            >process payments</a
+                                            >.</span
+                                                                        >
+                                                                        </p>
+                                                                    </div>
+                                                                </div>
+                                                            </div>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                                <div class="css-8r08w0">
+                                                    <ul class="css-1dxpste">
+                                                        <li class="css-fbykdt" data-active="true"></li>
+                                                        <li class="css-r4qme7" data-active="false"></li>
+                                                        <li class="css-r4qme7" data-active="false"></li>
+                                                        <li class="css-r4qme7" data-active="false"></li>
+                                                        <li class="css-r4qme7" data-active="false"></li>
+                                                        <li class="css-r4qme7" data-active="false"></li>
+                                                    </ul>
+                                                    <nav
+                                                      aria-controls="storyline-context-container"
+                                                      class="css-cm1d69"
+                                                    >
+                                <span
+                                  class="arrow-left css-1tnh8ll"
+                                  role="button"
+                                  aria-label="Previous card"
+                                  aria-disabled="true"
+                                  tabindex="-1"
+                                ></span
+                                ><span
+                                                      class="arrow-right css-95lxlj"
+                                                      role="button"
+                                                      aria-label="Next card"
+                                                      aria-disabled="false"
+                                                      tabindex="0"
+                                                    ></span>
+                                                    </nav>
+                                                </div>
+                                            </section>
+                                        </div>
+                                        <p class="css-at9mc1 evys1bk0">
+                                            “It will still be required by law to have a board of
+                                            directors, and that would probably include Elon Musk
+                                            and some of the other big equity investors in the
+                                            company,” said Eric Talley, a professor at Columbia
+                                            Law School. “I expect Mr. Musk will run it as a
+                                            somewhat friendly dictatorship.”
+                                        </p>
+                                        <h2 class="css-xactqe eoo0vm40" id="link-3f9ca2b1">
+                                            What happens to Twitter’s top executives?
+                                        </h2>
+                                        <p class="css-at9mc1 evys1bk0">
+                                            Mr. Musk has already started cleaning house, with
+                                            several of Twitter’s top executives
+                                            <a
+                                              class="css-yywogo"
+                                              href="https://www.nytimes.com/2022/10/27/technology/elon-musk-twitter-deal-complete.html"
+                                              title=""
+                                            >getting fired on Thursday</a
+                                            >.
+                                        </p>
+                                        <p class="css-at9mc1 evys1bk0">
+                                            The executives who were fired include
+                                            <a
+                                              class="css-yywogo"
+                                              href="https://www.nytimes.com/2021/11/29/technology/parag-agrawal-twitter.html"
+                                              title=""
+                                            >Parag Agrawal</a
+                                            >, Twitter’s chief executive, who has clashed publicly
+                                            and privately with Mr. Musk. When Mr. Musk complained
+                                            this year that Twitter had an unchecked spam problem,
+                                            Mr. Agrawal tweeted to rebut his claims. Mr. Musk
+                                            responded with a poop emoji.
+                                        </p>
+                                        <p class="css-at9mc1 evys1bk0">
+                                            At another point, Mr. Agrawal texted Mr. Musk, telling
+                                            the billionaire that his criticisms were harming
+                                            Twitter, according to a
+                                            <a
+                                              class="css-yywogo"
+                                              href="https://www.documentcloud.org/documents/23112929-elon-musk-text-exhibits-twitter-v-musk"
+                                              title=""
+                                              rel="noopener noreferrer"
+                                              target="_blank"
+                                            >court filing</a
+                                            >.
+                                        </p>
+                                        <p class="css-at9mc1 evys1bk0">
+                                            “This is a waste of time,” Mr. Musk retorted.
+                                        </p>
+                                        <p class="css-at9mc1 evys1bk0">
+                                            Other executives who were fired include Ned Segal,
+                                            Twitter’s chief financial officer; Vijaya Gadde, the
+                                            top legal and policy executive; and Sean Edgett, the
+                                            general counsel.
+                                        </p>
+                                    </div>
+                                    <aside
+                                      class="css-ew4tgv"
+                                      aria-label="companion column"
+                                    ></aside>
+                                </div>
+                                <div></div>
+                                <div class="css-s99gbd StoryBodyCompanionColumn">
+                                    <div class="css-53u6y8">
+                                        <p class="css-at9mc1 evys1bk0">
+                                            Under the merger agreement, Mr. Agrawal was
+                                            potentially set to receive a golden parachute worth
+                                            about $60 million, with Mr. Segal to receive $46
+                                            million, while Ms. Gadde would receive about $20
+                                            million. It was not immediately clear whether Mr. Musk
+                                            intended to make the payments.
+                                        </p>
+                                    </div>
+                                    <aside
+                                      class="css-ew4tgv"
+                                      aria-label="companion column"
+                                    ></aside>
+                                </div>
+                                <div>
+                                    <div class="css-79elbk" data-testid="photoviewer-wrapper">
+                                        <div
+                                          class="css-z3e15g"
+                                          data-testid="photoviewer-wrapper-hidden"
+                                        ></div>
+                                        <div
+                                          data-testid="photoviewer-children"
+                                          class="css-1a48zt4 e11si9ry5"
+                                        >
+                                            <figure
+                                              class="img-sz-medium css-1vxyf6h e1g7ppur0"
+                                              aria-label="media"
+                                              role="group"
+                                            >
+                                                <div class="css-1xdhyk6 erfvjey0">
+                                                    <span class="css-1ly73wi e1tej78p0">Image</span>
+                                                    <div class="css-nwd8t8" data-testid="lazy-image">
+                                                        <div
+                                                          data-testid="lazyimage-container"
+                                                          style="height: 386.6666666666667px"
+                                                        ></div>
+                                                    </div>
+                                                </div>
+                                                <figcaption class="css-xaa95i ewdxa0s0">
+                              <span
+                                aria-hidden="true"
+                                class="css-jevhma e13ogyst0"
+                              >Parag Agrawal was fired by Mr. Musk as
+                                Twitter’s chief executive on Thursday. </span
+                              ><span class="css-1u46b97 e1z0qqy90"
+                                                ><span class="css-1ly73wi e1tej78p0"
+                                                >Credit...</span
+                                                ><span
+                                                ><span aria-hidden="false"
+                                                >Kevin Dietsch/Getty Images</span
+                                                ></span
+                                                ></span
+                                                >
+                                                </figcaption>
+                                            </figure>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="css-s99gbd StoryBodyCompanionColumn">
+                                    <div class="css-53u6y8">
+                                        <h2 class="css-xactqe eoo0vm40" id="link-79d7db93">
+                                            What about Twitter’s employees?
+                                        </h2>
+                                        <p class="css-at9mc1 evys1bk0">
+                                            Twitter has about 7,500 employees. Some of them
+                                            <a
+                                              class="css-yywogo"
+                                              href="https://www.nytimes.com/2022/10/21/technology/twitter-employees-elon-musk.html"
+                                              title=""
+                                            >have been jittery</a
+                                            >
+                                            for months about the company’s sale to Mr. Musk. Many
+                                            could face layoffs or job changes as their new owner
+                                            takes over.
+                                        </p>
+                                        <div>
+                                            <section
+                                              role="complementary"
+                                              aria-labelledby="styln-toplinks-title"
+                                              class="css-1at4x3t"
+                                            >
+                                                <h2 id="styln-toplinks-title" class="css-4od1bx">
+                                                    More on Elon Musk’s Twitter Takeover
+                                                </h2>
+                                                <ul class="css-10ikpw">
+                                                    <li>
+                                <span
+                                ><strong>An Established Pattern:</strong
+                                > Firing people. Talking of bankruptcy.
+                                  Telling workers to be “hard core.” Twitter
+                                  isn’t the first company that witnessed Elon
+                                  Musk
+                                  <a
+                                    href="https://www.nytimes.com/2022/11/21/technology/elon-musk-twitter-management.html?action=click&pgtype=Article&state=default&module=styln-elon-musk&variant=show&region=MAIN_CONTENT_3&block=storyline_top_links_recirc"
+                                  >use those tactics</a
+                                  >.</span
+                                >
+                                                    </li>
+                                                    <li>
+                                <span
+                                ><strong>Targeting Critics: </strong>After
+                                  laying off
+                                  <a
+                                    href="https://www.nytimes.com/2022/11/04/technology/elon-musk-twitter-layoffs.html?action=click&pgtype=Article&state=default&module=styln-elon-musk&variant=show&region=MAIN_CONTENT_3&block=storyline_top_links_recirc"
+                                  >nearly half the company</a
+                                  >, Mr. Musk has continued cutting Twitter’s
+                                  work force by
+                                  <a
+                                    href="https://www.nytimes.com/2022/11/15/technology/elon-musk-twitter-fired-criticism.html?action=click&pgtype=Article&state=default&module=styln-elon-musk&variant=show&region=MAIN_CONTENT_3&block=storyline_top_links_recirc"
+                                  >firing employees who had criticized him</a
+                                  >.</span
+                                >
+                                                    </li>
+                                                    <li>
+                                <span
+                                ><strong>On the Edge: </strong>Mr. Musk gave
+                                  the employees still with the company
+                                  <a
+                                    href="https://www.nytimes.com/2022/11/18/business/dealbook/twitter-employees-quit-musk.html?action=click&pgtype=Article&state=default&module=styln-elon-musk&variant=show&region=MAIN_CONTENT_3&block=storyline_top_links_recirc"
+                                  >a deadline</a
+                                  > to decide whether to stay or leave.
+                                  <a
+                                    href="https://www.nytimes.com/2022/11/17/technology/twitter-elon-musk-ftc.html?action=click&pgtype=Article&state=default&module=styln-elon-musk&variant=show&region=MAIN_CONTENT_3&block=storyline_top_links_recirc"
+                                  >Hundreds resigned</a
+                                  >, leading users to question
+                                  <a
+                                    href="https://www.nytimes.com/2022/11/18/technology/elon-musk-twitter-workers-quit.html?action=click&pgtype=Article&state=default&module=styln-elon-musk&variant=show&region=MAIN_CONTENT_3&block=storyline_top_links_recirc"
+                                  >whether the site would survive</a
+                                  >.</span
+                                >
+                                                    </li>
+                                                    <li>
+                                <span
+                                ><strong>Unpaid Bills</strong
+                                ><strong>: </strong>Mr. Musk and his advisers
+                                  have scrutinized all types of costs at
+                                  Twitter, instructing staff to review,
+                                  renegotiate and in some cases
+                                  <a
+                                    href="https://www.nytimes.com/2022/11/22/technology/elon-musk-twitter-cost-cutting.html?action=click&pgtype=Article&state=default&module=styln-elon-musk&variant=show&region=MAIN_CONTENT_3&block=storyline_top_links_recirc"
+                                  >not pay outside vendors at all</a
+                                  >.</span
+                                >
+                                                    </li>
+                                                </ul>
+                                            </section>
+                                        </div>
+                                        <p class="css-at9mc1 evys1bk0">
+                                            Their compensation is also set to change. Employees
+                                            typically receive stock options in the company. But,
+                                            with the delisting of Twitter’s stock, employees are
+                                            set to be cashed out for shares they already have and
+                                            to be paid with cash bonuses going forward, instead of
+                                            the stock options they were scheduled to receive,
+                                            according to the merger agreement. Some
+                                            <a
+                                              class="css-yywogo"
+                                              href="https://www.nytimes.com/2022/10/21/technology/twitter-employees-elon-musk.html"
+                                              title=""
+                                            >employees have worried</a
+                                            >
+                                            that Mr. Musk may not honor the agreement.
+                                        </p>
+                                        <p class="css-at9mc1 evys1bk0">
+                                            “Most of these employees have been in a public company
+                                            and are used to public option grants, which are
+                                            liquid,” Mr. Quinn said. “They will have to come up
+                                            with some other Silicon Valley-friendly method of
+                                            keeping people around.”
+                                        </p>
+                                        <h2 class="css-xactqe eoo0vm40" id="link-13174875">
+                                            What financial pressures will Twitter face as a
+                                            private company?
+                                        </h2>
+                                        <p class="css-at9mc1 evys1bk0">
+                                            By going private, Twitter will avoid some public
+                                            scrutiny since it will no longer be required to make
+                                            quarterly disclosures about the health of its
+                                            business. This will give Mr. Musk some flexibility as
+                                            he changes Twitter.
+                                        </p>
+                                        <p class="css-at9mc1 evys1bk0">
+                                            But he will face pressure from the banks that lent him
+                                            $12.5 billion for the deal to begin repaying his debt.
+                                            The cost of repaying those loans could run as high as
+                                            $1 billion a year, financial analysts said.
+                                        </p>
+                                    </div>
+                                    <aside
+                                      class="css-ew4tgv"
+                                      aria-label="companion column"
+                                    ></aside>
+                                </div>
+                                <div></div>
+                                <div class="css-s99gbd StoryBodyCompanionColumn">
+                                    <div class="css-53u6y8">
+                                        <p class="css-at9mc1 evys1bk0">
+                                            “He has less public pressure, but he has a lot of
+                                            private pressure from the banks to make the payments,”
+                                            Mr. Quinn said of Mr. Musk. “Like almost every other
+                                            private-equity take-private, he’s going to need a
+                                            manager who is very focused on operations, being lean
+                                            and being able to pay the bills on a day-to-day
+                                            basis.”
+                                        </p>
+                                        <p class="css-at9mc1 evys1bk0">
+                                            Mr. Musk also took about $7.1 billion from equity
+                                            investors to push the deal through. He may also face
+                                            pressure from those investors, who might expect him to
+                                            take Twitter public again at some point so that they
+                                            can recoup their investment.
+                                        </p>
+                                        <p class="css-at9mc1 evys1bk0">
+                                            In some take-private deals, owners have opted to sell
+                                            branches of their companies to pay their debts. Mr.
+                                            Musk could choose to do the same at Twitter.
+                                        </p>
+                                        <p class="css-at9mc1 evys1bk0">
+                                            “It’s conceivable that some aspects of Twitter could
+                                            potentially be carved off, sold off or spun off to
+                                            raise money that could go toward paying the debt,” Mr.
+                                            Talley said. “Twitter kind of is pared down to its
+                                            core mission right now. They would have to get a
+                                            little creative.”
+                                        </p>
+                                    </div>
+                                    <aside
+                                      class="css-ew4tgv"
+                                      aria-label="companion column"
+                                    ></aside>
+                                </div>
+                                <div><div></div></div>
+                            </section>
+                            <div></div>
+                            <div></div>
+                            <div></div>
+                            <div></div>
+                            <div>
+                                <div id="bottom-wrapper" class="css-c4adj9">
+                                    <div id="bottom-slug" class="css-l9onyx">
+                                        <p>Advertisement</p>
+                                    </div>
+                                    <a href="#after-bottom" class="css-1ly73wi"
+                                    >Continue reading the main story</a
+                                    >
+                                    <div
+                                      class="ad bottom-wrapper css-rfqw0c"
+                                      id="bottom"
+                                      style="min-height: 90px"
+                                    ></div>
+                                    <div id="after-bottom"></div>
+                                </div>
+                            </div>
+                        </article>
+                    </div>
+                </main>
+                <div></div>
+                <footer class="css-1e1s8k7" role="contentinfo">
+                    <nav data-testid="footer" class="css-15uy5yv">
+                        <h2 class="css-1dv1kvn">Site Information Navigation</h2>
+                        <ul class="css-1ho5u4o edvi3so0">
+                            <li data-testid="copyright">
+                                <a
+                                  class="css-jq1cx6"
+                                  href="https://help.nytimes.com/hc/en-us/articles/115014792127-Copyright-notice"
+                                >© <span>2022</span> <span
+                                >The New York Times Company</span
+                                ></a
+                                >
+                            </li>
+                        </ul>
+                        <ul class="css-13o0c9t edvi3so1">
+                            <li class="css-a7htku edvi3so2">
+                                <a
+                                  data-testid="footer-link"
+                                  class="css-jq1cx6"
+                                  href="https://www.nytco.com/"
+                                >NYTCo</a
+                                >
+                            </li>
+                            <li class="css-a7htku edvi3so2">
+                                <a
+                                  data-testid="footer-link"
+                                  class="css-jq1cx6"
+                                  href="https://help.nytimes.com/hc/en-us/articles/115015385887-Contact-Us"
+                                >Contact Us</a
+                                >
+                            </li>
+                            <li class="css-a7htku edvi3so2">
+                                <a
+                                  data-testid="footer-link"
+                                  class="css-jq1cx6"
+                                  href="https://help.nytimes.com/hc/en-us/articles/115015727108-Accessibility"
+                                >Accessibility</a
+                                >
+                            </li>
+                            <li class="css-a7htku edvi3so2">
+                                <a
+                                  data-testid="footer-link"
+                                  class="css-jq1cx6"
+                                  href="https://www.nytco.com/careers/"
+                                >Work with us</a
+                                >
+                            </li>
+                            <li class="css-a7htku edvi3so2">
+                                <a
+                                  data-testid="footer-link"
+                                  class="css-jq1cx6"
+                                  href="https://nytmediakit.com/"
+                                >Advertise</a
+                                >
+                            </li>
+                            <li class="css-a7htku edvi3so2">
+                                <a
+                                  data-testid="footer-link"
+                                  class="css-jq1cx6"
+                                  href="https://www.tbrandstudio.com/"
+                                >T Brand Studio</a
+                                >
+                            </li>
+                            <li class="css-a7htku edvi3so2">
+                                <a
+                                  data-testid="footer-link"
+                                  class="css-jq1cx6"
+                                  href="https://www.nytimes.com/privacy/cookie-policy#how-do-i-manage-trackers"
+                                >Your Ad Choices</a
+                                >
+                            </li>
+                            <li class="css-a7htku edvi3so2">
+                                <a
+                                  data-testid="footer-link"
+                                  class="css-jq1cx6"
+                                  href="https://www.nytimes.com/privacy/privacy-policy"
+                                >Privacy Policy</a
+                                >
+                            </li>
+                            <li class="css-a7htku edvi3so2">
+                                <a
+                                  data-testid="footer-link"
+                                  class="css-jq1cx6"
+                                  href="https://help.nytimes.com/hc/en-us/articles/115014893428-Terms-of-service"
+                                >Terms of Service</a
+                                >
+                            </li>
+                            <li class="css-a7htku edvi3so2">
+                                <a
+                                  data-testid="footer-link"
+                                  class="css-jq1cx6"
+                                  href="https://help.nytimes.com/hc/en-us/articles/115014893968-Terms-of-sale"
+                                >Terms of Sale</a
+                                >
+                            </li>
+                            <li class="css-a7htku edvi3so2">
+                                <a
+                                  data-testid="footer-link"
+                                  class="css-jq1cx6"
+                                  href="/sitemap/"
+                                >Site Map</a
+                                >
+                            </li>
+                            <li class="mobileOnly css-a7htku edvi3so2">
+                                <a
+                                  data-testid="footer-link"
+                                  class="css-jq1cx6"
+                                  href="https://www.nytimes.com/ca/?action=click&amp;region=Footer&amp;pgtype=Homepage"
+                                >Canada</a
+                                >
+                            </li>
+                            <li class="mobileOnly css-a7htku edvi3so2">
+                                <a
+                                  data-testid="footer-link"
+                                  class="css-jq1cx6"
+                                  href="https://www.nytimes.com/international/?action=click&amp;region=Footer&amp;pgtype=Homepage"
+                                >International</a
+                                >
+                            </li>
+                            <li class="css-a7htku edvi3so2">
+                                <a
+                                  data-testid="footer-link"
+                                  class="css-jq1cx6"
+                                  href="https://help.nytimes.com/hc/en-us"
+                                >Help</a
+                                >
+                            </li>
+                            <li class="css-a7htku edvi3so2">
+                                <a
+                                  data-testid="footer-link"
+                                  class="css-jq1cx6"
+                                  href="https://www.nytimes.com/subscription?campaignId=37WXW"
+                                >Subscriptions</a
+                                >
+                            </li>
+                        </ul>
+                    </nav>
+                </footer>
+            </div>
+        </div>
+    </div>
+</div>
+<script>
+    window.__preloadedData = {
+        initialData: {
+            data: {
+                article: {
+                    __typename: "Article",
+                    id: "QXJ0aWNsZTpueXQ6Ly9hcnRpY2xlLzFkN2JmNDI4LWJlNzgtNTYyZi05Mjg3LWJkYmRmNDc1MDJhMA==",
+                    compatibility: {
+                        isOak: true,
+                        __typename: "CompatibilityFeatures",
+                        hasVideo: false,
+                        hasOakConversionError: false,
+                        isArtReview: false,
+                        isBookReview: false,
+                        isDiningReview: false,
+                        isMovieReview: false,
+                        isTheaterReview: false,
+                    },
+                    archiveProperties: {
+                        timesMachineUrl: "",
+                        lede: "",
+                        thumbnails: [],
+                        __typename: "ArticleArchiveProperties",
+                    },
+                    collections: [
+                        {
+                            id: "TGVnYWN5Q29sbGVjdGlvbjpueXQ6Ly9sZWdhY3ljb2xsZWN0aW9uLzU4ZWNlMGQwLTNjMzUtNWZhOS1iNTM1LTk0OTk3YTdjOGMwZg==",
+                            url: "https:\u002F\u002Fwww.nytimes.com\u002Fsection\u002Ftechnology",
+                            slug: "technology",
+                            __typename: "LegacyCollection",
+                            name: "Technology",
+                            collectionType: "SECTION",
+                            uri: "nyt:\u002F\u002Flegacycollection\u002F58ece0d0-3c35-5fa9-b535-94997a7c8c0f",
+                            active: true,
+                            header: "",
+                            tagline: "",
+                            mobileHeader: "",
+                            lastModified: "2022-11-28T20:15:56.066Z",
+                            type: "legacycollection",
+                        },
+                        {
+                            id: "TGVnYWN5Q29sbGVjdGlvbjpueXQ6Ly9sZWdhY3ljb2xsZWN0aW9uLzk4MGI2MzNkLThhMTItNTE0NC1iNGNkLTBhZjllNGQxZTM0Nw==",
+                            url: "https:\u002F\u002Fwww.nytimes.com\u002Fsection\u002Fbusiness\u002Fmedia",
+                            slug: "business-media",
+                            __typename: "LegacyCollection",
+                            name: "Media",
+                            collectionType: "SECTION",
+                            uri: "nyt:\u002F\u002Flegacycollection\u002F980b633d-8a12-5144-b4cd-0af9e4d1e347",
+                            active: true,
+                            header: "",
+                            tagline: "",
+                            mobileHeader: "",
+                            lastModified: "2021-12-06T17:34:12.262Z",
+                            type: "legacycollection",
+                        },
+                        {
+                            id: "TGVnYWN5Q29sbGVjdGlvbjpueXQ6Ly9sZWdhY3ljb2xsZWN0aW9uLzU0YzJkNTFjLTE0ZjYtNTgyMC04MzJkLTk2ODk0NmZiMzM4ZA==",
+                            url: "https:\u002F\u002Fwww.nytimes.com\u002Fsection\u002Fbusiness",
+                            slug: "business",
+                            __typename: "LegacyCollection",
+                            name: "Business",
+                            collectionType: "SECTION",
+                            uri: "nyt:\u002F\u002Flegacycollection\u002F54c2d51c-14f6-5820-832d-968946fb338d",
+                            active: true,
+                            header: "",
+                            tagline: "",
+                            mobileHeader: "",
+                            lastModified: "2022-11-28T22:44:11.973Z",
+                            type: "legacycollection",
+                        },
+                        {
+                            id: "TGVnYWN5Q29sbGVjdGlvbjpueXQ6Ly9sZWdhY3ljb2xsZWN0aW9uLzA4ZGEwNWU1LWU0YzctNWRkYS05NWIzLWRkMWQ5MmM3N2FkNA==",
+                            url: "https:\u002F\u002Fwww.nytimes.com\u002Fsection\u002Fbusiness\u002Fdealbook",
+                            slug: "business-dealbook",
+                            __typename: "LegacyCollection",
+                            name: "DealBook",
+                            collectionType: "SECTION",
+                            uri: "nyt:\u002F\u002Flegacycollection\u002F08da05e5-e4c7-5dda-95b3-dd1d92c77ad4",
+                            active: true,
+                            header: "",
+                            tagline: "",
+                            mobileHeader: "",
+                            lastModified: "2022-11-28T12:28:45.535Z",
+                            type: "legacycollection",
+                        },
+                    ],
+                    tone: "NEWS",
+                    section: {
+                        id: "U2VjdGlvbjpueXQ6Ly9zZWN0aW9uLzQyMjQyNDBmLWIxYWItNTBiZC04ODFmLTc4MmQ2YTNiYzUyNw==",
+                        name: "technology",
+                        displayName: "Technology",
+                        url: "https:\u002F\u002Fwww.nytimes.com\u002Fsection\u002Ftechnology",
+                        uri: "nyt:\u002F\u002Fsection\u002F4224240f-b1ab-50bd-881f-782d6a3bc527",
+                        __typename: "Section",
+                    },
+                    subsection: null,
+                    sprinkledBody: {
+                        content: [
+                            {
+                                __typename: "HeaderBasicBlock",
+                                label: null,
+                                headline: {
+                                    textAlign: "LEFT",
+                                    content: [
+                                        {
+                                            __typename: "TextInline",
+                                            text: "How Twitter Will Change as a Private Company",
+                                            formats: [],
+                                        },
+                                    ],
+                                    __typename: "Heading1Block",
+                                },
+                                summary: {
+                                    textAlign: "LEFT",
+                                    content: [
+                                        {
+                                            __typename: "TextInline",
+                                            text: "The social media company went public in 2013. But Elon Musk is taking it private as part of his acquisition of the firm. Here’s what that means.",
+                                            formats: [],
+                                        },
+                                    ],
+                                    __typename: "SummaryBlock",
+                                },
+                                ledeMedia: {
+                                    __typename: "ImageBlock",
+                                    size: "MEDIUM",
+                                    media: {
+                                        id: "SW1hZ2U6bnl0Oi8vaW1hZ2UvOWQ2MjIzMWMtMGYwYi01NmVhLTlmMWYtYjQwNGU3NzUwZTE1",
+                                        imageType: "photo",
+                                        url: "\u002Fimagepages\u002F2022\u002F10\u002F28\u002Fbusiness\u002F00TWITTER-PRIVATE.html",
+                                        uri: "nyt:\u002F\u002Fimage\u002F9d62231c-0f0b-56ea-9f1f-b404e7750e15",
+                                        credit: "Jason Henry for The New York Times",
+                                        legacyHtmlCaption:
+                                          "Elon Musk plans to change Twitter from a public to a privately held company.",
+                                        crops: [
+                                            {
+                                                renditions: [
+                                                    {
+                                                        url: "https:\u002F\u002Fstatic01.nyt.com\u002Fimages\u002F2022\u002F10\u002F29\u002Fbusiness\u002F00jpTWITTER-PRIVATE2-print\u002Fmerlin_214496130_63f02e73-7e2f-47ef-9597-f0b9fc9d20c3-articleLarge.jpg",
+                                                        name: "articleLarge",
+                                                        width: 600,
+                                                        height: 400,
+                                                        __typename: "ImageRendition",
+                                                    },
+                                                    {
+                                                        url: "https:\u002F\u002Fstatic01.nyt.com\u002Fimages\u002F2022\u002F10\u002F29\u002Fbusiness\u002F00jpTWITTER-PRIVATE2-print\u002Fmerlin_214496130_63f02e73-7e2f-47ef-9597-f0b9fc9d20c3-popup.jpg",
+                                                        name: "popup",
+                                                        width: 650,
+                                                        height: 433,
+                                                        __typename: "ImageRendition",
+                                                    },
+                                                    {
+                                                        url: "https:\u002F\u002Fstatic01.nyt.com\u002Fimages\u002F2022\u002F10\u002F29\u002Fbusiness\u002F00jpTWITTER-PRIVATE2-print\u002Fmerlin_214496130_63f02e73-7e2f-47ef-9597-f0b9fc9d20c3-jumbo.jpg",
+                                                        name: "jumbo",
+                                                        width: 1024,
+                                                        height: 683,
+                                                        __typename: "ImageRendition",
+                                                    },
+                                                    {
+                                                        url: "https:\u002F\u002Fstatic01.nyt.com\u002Fimages\u002F2022\u002F10\u002F29\u002Fbusiness\u002F00jpTWITTER-PRIVATE2-print\u002Fmerlin_214496130_63f02e73-7e2f-47ef-9597-f0b9fc9d20c3-superJumbo.jpg",
+                                                        name: "superJumbo",
+                                                        width: 2048,
+                                                        height: 1365,
+                                                        __typename: "ImageRendition",
+                                                    },
+                                                ],
+                                                __typename: "ImageCrop",
+                                            },
+                                            {
+                                                renditions: [
+                                                    {
+                                                        url: "https:\u002F\u002Fstatic01.nyt.com\u002Fimages\u002F2022\u002F10\u002F29\u002Fbusiness\u002F00jpTWITTER-PRIVATE2-print\u002Fmerlin_214496130_63f02e73-7e2f-47ef-9597-f0b9fc9d20c3-articleInline.jpg",
+                                                        name: "articleInline",
+                                                        width: 190,
+                                                        height: 127,
+                                                        __typename: "ImageRendition",
+                                                    },
+                                                ],
+                                                __typename: "ImageCrop",
+                                            },
+                                            {
+                                                renditions: [
+                                                    {
+                                                        url: "https:\u002F\u002Fstatic01.nyt.com\u002Fimages\u002F2022\u002F10\u002F29\u002Fbusiness\u002F00jpTWITTER-PRIVATE2-print\u002Fmerlin_214496130_63f02e73-7e2f-47ef-9597-f0b9fc9d20c3-mobileMasterAt3x.jpg",
+                                                        name: "mobileMasterAt3x",
+                                                        width: 1800,
+                                                        height: 1200,
+                                                        __typename: "ImageRendition",
+                                                    },
+                                                ],
+                                                __typename: "ImageCrop",
+                                            },
+                                        ],
+                                        caption: {
+                                            text: "Elon Musk plans to change Twitter from a public to a privately held company.",
+                                            content: [
+                                                {
+                                                    __typename: "ParagraphBlock",
+                                                    content: [
+                                                        {
+                                                            text: "Elon Musk plans to change Twitter from a public to a privately held company.",
+                                                            __typename: "TextInline",
+                                                            formats: [],
+                                                        },
+                                                    ],
+                                                },
+                                            ],
+                                            __typename: "TextOnlyDocumentBlock",
+                                        },
+                                        altText: "",
+                                        __typename: "Image",
+                                    },
+                                },
+                                byline: {
+                                    textAlign: "LEFT",
+                                    hideHeadshots: false,
+                                    bylines: [
+                                        {
+                                            prefix: "By",
+                                            creators: [
+                                                {
+                                                    id: "UGVyc29uOm55dDovL3BlcnNvbi82MWM0ZDBkOS1iNTA2LTU1NzAtOTQ1Zi03N2Q0OGMwMzgyYjE=",
+                                                    displayName: "Kate Conger",
+                                                    bioUrl:
+                                                      "https:\u002F\u002Fwww.nytimes.com\u002Fby\u002Fkate-conger",
+                                                    promotionalMedia: null,
+                                                    __typename: "Person",
+                                                },
+                                            ],
+                                            renderedRepresentation: "By Kate Conger",
+                                            __typename: "Byline",
+                                        },
+                                    ],
+                                    role: [],
+                                    __typename: "BylineBlock",
+                                },
+                                timestampBlock: {
+                                    timestamp: "2022-10-28T09:00:25.000Z",
+                                    align: "LEFT",
+                                    showUpdatedTimestamp: null,
+                                    __typename: "TimestampBlock",
+                                },
+                            },
+                            {
+                                __typename: "ParagraphBlock",
+                                textAlign: "LEFT",
+                                content: [
+                                    {
+                                        __typename: "TextInline",
+                                        text: "Elon Musk closes his purchase of Twitter and fires several top executives. ",
+                                        formats: [{ __typename: "ItalicFormat", type: null }],
+                                    },
+                                    {
+                                        __typename: "TextInline",
+                                        text: "Follow for the latest news updates",
+                                        formats: [
+                                            { __typename: "ItalicFormat", type: null },
+                                            {
+                                                __typename: "LinkFormat",
+                                                url: "https:\u002F\u002Fwww.nytimes.com\u002Flive\u002F2022\u002F10\u002F28\u002Fbusiness\u002Felon-musk-twitter",
+                                                title: "",
+                                            },
+                                        ],
+                                    },
+                                    {
+                                        __typename: "TextInline",
+                                        text: ".",
+                                        formats: [{ __typename: "ItalicFormat", type: null }],
+                                    },
+                                ],
+                            },
+                            {
+                                __typename: "Dropzone",
+                                adsMobile: false,
+                                adsDesktop: false,
+                                index: 0,
+                                bad: false,
+                            },
+                            {
+                                __typename: "ParagraphBlock",
+                                textAlign: "LEFT",
+                                content: [
+                                    {
+                                        __typename: "TextInline",
+                                        text: "SAN FRANCISCO — In August 2018, Elon Musk called ",
+                                        formats: [],
+                                    },
+                                    {
+                                        __typename: "TextInline",
+                                        text: "Michael Dell",
+                                        formats: [
+                                            {
+                                                __typename: "LinkFormat",
+                                                url: "https:\u002F\u002Fwww.nytimes.com\u002Ftopic\u002Fperson\u002Fmichael-s-dell",
+                                                title: "",
+                                            },
+                                        ],
+                                    },
+                                    {
+                                        __typename: "TextInline",
+                                        text: " for advice.",
+                                        formats: [],
+                                    },
+                                ],
+                            },
+                            {
+                                __typename: "ParagraphBlock",
+                                textAlign: "LEFT",
+                                content: [
+                                    {
+                                        __typename: "TextInline",
+                                        text: "Mr. Musk, who was ",
+                                        formats: [],
+                                    },
+                                    {
+                                        __typename: "TextInline",
+                                        text: "trying to take Tesla, his electric car company, private",
+                                        formats: [
+                                            {
+                                                __typename: "LinkFormat",
+                                                url: "https:\u002F\u002Fwww.nytimes.com\u002F2018\u002F08\u002F07\u002Fbusiness\u002Ftesla-stock-elon-musk-private.html",
+                                                title: "",
+                                            },
+                                        ],
+                                    },
+                                    {
+                                        __typename: "TextInline",
+                                        text: ", quizzed Mr. Dell, who had done that very thing with ",
+                                        formats: [],
+                                    },
+                                    {
+                                        __typename: "TextInline",
+                                        text: "his eponymous computer company in 2013",
+                                        formats: [
+                                            {
+                                                __typename: "LinkFormat",
+                                                url: "https:\u002F\u002Farchive.nytimes.com\u002Fdealbook.nytimes.com\u002F2013\u002F02\u002F05\u002Fdell-sets-23-8-billion-deal-to-go-private\u002F",
+                                                title: "",
+                                            },
+                                        ],
+                                    },
+                                    {
+                                        __typename: "TextInline",
+                                        text: ", about the process and the best lawyers to use for the complicated transaction.",
+                                        formats: [],
+                                    },
+                                ],
+                            },
+                            {
+                                __typename: "Dropzone",
+                                adsMobile: false,
+                                adsDesktop: false,
+                                index: 1,
+                                bad: false,
+                            },
+                            {
+                                __typename: "ParagraphBlock",
+                                textAlign: "LEFT",
+                                content: [
+                                    {
+                                        __typename: "TextInline",
+                                        text: "“I was really asking him about — did he find being private was good?” Mr. Musk recalled in a ",
+                                        formats: [],
+                                    },
+                                    {
+                                        __typename: "TextInline",
+                                        text: "deposition",
+                                        formats: [
+                                            {
+                                                __typename: "LinkFormat",
+                                                url: "https:\u002F\u002Fstorage.courtlistener.com\u002Frecap\u002Fgov.uscourts.cand.330489\u002Fgov.uscourts.cand.330489.403.0.pdf",
+                                                title: "",
+                                            },
+                                        ],
+                                    },
+                                    {
+                                        __typename: "TextInline",
+                                        text: " about the Tesla effort. “Did he regret going private?”",
+                                        formats: [],
+                                    },
+                                ],
+                            },
+                            {
+                                __typename: "Dropzone",
+                                adsMobile: false,
+                                adsDesktop: false,
+                                index: 2,
+                                bad: false,
+                            },
+                            {
+                                __typename: "ParagraphBlock",
+                                textAlign: "LEFT",
+                                content: [
+                                    {
+                                        __typename: "TextInline",
+                                        text: "Mr. Dell warned Mr. Musk that it was “a very difficult process” but that he was glad to have done it, according to court filings.",
+                                        formats: [],
+                                    },
+                                ],
+                            },
+                            {
+                                __typename: "Dropzone",
+                                adsMobile: true,
+                                adsDesktop: true,
+                                index: 3,
+                                bad: false,
+                            },
+                            {
+                                __typename: "ParagraphBlock",
+                                textAlign: "LEFT",
+                                content: [
+                                    {
+                                        __typename: "TextInline",
+                                        text: "Now, Mr. Musk, who did not end up taking Tesla private, is doing so with Twitter. As part of his $44 billion acquisition of the social media service, which closed on Thursday, he is delisting the company’s stock and taking it out of the hands of public shareholders.",
+                                        formats: [],
+                                    },
+                                ],
+                            },
+                            {
+                                __typename: "Dropzone",
+                                adsMobile: false,
+                                adsDesktop: false,
+                                index: 4,
+                                bad: false,
+                            },
+                            {
+                                __typename: "ParagraphBlock",
+                                textAlign: "LEFT",
+                                content: [
+                                    {
+                                        __typename: "TextInline",
+                                        text: "Making Twitter a private company gives Mr. Musk some advantages. Unlike publicly traded companies, privately held firms do not have to make quarterly public disclosures about their performance. They are also subject to less regulatory scrutiny and can be more tightly controlled by an owner. That means Mr. Musk can make over Twitter — including tweaking the platform’s content rules, its finances and its priorities — without having to consider the worries of the investing public.",
+                                        formats: [],
+                                    },
+                                ],
+                            },
+                            {
+                                __typename: "Dropzone",
+                                adsMobile: false,
+                                adsDesktop: false,
+                                index: 5,
+                                bad: false,
+                            },
+                            {
+                                __typename: "ParagraphBlock",
+                                textAlign: "LEFT",
+                                content: [
+                                    {
+                                        __typename: "TextInline",
+                                        text: "“It’s hard to run a public company if you think you should be the one running it and you’re not open to other views from people, like stockholders,” said Brian J.M. Quinn, a professor at Boston College Law School. “By taking it private, you feel like you have a lot more flexibility.”",
+                                        formats: [],
+                                    },
+                                ],
+                            },
+                            {
+                                __typename: "Dropzone",
+                                adsMobile: true,
+                                adsDesktop: false,
+                                index: 6,
+                                bad: false,
+                            },
+                            {
+                                __typename: "ParagraphBlock",
+                                textAlign: "LEFT",
+                                content: [
+                                    {
+                                        __typename: "TextInline",
+                                        text: "Here’s how Twitter is set to change as a private company under Mr. Musk.",
+                                        formats: [],
+                                    },
+                                ],
+                            },
+                            {
+                                __typename: "Heading2Block",
+                                textAlign: "LEFT",
+                                content: [
+                                    {
+                                        __typename: "TextInline",
+                                        text: "How is Mr. Musk taking Twitter private?",
+                                        formats: [],
+                                    },
+                                ],
+                            },
+                            {
+                                __typename: "ParagraphBlock",
+                                textAlign: "LEFT",
+                                content: [
+                                    {
+                                        __typename: "TextInline",
+                                        text: "As part of buying Twitter, Mr. Musk is merging the social media company with ",
+                                        formats: [],
+                                    },
+                                    {
+                                        __typename: "TextInline",
+                                        text: "X Holdings",
+                                        formats: [
+                                            {
+                                                __typename: "LinkFormat",
+                                                url: "https:\u002F\u002Fwww.nytimes.com\u002F2022\u002F10\u002F06\u002Ftechnology\u002Felon-musk-x.html",
+                                                title: "",
+                                            },
+                                        ],
+                                    },
+                                    {
+                                        __typename: "TextInline",
+                                        text: ", a corporate entity that he established in Delaware to handle the deal. X is buying out all of Twitter’s stock and will control the service, and Mr. Musk will control the holding company.",
+                                        formats: [],
+                                    },
+                                ],
+                            },
+                            {
+                                __typename: "Dropzone",
+                                adsMobile: false,
+                                adsDesktop: false,
+                                index: 7,
+                                bad: true,
+                            },
+                            {
+                                __typename: "ImageBlock",
+                                size: "MEDIUM",
+                                media: {
+                                    id: "SW1hZ2U6bnl0Oi8vaW1hZ2UvNmFjYTZkYTItMWQzYy01YWQ5LWFkMTUtZTVhN2YzMTBlZWZl",
+                                    imageType: "photo",
+                                    url: "\u002Fimagepages\u002F2022\u002F10\u002F28\u002Fbusiness\u002F00twitter-private-ipo.html",
+                                    uri: "nyt:\u002F\u002Fimage\u002F6aca6da2-1d3c-5ad9-ad15-e5a7f310eefe",
+                                    credit: "Lucas Jackson\u002FReuters",
+                                    legacyHtmlCaption:
+                                      "Twitter&rsquo;s logo on the screens of the New York Stock Exchange during the company&rsquo;s initial public offering in 2013.",
+                                    crops: [
+                                        {
+                                            renditions: [
+                                                {
+                                                    url: "https:\u002F\u002Fstatic01.nyt.com\u002Fimages\u002F2022\u002F10\u002F29\u002Fbusiness\u002F00JPtwitter-private1-print\u002F00twitter-private-ipo-articleLarge.jpg",
+                                                    name: "articleLarge",
+                                                    width: 600,
+                                                    height: 400,
+                                                    __typename: "ImageRendition",
+                                                },
+                                                {
+                                                    url: "https:\u002F\u002Fstatic01.nyt.com\u002Fimages\u002F2022\u002F10\u002F29\u002Fbusiness\u002F00JPtwitter-private1-print\u002F00twitter-private-ipo-popup.jpg",
+                                                    name: "popup",
+                                                    width: 650,
+                                                    height: 433,
+                                                    __typename: "ImageRendition",
+                                                },
+                                                {
+                                                    url: "https:\u002F\u002Fstatic01.nyt.com\u002Fimages\u002F2022\u002F10\u002F29\u002Fbusiness\u002F00JPtwitter-private1-print\u002F00twitter-private-ipo-jumbo.jpg",
+                                                    name: "jumbo",
+                                                    width: 1024,
+                                                    height: 683,
+                                                    __typename: "ImageRendition",
+                                                },
+                                                {
+                                                    url: "https:\u002F\u002Fstatic01.nyt.com\u002Fimages\u002F2022\u002F10\u002F29\u002Fbusiness\u002F00JPtwitter-private1-print\u002F00twitter-private-ipo-superJumbo.jpg",
+                                                    name: "superJumbo",
+                                                    width: 2048,
+                                                    height: 1365,
+                                                    __typename: "ImageRendition",
+                                                },
+                                            ],
+                                            __typename: "ImageCrop",
+                                        },
+                                        {
+                                            renditions: [
+                                                {
+                                                    url: "https:\u002F\u002Fstatic01.nyt.com\u002Fimages\u002F2022\u002F10\u002F29\u002Fbusiness\u002F00JPtwitter-private1-print\u002F00twitter-private-ipo-articleInline.jpg",
+                                                    name: "articleInline",
+                                                    width: 190,
+                                                    height: 127,
+                                                    __typename: "ImageRendition",
+                                                },
+                                            ],
+                                            __typename: "ImageCrop",
+                                        },
+                                        {
+                                            renditions: [
+                                                {
+                                                    url: "https:\u002F\u002Fstatic01.nyt.com\u002Fimages\u002F2022\u002F10\u002F29\u002Fbusiness\u002F00JPtwitter-private1-print\u002F00twitter-private-ipo-mobileMasterAt3x.jpg",
+                                                    name: "mobileMasterAt3x",
+                                                    width: 1800,
+                                                    height: 1200,
+                                                    __typename: "ImageRendition",
+                                                },
+                                            ],
+                                            __typename: "ImageCrop",
+                                        },
+                                    ],
+                                    caption: {
+                                        text: "Twitter’s logo on the screens of the New York Stock Exchange during the company’s initial public offering in 2013.",
+                                        content: [
+                                            {
+                                                __typename: "ParagraphBlock",
+                                                content: [
+                                                    {
+                                                        text: "Twitter’s logo on the screens of the New York Stock Exchange during the company’s initial public offering in 2013.",
+                                                        __typename: "TextInline",
+                                                        formats: [],
+                                                    },
+                                                ],
+                                            },
+                                        ],
+                                        __typename: "TextOnlyDocumentBlock",
+                                    },
+                                    altText: "",
+                                    __typename: "Image",
+                                },
+                            },
+                            {
+                                __typename: "Dropzone",
+                                adsMobile: false,
+                                adsDesktop: false,
+                                index: 8,
+                                bad: true,
+                            },
+                            {
+                                __typename: "Heading2Block",
+                                textAlign: "LEFT",
+                                content: [
+                                    {
+                                        __typename: "TextInline",
+                                        text: "What happens to Twitter’s stock?",
+                                        formats: [],
+                                    },
+                                ],
+                            },
+                            {
+                                __typename: "ParagraphBlock",
+                                textAlign: "LEFT",
+                                content: [
+                                    {
+                                        __typename: "TextInline",
+                                        text: "Twitter will be delisted from the New York Stock Exchange and its shares will no longer trade on public markets as of Nov. 8, according to ",
+                                        formats: [],
+                                    },
+                                    {
+                                        __typename: "TextInline",
+                                        text: "a securities filing",
+                                        formats: [
+                                            {
+                                                __typename: "LinkFormat",
+                                                url: "https:\u002F\u002Fwww.sec.gov\u002FArchives\u002Fedgar\u002Fdata\u002F876661\u002F000087666122000890\u002FxslF25X02\u002Fprimary_doc.xml",
+                                                title: "",
+                                            },
+                                        ],
+                                    },
+                                    {
+                                        __typename: "TextInline",
+                                        text: ". In September, Twitter’s shareholders approved the company’s sale to Mr. Musk and agreed to sell their stock to him for $54.20 a share. Investors will be able to claim the cash value of their shares.",
+                                        formats: [],
+                                    },
+                                ],
+                            },
+                            {
+                                __typename: "Dropzone",
+                                adsMobile: false,
+                                adsDesktop: true,
+                                index: 9,
+                                bad: false,
+                            },
+                            {
+                                __typename: "Heading2Block",
+                                textAlign: "LEFT",
+                                content: [
+                                    {
+                                        __typename: "TextInline",
+                                        text: "What happens to Twitter’s board of directors?",
+                                        formats: [],
+                                    },
+                                ],
+                            },
+                            {
+                                __typename: "ParagraphBlock",
+                                textAlign: "LEFT",
+                                content: [
+                                    {
+                                        __typename: "TextInline",
+                                        text: "With the deal’s completion, ",
+                                        formats: [],
+                                    },
+                                    {
+                                        __typename: "TextInline",
+                                        text: "Twitter’s board of directors",
+                                        formats: [
+                                            {
+                                                __typename: "LinkFormat",
+                                                url: "https:\u002F\u002Fwww.nytimes.com\u002F2022\u002F10\u002F04\u002Ftechnology\u002Ftwitter-board-elon-musk.html",
+                                                title: "",
+                                            },
+                                        ],
+                                    },
+                                    {
+                                        __typename: "TextInline",
+                                        text: " will dissolve and its nine members will no longer preside over the company’s operations. Mr. Musk will most likely appoint a new board made up of friends and investors who helped fund the acquisition. The new board will be responsible for plotting Twitter’s trajectory as a private company.",
+                                        formats: [],
+                                    },
+                                ],
+                            },
+                            {
+                                __typename: "Dropzone",
+                                adsMobile: false,
+                                adsDesktop: false,
+                                index: 10,
+                                bad: false,
+                            },
+                            {
+                                __typename: "ParagraphBlock",
+                                textAlign: "LEFT",
+                                content: [
+                                    {
+                                        __typename: "TextInline",
+                                        text: "“It will still be required by law to have a board of directors, and that would probably include Elon Musk and some of the other big equity investors in the company,” said Eric Talley, a professor at Columbia Law School. “I expect Mr. Musk will run it as a somewhat friendly dictatorship.”",
+                                        formats: [],
+                                    },
+                                ],
+                            },
+                            {
+                                __typename: "Dropzone",
+                                adsMobile: true,
+                                adsDesktop: false,
+                                index: 11,
+                                bad: false,
+                            },
+                            {
+                                __typename: "Heading2Block",
+                                textAlign: "LEFT",
+                                content: [
+                                    {
+                                        __typename: "TextInline",
+                                        text: "What happens to Twitter’s top executives?",
+                                        formats: [],
+                                    },
+                                ],
+                            },
+                            {
+                                __typename: "ParagraphBlock",
+                                textAlign: "LEFT",
+                                content: [
+                                    {
+                                        __typename: "TextInline",
+                                        text: "Mr. Musk has already started cleaning house, with several of Twitter’s top executives ",
+                                        formats: [],
+                                    },
+                                    {
+                                        __typename: "TextInline",
+                                        text: "getting fired on Thursday",
+                                        formats: [
+                                            {
+                                                __typename: "LinkFormat",
+                                                url: "https:\u002F\u002Fwww.nytimes.com\u002F2022\u002F10\u002F27\u002Ftechnology\u002Felon-musk-twitter-deal-complete.html",
+                                                title: "",
+                                            },
+                                        ],
+                                    },
+                                    { __typename: "TextInline", text: ".", formats: [] },
+                                ],
+                            },
+                            {
+                                __typename: "Dropzone",
+                                adsMobile: false,
+                                adsDesktop: false,
+                                index: 12,
+                                bad: false,
+                            },
+                            {
+                                __typename: "ParagraphBlock",
+                                textAlign: "LEFT",
+                                content: [
+                                    {
+                                        __typename: "TextInline",
+                                        text: "The executives who were fired include ",
+                                        formats: [],
+                                    },
+                                    {
+                                        __typename: "TextInline",
+                                        text: "Parag Agrawal",
+                                        formats: [
+                                            {
+                                                __typename: "LinkFormat",
+                                                url: "https:\u002F\u002Fwww.nytimes.com\u002F2021\u002F11\u002F29\u002Ftechnology\u002Fparag-agrawal-twitter.html",
+                                                title: "",
+                                            },
+                                        ],
+                                    },
+                                    {
+                                        __typename: "TextInline",
+                                        text: ", Twitter’s chief executive, who has clashed publicly and privately with Mr. Musk. When Mr. Musk complained this year that Twitter had an unchecked spam problem, Mr. Agrawal tweeted to rebut his claims. Mr. Musk responded with a poop emoji.",
+                                        formats: [],
+                                    },
+                                ],
+                            },
+                            {
+                                __typename: "Dropzone",
+                                adsMobile: false,
+                                adsDesktop: false,
+                                index: 13,
+                                bad: false,
+                            },
+                            {
+                                __typename: "ParagraphBlock",
+                                textAlign: "LEFT",
+                                content: [
+                                    {
+                                        __typename: "TextInline",
+                                        text: "At another point, Mr. Agrawal texted Mr. Musk, telling the billionaire that his criticisms were harming Twitter, according to a ",
+                                        formats: [],
+                                    },
+                                    {
+                                        __typename: "TextInline",
+                                        text: "court filing",
+                                        formats: [
+                                            {
+                                                __typename: "LinkFormat",
+                                                url: "https:\u002F\u002Fwww.documentcloud.org\u002Fdocuments\u002F23112929-elon-musk-text-exhibits-twitter-v-musk",
+                                                title: "",
+                                            },
+                                        ],
+                                    },
+                                    { __typename: "TextInline", text: ".", formats: [] },
+                                ],
+                            },
+                            {
+                                __typename: "Dropzone",
+                                adsMobile: false,
+                                adsDesktop: false,
+                                index: 14,
+                                bad: false,
+                            },
+                            {
+                                __typename: "ParagraphBlock",
+                                textAlign: "LEFT",
+                                content: [
+                                    {
+                                        __typename: "TextInline",
+                                        text: "“This is a waste of time,” Mr. Musk retorted.",
+                                        formats: [],
+                                    },
+                                ],
+                            },
+                            {
+                                __typename: "ParagraphBlock",
+                                textAlign: "LEFT",
+                                content: [
+                                    {
+                                        __typename: "TextInline",
+                                        text: "Other executives who were fired include Ned Segal, Twitter’s chief financial officer; Vijaya Gadde, the top legal and policy executive; and Sean Edgett, the general counsel.",
+                                        formats: [],
+                                    },
+                                ],
+                            },
+                            {
+                                __typename: "Dropzone",
+                                adsMobile: true,
+                                adsDesktop: true,
+                                index: 15,
+                                bad: false,
+                            },
+                            {
+                                __typename: "ParagraphBlock",
+                                textAlign: "LEFT",
+                                content: [
+                                    {
+                                        __typename: "TextInline",
+                                        text: "Under the merger agreement, Mr. Agrawal was potentially set to receive a golden parachute worth about $60 million, with Mr. Segal to receive $46 million, while Ms. Gadde would receive about $20 million. It was not immediately clear whether Mr. Musk intended to make the payments.",
+                                        formats: [],
+                                    },
+                                ],
+                            },
+                            {
+                                __typename: "Dropzone",
+                                adsMobile: false,
+                                adsDesktop: false,
+                                index: 16,
+                                bad: true,
+                            },
+                            {
+                                __typename: "ImageBlock",
+                                size: "MEDIUM",
+                                media: {
+                                    id: "SW1hZ2U6bnl0Oi8vaW1hZ2UvZmIwN2Y2YzMtYmM3Yi01MjU1LTg3MDktOGNlZmRmODNmYTA4",
+                                    imageType: "photo",
+                                    url: "\u002Fimagepages\u002F2022\u002F10\u002F28\u002Fbusiness\u002F00twitter-private-Agrawal.html",
+                                    uri: "nyt:\u002F\u002Fimage\u002Ffb07f6c3-bc7b-5255-8709-8cefdf83fa08",
+                                    credit: "Kevin Dietsch\u002FGetty Images",
+                                    legacyHtmlCaption:
+                                      "Parag Agrawal was fired by Mr. Musk as Twitter’s chief executive on Thursday. ",
+                                    crops: [
+                                        {
+                                            renditions: [
+                                                {
+                                                    url: "https:\u002F\u002Fstatic01.nyt.com\u002Fimages\u002F2022\u002F10\u002F25\u002Fbusiness\u002F00twitter-private-Agrawal\u002F00twitter-private-Agrawal-articleLarge.jpg",
+                                                    name: "articleLarge",
+                                                    width: 600,
+                                                    height: 600,
+                                                    __typename: "ImageRendition",
+                                                },
+                                                {
+                                                    url: "https:\u002F\u002Fstatic01.nyt.com\u002Fimages\u002F2022\u002F10\u002F25\u002Fbusiness\u002F00twitter-private-Agrawal\u002F00twitter-private-Agrawal-popup.jpg",
+                                                    name: "popup",
+                                                    width: 500,
+                                                    height: 500,
+                                                    __typename: "ImageRendition",
+                                                },
+                                                {
+                                                    url: "https:\u002F\u002Fstatic01.nyt.com\u002Fimages\u002F2022\u002F10\u002F25\u002Fbusiness\u002F00twitter-private-Agrawal\u002F00twitter-private-Agrawal-jumbo.jpg",
+                                                    name: "jumbo",
+                                                    width: 1024,
+                                                    height: 1024,
+                                                    __typename: "ImageRendition",
+                                                },
+                                                {
+                                                    url: "https:\u002F\u002Fstatic01.nyt.com\u002Fimages\u002F2022\u002F10\u002F25\u002Fbusiness\u002F00twitter-private-Agrawal\u002F00twitter-private-Agrawal-superJumbo.jpg",
+                                                    name: "superJumbo",
+                                                    width: 1118,
+                                                    height: 1118,
+                                                    __typename: "ImageRendition",
+                                                },
+                                            ],
+                                            __typename: "ImageCrop",
+                                        },
+                                        {
+                                            renditions: [
+                                                {
+                                                    url: "https:\u002F\u002Fstatic01.nyt.com\u002Fimages\u002F2022\u002F10\u002F25\u002Fbusiness\u002F00twitter-private-Agrawal\u002F00twitter-private-Agrawal-articleInline.jpg",
+                                                    name: "articleInline",
+                                                    width: 190,
+                                                    height: 190,
+                                                    __typename: "ImageRendition",
+                                                },
+                                            ],
+                                            __typename: "ImageCrop",
+                                        },
+                                        {
+                                            renditions: [
+                                                {
+                                                    url: "https:\u002F\u002Fstatic01.nyt.com\u002Fimages\u002F2022\u002F10\u002F25\u002Fbusiness\u002F00twitter-private-Agrawal\u002F00twitter-private-Agrawal-mobileMasterAt3x.jpg",
+                                                    name: "mobileMasterAt3x",
+                                                    width: 1118,
+                                                    height: 1118,
+                                                    __typename: "ImageRendition",
+                                                },
+                                            ],
+                                            __typename: "ImageCrop",
+                                        },
+                                    ],
+                                    caption: {
+                                        text: "Parag Agrawal was fired by Mr. Musk as Twitter’s chief executive on Thursday. ",
+                                        content: [
+                                            {
+                                                __typename: "ParagraphBlock",
+                                                content: [
+                                                    {
+                                                        text: "Parag Agrawal was fired by Mr. Musk as Twitter’s chief executive on Thursday. ",
+                                                        __typename: "TextInline",
+                                                        formats: [],
+                                                    },
+                                                ],
+                                            },
+                                        ],
+                                        __typename: "TextOnlyDocumentBlock",
+                                    },
+                                    altText: "",
+                                    __typename: "Image",
+                                },
+                            },
+                            {
+                                __typename: "Dropzone",
+                                adsMobile: false,
+                                adsDesktop: false,
+                                index: 17,
+                                bad: true,
+                            },
+                            {
+                                __typename: "Heading2Block",
+                                textAlign: "LEFT",
+                                content: [
+                                    {
+                                        __typename: "TextInline",
+                                        text: "What about Twitter’s employees?",
+                                        formats: [],
+                                    },
+                                ],
+                            },
+                            {
+                                __typename: "ParagraphBlock",
+                                textAlign: "LEFT",
+                                content: [
+                                    {
+                                        __typename: "TextInline",
+                                        text: "Twitter has about 7,500 employees. Some of them ",
+                                        formats: [],
+                                    },
+                                    {
+                                        __typename: "TextInline",
+                                        text: "have been jittery",
+                                        formats: [
+                                            {
+                                                __typename: "LinkFormat",
+                                                url: "https:\u002F\u002Fwww.nytimes.com\u002F2022\u002F10\u002F21\u002Ftechnology\u002Ftwitter-employees-elon-musk.html",
+                                                title: "",
+                                            },
+                                        ],
+                                    },
+                                    {
+                                        __typename: "TextInline",
+                                        text: " for months about the company’s sale to Mr. Musk. Many could face layoffs or job changes as their new owner takes over.",
+                                        formats: [],
+                                    },
+                                ],
+                            },
+                            {
+                                __typename: "Dropzone",
+                                adsMobile: false,
+                                adsDesktop: false,
+                                index: 18,
+                                bad: false,
+                            },
+                            {
+                                __typename: "ParagraphBlock",
+                                textAlign: "LEFT",
+                                content: [
+                                    {
+                                        __typename: "TextInline",
+                                        text: "Their compensation is also set to change. Employees typically receive stock options in the company. But, with the delisting of Twitter’s stock, employees are set to be cashed out for shares they already have and to be paid with cash bonuses going forward, instead of the stock options they were scheduled to receive, according to the merger agreement. Some ",
+                                        formats: [],
+                                    },
+                                    {
+                                        __typename: "TextInline",
+                                        text: "employees have worried",
+                                        formats: [
+                                            {
+                                                __typename: "LinkFormat",
+                                                url: "https:\u002F\u002Fwww.nytimes.com\u002F2022\u002F10\u002F21\u002Ftechnology\u002Ftwitter-employees-elon-musk.html",
+                                                title: "",
+                                            },
+                                        ],
+                                    },
+                                    {
+                                        __typename: "TextInline",
+                                        text: " that Mr. Musk may not honor the agreement.",
+                                        formats: [],
+                                    },
+                                ],
+                            },
+                            {
+                                __typename: "Dropzone",
+                                adsMobile: true,
+                                adsDesktop: false,
+                                index: 19,
+                                bad: false,
+                            },
+                            {
+                                __typename: "ParagraphBlock",
+                                textAlign: "LEFT",
+                                content: [
+                                    {
+                                        __typename: "TextInline",
+                                        text: "“Most of these employees have been in a public company and are used to public option grants, which are liquid,” Mr. Quinn said. “They will have to come up with some other Silicon Valley-friendly method of keeping people around.”",
+                                        formats: [],
+                                    },
+                                ],
+                            },
+                            {
+                                __typename: "Dropzone",
+                                adsMobile: false,
+                                adsDesktop: false,
+                                index: 20,
+                                bad: false,
+                            },
+                            {
+                                __typename: "Heading2Block",
+                                textAlign: "LEFT",
+                                content: [
+                                    {
+                                        __typename: "TextInline",
+                                        text: "What financial pressures will Twitter face as a private company?",
+                                        formats: [],
+                                    },
+                                ],
+                            },
+                            {
+                                __typename: "ParagraphBlock",
+                                textAlign: "LEFT",
+                                content: [
+                                    {
+                                        __typename: "TextInline",
+                                        text: "By going private, Twitter will avoid some public scrutiny since it will no longer be required to make quarterly disclosures about the health of its business. This will give Mr. Musk some flexibility as he changes Twitter.",
+                                        formats: [],
+                                    },
+                                ],
+                            },
+                            {
+                                __typename: "Dropzone",
+                                adsMobile: false,
+                                adsDesktop: false,
+                                index: 21,
+                                bad: false,
+                            },
+                            {
+                                __typename: "ParagraphBlock",
+                                textAlign: "LEFT",
+                                content: [
+                                    {
+                                        __typename: "TextInline",
+                                        text: "But he will face pressure from the banks that lent him $12.5 billion for the deal to begin repaying his debt. The cost of repaying those loans could run as high as $1 billion a year, financial analysts said.",
+                                        formats: [],
+                                    },
+                                ],
+                            },
+                            {
+                                __typename: "Dropzone",
+                                adsMobile: false,
+                                adsDesktop: true,
+                                index: 22,
+                                bad: false,
+                            },
+                            {
+                                __typename: "ParagraphBlock",
+                                textAlign: "LEFT",
+                                content: [
+                                    {
+                                        __typename: "TextInline",
+                                        text: "“He has less public pressure, but he has a lot of private pressure from the banks to make the payments,” Mr. Quinn said of Mr. Musk. “Like almost every other private-equity take-private, he’s going to need a manager who is very focused on operations, being lean and being able to pay the bills on a day-to-day basis.”",
+                                        formats: [],
+                                    },
+                                ],
+                            },
+                            {
+                                __typename: "Dropzone",
+                                adsMobile: true,
+                                adsDesktop: false,
+                                index: 23,
+                                bad: false,
+                            },
+                            {
+                                __typename: "ParagraphBlock",
+                                textAlign: "LEFT",
+                                content: [
+                                    {
+                                        __typename: "TextInline",
+                                        text: "Mr. Musk also took about $7.1 billion from equity investors to push the deal through. He may also face pressure from those investors, who might expect him to take Twitter public again at some point so that they can recoup their investment.",
+                                        formats: [],
+                                    },
+                                ],
+                            },
+                            {
+                                __typename: "Dropzone",
+                                adsMobile: false,
+                                adsDesktop: false,
+                                index: 24,
+                                bad: false,
+                            },
+                            {
+                                __typename: "ParagraphBlock",
+                                textAlign: "LEFT",
+                                content: [
+                                    {
+                                        __typename: "TextInline",
+                                        text: "In some take-private deals, owners have opted to sell branches of their companies to pay their debts. Mr. Musk could choose to do the same at Twitter.",
+                                        formats: [],
+                                    },
+                                ],
+                            },
+                            {
+                                __typename: "Dropzone",
+                                adsMobile: false,
+                                adsDesktop: false,
+                                index: 25,
+                                bad: false,
+                            },
+                            {
+                                __typename: "ParagraphBlock",
+                                textAlign: "LEFT",
+                                content: [
+                                    {
+                                        __typename: "TextInline",
+                                        text: "“It’s conceivable that some aspects of Twitter could potentially be carved off, sold off or spun off to raise money that could go toward paying the debt,” Mr. Talley said. “Twitter kind of is pared down to its core mission right now. They would have to get a little creative.”",
+                                        formats: [],
+                                    },
+                                ],
+                            },
+                            {
+                                __typename: "Dropzone",
+                                adsMobile: false,
+                                adsDesktop: false,
+                                index: 26,
+                                bad: true,
+                            },
+                            {
+                                __typename: "RelatedLinksBlock",
+                                displayStyle: "STANDARD",
+                                title: [
+                                    {
+                                        __typename: "TextInline",
+                                        text: "Changes for Twitter",
+                                        formats: [],
+                                    },
+                                ],
+                                description: [],
+                                related: [
+                                    {
+                                        __typename: "Article",
+                                        promotionalHeadline:
+                                          "Twitter Tries Calming Employees as Deal With Elon Musk Looms",
+                                        promotionalSummary:
+                                          "With Mr. Musk’s $44 billion deal to buy Twitter set to close no later than Oct. 28, the company is trying to reassure workers about their employment and compensation.",
+                                        headline: {
+                                            default:
+                                              "Twitter Tries Calming Employees as Deal With Elon Musk Looms",
+                                            seo: "",
+                                            __typename: "CreativeWorkHeadline",
+                                        },
+                                        summary:
+                                          "With Mr. Musk’s $44 billion deal to buy Twitter set to close no later than Oct. 28, the company is trying to reassure workers about their employment and compensation.",
+                                        url: "https:\u002F\u002Fwww.nytimes.com\u002F2022\u002F10\u002F21\u002Ftechnology\u002Ftwitter-employees-elon-musk.html",
+                                        firstPublished: "2022-10-21T21:34:46.000Z",
+                                        id: "QXJ0aWNsZTpueXQ6Ly9hcnRpY2xlLzU4Yjk4MGViLTdjYjQtNTUwNC1hODE5LWZkOWJhNmU4YzMyZA==",
+                                        typeOfMaterials: ["News"],
+                                        collections: [],
+                                        promotionalMedia: {
+                                            id: "SW1hZ2U6bnl0Oi8vaW1hZ2UvMzY4NDNiMjUtYWFhOS01YzNiLWE2OGYtNmQ2ZDA5YWRkY2E2",
+                                            credit: "Jason Henry for The New York Times",
+                                            crops: [
+                                                {
+                                                    renditions: [
+                                                        {
+                                                            url: "https:\u002F\u002Fstatic01.nyt.com\u002Fimages\u002F2022\u002F10\u002F21\u002Fbusiness\u002F21twitter\u002Fmerlin_214496592_519bbab8-ff80-49f8-a337-2cfc16cc9919-thumbLarge.jpg",
+                                                            name: "thumbLarge",
+                                                            width: 150,
+                                                            __typename: "ImageRendition",
+                                                        },
+                                                    ],
+                                                    __typename: "ImageCrop",
+                                                },
+                                                {
+                                                    renditions: [
+                                                        {
+                                                            url: "https:\u002F\u002Fstatic01.nyt.com\u002Fimages\u002F2022\u002F10\u002F21\u002Fbusiness\u002F21twitter\u002Fmerlin_214496592_519bbab8-ff80-49f8-a337-2cfc16cc9919-videoLarge.jpg",
+                                                            name: "videoLarge",
+                                                            width: 768,
+                                                            __typename: "ImageRendition",
+                                                        },
+                                                        {
+                                                            url: "https:\u002F\u002Fstatic01.nyt.com\u002Fimages\u002F2022\u002F10\u002F21\u002Fbusiness\u002F21twitter\u002Fmerlin_214496592_519bbab8-ff80-49f8-a337-2cfc16cc9919-mediumThreeByTwo440.jpg",
+                                                            name: "mediumThreeByTwo440",
+                                                            width: 440,
+                                                            __typename: "ImageRendition",
+                                                        },
+                                                        {
+                                                            url: "https:\u002F\u002Fstatic01.nyt.com\u002Fimages\u002F2022\u002F10\u002F21\u002Fbusiness\u002F21twitter\u002Fmerlin_214496592_519bbab8-ff80-49f8-a337-2cfc16cc9919-threeByTwoSmallAt2X.jpg",
+                                                            name: "threeByTwoSmallAt2X",
+                                                            width: 600,
+                                                            __typename: "ImageRendition",
+                                                        },
+                                                    ],
+                                                    __typename: "ImageCrop",
+                                                },
+                                            ],
+                                            __typename: "Image",
+                                        },
+                                        section: {
+                                            id: "U2VjdGlvbjpueXQ6Ly9zZWN0aW9uLzQyMjQyNDBmLWIxYWItNTBiZC04ODFmLTc4MmQ2YTNiYzUyNw==",
+                                            displayName: "Technology",
+                                            __typename: "Section",
+                                        },
+                                        bylines: [
+                                            {
+                                                creators: [
+                                                    {
+                                                        id: "UGVyc29uOm55dDovL3BlcnNvbi82MWM0ZDBkOS1iNTA2LTU1NzAtOTQ1Zi03N2Q0OGMwMzgyYjE=",
+                                                        displayName: "Kate Conger",
+                                                        __typename: "Person",
+                                                    },
+                                                    {
+                                                        id: "UGVyc29uOm55dDovL3BlcnNvbi85YjQyNDIzZi1mNTk5LTVhM2YtOTYyNi02ZGQ5ODUzZGM0Y2I=",
+                                                        displayName: "Ryan Mac",
+                                                        __typename: "Person",
+                                                    },
+                                                    {
+                                                        id: "UGVyc29uOm55dDovL3BlcnNvbi84NmUyMjgwNy02NjA4LTVlNTctODRiZS1iNjU0YWI0MDc4NDA=",
+                                                        displayName: "Lauren Hirsch",
+                                                        __typename: "Person",
+                                                    },
+                                                ],
+                                                __typename: "Byline",
+                                            },
+                                        ],
+                                    },
+                                    {
+                                        __typename: "Article",
+                                        promotionalHeadline:
+                                          "Silicon Valley’s Elite Get Dragged Into Musk-Twitter Trial",
+                                        promotionalSummary:
+                                          "More than 100 subpoenas have been issued to techies like Jack Dorsey and Marc Andreessen as Twitter tries to force Elon Musk to complete a $44 billion deal. Law firms are stoked.",
+                                        headline: {
+                                            default:
+                                              "Silicon Valley’s Elite Get Dragged Into Musk-Twitter Trial",
+                                            seo: "",
+                                            __typename: "CreativeWorkHeadline",
+                                        },
+                                        summary:
+                                          "More than 100 subpoenas have been issued to techies like Jack Dorsey and Marc Andreessen as Twitter tries to force Elon Musk to complete a $44 billion deal. Law firms are stoked.",
+                                        url: "https:\u002F\u002Fwww.nytimes.com\u002F2022\u002F08\u002F29\u002Ftechnology\u002Fmusk-twitter-trial-lawyers.html",
+                                        firstPublished: "2022-08-29T09:00:36.000Z",
+                                        id: "QXJ0aWNsZTpueXQ6Ly9hcnRpY2xlL2JhMjdlM2YwLTEyNjUtNTgyOS05NWE2LWIzMWFhYWY0NWFiZA==",
+                                        typeOfMaterials: ["News"],
+                                        collections: [],
+                                        promotionalMedia: {
+                                            id: "SW1hZ2U6bnl0Oi8vaW1hZ2UvMDAxY2ZhZDYtMmI5ZC01OGFhLWJiMGQtYTcyNTIxNzI3MmFj",
+                                            credit: "Igor Bastidas",
+                                            crops: [
+                                                {
+                                                    renditions: [
+                                                        {
+                                                            url: "https:\u002F\u002Fstatic01.nyt.com\u002Fimages\u002F2022\u002F08\u002F26\u002Fbusiness\u002F26lawyer-up\u002F26lawyer-up-thumbLarge.jpg",
+                                                            name: "thumbLarge",
+                                                            width: 150,
+                                                            __typename: "ImageRendition",
+                                                        },
+                                                    ],
+                                                    __typename: "ImageCrop",
+                                                },
+                                                {
+                                                    renditions: [
+                                                        {
+                                                            url: "https:\u002F\u002Fstatic01.nyt.com\u002Fimages\u002F2022\u002F08\u002F26\u002Fbusiness\u002F26lawyer-up\u002F26lawyer-up-videoLarge.jpg",
+                                                            name: "videoLarge",
+                                                            width: 768,
+                                                            __typename: "ImageRendition",
+                                                        },
+                                                        {
+                                                            url: "https:\u002F\u002Fstatic01.nyt.com\u002Fimages\u002F2022\u002F08\u002F26\u002Fbusiness\u002F26lawyer-up\u002F26lawyer-up-mediumThreeByTwo440.jpg",
+                                                            name: "mediumThreeByTwo440",
+                                                            width: 440,
+                                                            __typename: "ImageRendition",
+                                                        },
+                                                        {
+                                                            url: "https:\u002F\u002Fstatic01.nyt.com\u002Fimages\u002F2022\u002F08\u002F26\u002Fbusiness\u002F26lawyer-up\u002F26lawyer-up-threeByTwoSmallAt2X.jpg",
+                                                            name: "threeByTwoSmallAt2X",
+                                                            width: 600,
+                                                            __typename: "ImageRendition",
+                                                        },
+                                                    ],
+                                                    __typename: "ImageCrop",
+                                                },
+                                            ],
+                                            __typename: "Image",
+                                        },
+                                        section: {
+                                            id: "U2VjdGlvbjpueXQ6Ly9zZWN0aW9uLzQyMjQyNDBmLWIxYWItNTBiZC04ODFmLTc4MmQ2YTNiYzUyNw==",
+                                            displayName: "Technology",
+                                            __typename: "Section",
+                                        },
+                                        bylines: [
+                                            {
+                                                creators: [
+                                                    {
+                                                        id: "UGVyc29uOm55dDovL3BlcnNvbi82MWM0ZDBkOS1iNTA2LTU1NzAtOTQ1Zi03N2Q0OGMwMzgyYjE=",
+                                                        displayName: "Kate Conger",
+                                                        __typename: "Person",
+                                                    },
+                                                ],
+                                                __typename: "Byline",
+                                            },
+                                        ],
+                                    },
+                                    {
+                                        __typename: "Article",
+                                        promotionalHeadline:
+                                          "‘I Don’t Really Have a Business Plan’: How Elon Musk Wings It",
+                                        promotionalSummary:
+                                          "To a degree unseen in any other mogul, the world’s richest man acts on impulse and the belief that he is absolutely right.",
+                                        headline: {
+                                            default:
+                                              "‘I Don’t Really Have a Business Plan’: How Elon Musk Wings It",
+                                            seo: "How Elon Musk Winged It With Twitter, and Everything Else",
+                                            __typename: "CreativeWorkHeadline",
+                                        },
+                                        summary:
+                                          "To a degree unseen in any other mogul, the world’s richest man acts on impulse and the belief that he is absolutely right.",
+                                        url: "https:\u002F\u002Fwww.nytimes.com\u002F2022\u002F05\u002F03\u002Ftechnology\u002Felon-musk-twitter-plan.html",
+                                        firstPublished: "2022-05-03T07:00:21.000Z",
+                                        id: "QXJ0aWNsZTpueXQ6Ly9hcnRpY2xlLzgyMGQyYjNlLTI0YzAtNThjZC05MDZmLTQ0NmQ5NDU1ZjE5Nw==",
+                                        typeOfMaterials: ["News"],
+                                        collections: [],
+                                        promotionalMedia: {
+                                            id: "SW1hZ2U6bnl0Oi8vaW1hZ2UvYjQ2YWE5NDQtZDc2ZS01NjhiLWFhNGYtZjBhYWZhZjI5MWIz",
+                                            credit: "Jefferson Siegel for The New York Times",
+                                            crops: [
+                                                {
+                                                    renditions: [
+                                                        {
+                                                            url: "https:\u002F\u002Fstatic01.nyt.com\u002Fimages\u002F2022\u002F05\u002F03\u002Fbusiness\u002F00musk-top\u002F00musk-top-thumbLarge.jpg",
+                                                            name: "thumbLarge",
+                                                            width: 150,
+                                                            __typename: "ImageRendition",
+                                                        },
+                                                    ],
+                                                    __typename: "ImageCrop",
+                                                },
+                                                {
+                                                    renditions: [
+                                                        {
+                                                            url: "https:\u002F\u002Fstatic01.nyt.com\u002Fimages\u002F2022\u002F05\u002F03\u002Fbusiness\u002F00musk-top\u002F00musk-top-videoLarge.jpg",
+                                                            name: "videoLarge",
+                                                            width: 768,
+                                                            __typename: "ImageRendition",
+                                                        },
+                                                        {
+                                                            url: "https:\u002F\u002Fstatic01.nyt.com\u002Fimages\u002F2022\u002F05\u002F03\u002Fbusiness\u002F00musk-top\u002F00musk-top-mediumThreeByTwo440.jpg",
+                                                            name: "mediumThreeByTwo440",
+                                                            width: 440,
+                                                            __typename: "ImageRendition",
+                                                        },
+                                                        {
+                                                            url: "https:\u002F\u002Fstatic01.nyt.com\u002Fimages\u002F2022\u002F05\u002F03\u002Fbusiness\u002F00musk-top\u002F00musk-top-threeByTwoSmallAt2X.jpg",
+                                                            name: "threeByTwoSmallAt2X",
+                                                            width: 600,
+                                                            __typename: "ImageRendition",
+                                                        },
+                                                    ],
+                                                    __typename: "ImageCrop",
+                                                },
+                                            ],
+                                            __typename: "Image",
+                                        },
+                                        section: {
+                                            id: "U2VjdGlvbjpueXQ6Ly9zZWN0aW9uLzQyMjQyNDBmLWIxYWItNTBiZC04ODFmLTc4MmQ2YTNiYzUyNw==",
+                                            displayName: "Technology",
+                                            __typename: "Section",
+                                        },
+                                        bylines: [
+                                            {
+                                                creators: [
+                                                    {
+                                                        id: "UGVyc29uOm55dDovL3BlcnNvbi85YjQyNDIzZi1mNTk5LTVhM2YtOTYyNi02ZGQ5ODUzZGM0Y2I=",
+                                                        displayName: "Ryan Mac",
+                                                        __typename: "Person",
+                                                    },
+                                                    {
+                                                        id: "UGVyc29uOm55dDovL3BlcnNvbi9mYmRiNDFmZC00YTZjLTU0N2ItYWMxNC0zYTI2ZDhmZWFkZTY=",
+                                                        displayName: "Cade Metz",
+                                                        __typename: "Person",
+                                                    },
+                                                    {
+                                                        id: "UGVyc29uOm55dDovL3BlcnNvbi82MWM0ZDBkOS1iNTA2LTU1NzAtOTQ1Zi03N2Q0OGMwMzgyYjE=",
+                                                        displayName: "Kate Conger",
+                                                        __typename: "Person",
+                                                    },
+                                                ],
+                                                __typename: "Byline",
+                                            },
+                                        ],
+                                    },
+                                ],
+                            },
+                        ],
+                        __typename: "DocumentBlock",
+                    },
+                    url: "https:\u002F\u002Fwww.nytimes.com\u002F2022\u002F10\u002F28\u002Ftechnology\u002Ftwitter-changes.html",
+                    adTargetingParams: [
+                        {
+                            key: "als_test",
+                            value: "1669715959686",
+                            __typename: "AdTargetingParam",
+                        },
+                        { key: "prop", value: "nyt", __typename: "AdTargetingParam" },
+                        { key: "plat", value: "web", __typename: "AdTargetingParam" },
+                        { key: "edn", value: "us", __typename: "AdTargetingParam" },
+                        {
+                            key: "brandsensitive",
+                            value: "false",
+                            __typename: "AdTargetingParam",
+                        },
+                        {
+                            key: "per",
+                            value: "muskelon,agrawalparag",
+                            __typename: "AdTargetingParam",
+                        },
+                        {
+                            key: "org",
+                            value: "twitter",
+                            __typename: "AdTargetingParam",
+                        },
+                        { key: "geo", value: "", __typename: "AdTargetingParam" },
+                        {
+                            key: "des",
+                            value:
+                              "socialmedia,mergersacquisitionsanddivestit,stocksandbonds,computersandtheinternet,boardsofdirectors,appointmentsandexecutivechange,stockoptionsandpurchaseplans",
+                            __typename: "AdTargetingParam",
+                        },
+                        { key: "spon", value: "", __typename: "AdTargetingParam" },
+                        {
+                            key: "auth",
+                            value: "kateconger",
+                            __typename: "AdTargetingParam",
+                        },
+                        { key: "col", value: "", __typename: "AdTargetingParam" },
+                        {
+                            key: "coll",
+                            value: "technology,media,business,dealbook",
+                            __typename: "AdTargetingParam",
+                        },
+                        {
+                            key: "artlen",
+                            value: "medium",
+                            __typename: "AdTargetingParam",
+                        },
+                        {
+                            key: "ledemedsz",
+                            value: "none",
+                            __typename: "AdTargetingParam",
+                        },
+                        { key: "gui", value: "", __typename: "AdTargetingParam" },
+                        {
+                            key: "template",
+                            value: "article",
+                            __typename: "AdTargetingParam",
+                        },
+                        { key: "typ", value: "art", __typename: "AdTargetingParam" },
+                        {
+                            key: "section",
+                            value: "technology",
+                            __typename: "AdTargetingParam",
+                        },
+                        {
+                            key: "si_section",
+                            value: "technology",
+                            __typename: "AdTargetingParam",
+                        },
+                        {
+                            key: "id",
+                            value: "100000008591603",
+                            __typename: "AdTargetingParam",
+                        },
+                        { key: "trend", value: "", __typename: "AdTargetingParam" },
+                        {
+                            key: "pt",
+                            value:
+                              "nt10,nt14,nt16,nt17,nt18,nt2,nt3,nt4,nt5,nt6,nt7,pt11,pt13,pt21",
+                            __typename: "AdTargetingParam",
+                        },
+                        {
+                            key: "gscat",
+                            value:
+                              "neg_citi_aa,neg_ibmtest,neg_mastercard,cc_business_lead_boards,neg_capitalone,neg_google,neg_ibm,neg_chan2,neg_chanel,neg_hms,gs_business,gs_economy,gs_economy_markets,gb_safe,ggl_wrk_collab,neg_racism,neg_samsung,neg_bofa,neg_aramco,neg_gg1,gs_tech_social,gs_tech,gs_finance_loans,gs_business_management,gs_business_careers,gv_safe,gs_t",
+                            __typename: "AdTargetingParam",
+                        },
+                        { key: "tt", value: "7", __typename: "AdTargetingParam" },
+                        {
+                            key: "mt",
+                            value: "MT10,MT3,MT7",
+                            __typename: "AdTargetingParam",
+                        },
+                    ],
+                    sourceId: "100000008591603",
+                    type: "article",
+                    wordCount: 1105,
+                    bylines: [
+                        {
+                            creators: [
+                                {
+                                    id: "UGVyc29uOm55dDovL3BlcnNvbi82MWM0ZDBkOS1iNTA2LTU1NzAtOTQ1Zi03N2Q0OGMwMzgyYjE=",
+                                    displayName: "Kate Conger",
+                                    __typename: "Person",
+                                    url: "",
+                                    bioUrl:
+                                      "https:\u002F\u002Fwww.nytimes.com\u002Fby\u002Fkate-conger",
+                                },
+                            ],
+                            __typename: "Byline",
+                            renderedRepresentation: "By Kate Conger",
+                        },
+                    ],
+                    displayProperties: {
+                        fullBleedDisplayStyle: "",
+                        __typename: "CreativeWorkDisplayProperties",
+                        serveAsNyt4: false,
+                    },
+                    typeOfMaterials: ["News"],
+                    timesTags: [
+                        {
+                            __typename: "Organization",
+                            vernacular: "",
+                            isAdvertisingBrandSensitive: false,
+                            displayName: "Twitter",
+                        },
+                        {
+                            __typename: "Person",
+                            vernacular: "Elon Musk",
+                            isAdvertisingBrandSensitive: false,
+                            displayName: "Musk, Elon",
+                        },
+                        {
+                            __typename: "Subject",
+                            vernacular: "Social Media",
+                            isAdvertisingBrandSensitive: false,
+                            displayName: "Social Media",
+                        },
+                        {
+                            __typename: "Subject",
+                            vernacular: "Mergers and Acquisitions",
+                            isAdvertisingBrandSensitive: false,
+                            displayName: "Mergers, Acquisitions and Divestitures",
+                        },
+                        {
+                            __typename: "Subject",
+                            vernacular: "Stocks;Bonds",
+                            isAdvertisingBrandSensitive: false,
+                            displayName: "Stocks and Bonds",
+                        },
+                        {
+                            __typename: "Subject",
+                            vernacular: "Computers and the Internet,Tech Industry",
+                            isAdvertisingBrandSensitive: false,
+                            displayName: "Computers and the Internet",
+                        },
+                        {
+                            __typename: "Subject",
+                            vernacular: "Board of directors",
+                            isAdvertisingBrandSensitive: false,
+                            displayName: "Boards of Directors",
+                        },
+                        {
+                            __typename: "Subject",
+                            vernacular: "Appointments and Executive Changes",
+                            isAdvertisingBrandSensitive: false,
+                            displayName: "Appointments and Executive Changes",
+                        },
+                        {
+                            __typename: "Subject",
+                            vernacular: "Stock Options ESPP",
+                            isAdvertisingBrandSensitive: false,
+                            displayName: "Stock Options and Purchase Plans",
+                        },
+                        {
+                            __typename: "Person",
+                            vernacular: "Parag Agrawal",
+                            isAdvertisingBrandSensitive: false,
+                            displayName: "Agrawal, Parag",
+                        },
+                    ],
+                    language: { code: "en", __typename: "Language", name: "English" },
+                    desk: "Business",
+                    kicker: "",
+                    headline: {
+                        default: "How Twitter Will Change as a Private Company",
+                        __typename: "CreativeWorkHeadline",
+                        seo: "How Twitter Will Change as a Private Company Under Elon Musk",
+                    },
+                    commentProperties: {
+                        status: "NO_COMMENTS",
+                        __typename: "CreativeWorkCommentProperties",
+                        prompt: "",
+                        approvedCommentsCount: null,
+                    },
+                    firstPublished: "2022-10-28T09:00:25.000Z",
+                    lastModified: "2022-10-31T03:26:03.497Z",
+                    originalDesk: "Business",
+                    source: {
+                        id: "T3JnYW5pemF0aW9uOm55dDovL29yZ2FuaXphdGlvbi9jMjc5MTM4OC02YjE2LTVmZmQtYTExOS05NmVhY2IxOTg5YzE=",
+                        displayName: "New York Times",
+                        __typename: "Organization",
+                    },
+                    printInformation: {
+                        page: "1",
+                        section: "B",
+                        publicationDate: "2022-10-29T04:00:00.000Z",
+                        __typename: "PrintInformation",
+                    },
+                    sprinkled: {
+                        configs: [
+                            {
+                                name: "mobile",
+                                stride: 4,
+                                threshold: 3,
+                                __typename: "SprinkledConfig",
+                            },
+                            {
+                                name: "desktop",
+                                stride: 7,
+                                threshold: 3,
+                                __typename: "SprinkledConfig",
+                            },
+                            {
+                                name: "mobileHoldout",
+                                stride: 4,
+                                threshold: 2,
+                                __typename: "SprinkledConfig",
+                            },
+                            {
+                                name: "desktopHoldout",
+                                stride: 7,
+                                threshold: 2,
+                                __typename: "SprinkledConfig",
+                            },
+                            {
+                                name: "hybrid",
+                                stride: 4,
+                                threshold: 3,
+                                __typename: "SprinkledConfig",
+                            },
+                        ],
+                        __typename: "SprinkledContent",
+                    },
+                    column: null,
+                    dfpTaxonomyException: null,
+                    associatedNewsletter: null,
+                    advertisingProperties: {
+                        sensitivity: "SHOW_ADS",
+                        __typename: "CreativeWorkAdvertisingProperties",
+                    },
+                    translations: [],
+                    summary:
+                      "The social media company went public in 2013. But Elon Musk is taking it private as part of his acquisition of the firm. Here’s what that means.",
+                    lastMajorModification: "2022-10-28T18:54:00.000Z",
+                    uri: "nyt:\u002F\u002Farticle\u002F1d7bf428-be78-562f-9287-bdbdf47502a0",
+                    eventId:
+                      "pubp:\u002F\u002Fevent\u002F859041c3b72144faae00a2b948a91e8a",
+                    promotionalMedia: {
+                        id: "SW1hZ2U6bnl0Oi8vaW1hZ2UvOWQ2MjIzMWMtMGYwYi01NmVhLTlmMWYtYjQwNGU3NzUwZTE1",
+                        assetCrops: [
+                            {
+                                name: "MASTER",
+                                renditions: [
+                                    {
+                                        url: "https:\u002F\u002Fstatic01.nyt.com\u002Fimages\u002F2022\u002F10\u002F29\u002Fbusiness\u002F00jpTWITTER-PRIVATE2-print\u002Fmerlin_214496130_63f02e73-7e2f-47ef-9597-f0b9fc9d20c3-articleLarge.jpg",
+                                        height: 400,
+                                        width: 600,
+                                        name: "articleLarge",
+                                        __typename: "ImageRendition",
+                                    },
+                                    {
+                                        url: "https:\u002F\u002Fstatic01.nyt.com\u002Fimages\u002F2022\u002F10\u002F29\u002Fbusiness\u002F00jpTWITTER-PRIVATE2-print\u002Fmerlin_214496130_63f02e73-7e2f-47ef-9597-f0b9fc9d20c3-superJumbo.jpg",
+                                        height: 1365,
+                                        width: 2048,
+                                        name: "superJumbo",
+                                        __typename: "ImageRendition",
+                                    },
+                                ],
+                                __typename: "ImageCrop",
+                            },
+                            {
+                                name: "SMALL_SQUARE",
+                                renditions: [
+                                    {
+                                        url: "https:\u002F\u002Fstatic01.nyt.com\u002Fimages\u002F2022\u002F10\u002F29\u002Fbusiness\u002F00jpTWITTER-PRIVATE2-print\u002F00MUSK-TWITTER-thumbStandard.jpg",
+                                        height: 75,
+                                        width: 75,
+                                        name: "thumbStandard",
+                                        __typename: "ImageRendition",
+                                    },
+                                    {
+                                        url: "https:\u002F\u002Fstatic01.nyt.com\u002Fimages\u002F2022\u002F10\u002F29\u002Fbusiness\u002F00jpTWITTER-PRIVATE2-print\u002F00MUSK-TWITTER-thumbLarge.jpg",
+                                        height: 150,
+                                        width: 150,
+                                        name: "thumbLarge",
+                                        __typename: "ImageRendition",
+                                    },
+                                ],
+                                __typename: "ImageCrop",
+                            },
+                            {
+                                name: "MEDIUM_SQUARE",
+                                renditions: [
+                                    {
+                                        url: "https:\u002F\u002Fstatic01.nyt.com\u002Fimages\u002F2022\u002F10\u002F29\u002Fbusiness\u002F00jpTWITTER-PRIVATE2-print\u002F00MUSK-TWITTER-mediumSquareAt3X.jpg",
+                                        height: 1800,
+                                        width: 1800,
+                                        name: "mediumSquareAt3X",
+                                        __typename: "ImageRendition",
+                                    },
+                                ],
+                                __typename: "ImageCrop",
+                            },
+                            {
+                                name: "SIXTEEN_BY_NINE",
+                                renditions: [
+                                    {
+                                        url: "https:\u002F\u002Fstatic01.nyt.com\u002Fimages\u002F2022\u002F10\u002F29\u002Fbusiness\u002F00jpTWITTER-PRIVATE2-print\u002F00MUSK-TWITTER-videoSixteenByNine3000.jpg",
+                                        height: 1688,
+                                        width: 3000,
+                                        name: "videoSixteenByNine3000",
+                                        __typename: "ImageRendition",
+                                    },
+                                    {
+                                        url: "https:\u002F\u002Fstatic01.nyt.com\u002Fimages\u002F2022\u002F10\u002F29\u002Fbusiness\u002F00jpTWITTER-PRIVATE2-print\u002F00MUSK-TWITTER-videoSixteenByNineJumbo1600.jpg",
+                                        height: 900,
+                                        width: 1600,
+                                        name: "videoSixteenByNineJumbo1600",
+                                        __typename: "ImageRendition",
+                                    },
+                                ],
+                                __typename: "ImageCrop",
+                            },
+                            {
+                                name: "FACEBOOK",
+                                renditions: [
+                                    {
+                                        url: "https:\u002F\u002Fstatic01.nyt.com\u002Fimages\u002F2022\u002F10\u002F29\u002Fbusiness\u002F00jpTWITTER-PRIVATE2-print\u002F00MUSK-TWITTER-facebookJumbo.jpg",
+                                        height: 550,
+                                        width: 1050,
+                                        name: "facebookJumbo",
+                                        __typename: "ImageRendition",
+                                    },
+                                ],
+                                __typename: "ImageCrop",
+                            },
+                        ],
+                        caption: {
+                            text: "Elon Musk plans to change Twitter from a public to a privately held company.",
+                            __typename: "TextOnlyDocumentBlock",
+                        },
+                        __typename: "Image",
+                    },
+                    promotionalImage: {
+                        socialMediaRendition: {
+                            parentPublishDate: "2022-10-28T09:00:25.000Z",
+                            parentPublishYear: 2022,
+                            signature: {
+                                value:
+                                  "608110dd13dea3376d9c2c2eafc608b24c0243fe739dc5f291b3b4dff4af0116",
+                                keyId: "ZQJBKqZ0VN",
+                                __typename: "ImageSignature",
+                            },
+                            rendition: {
+                                name: "facebookJumbo",
+                                height: 550,
+                                width: 1050,
+                                url: "https:\u002F\u002Fstatic01.nyt.com\u002Fimages\u002F2022\u002F10\u002F29\u002Fbusiness\u002F00jpTWITTER-PRIVATE2-print\u002F00MUSK-TWITTER-facebookJumbo.jpg",
+                                __typename: "ImageRendition",
+                            },
+                            __typename: "SignableImageRendition",
+                        },
+                        twitterRendition: {
+                            parentPublishDate: "2022-10-28T09:00:25.000Z",
+                            parentPublishYear: 2022,
+                            signature: {
+                                value:
+                                  "411c0163d36e2635462319ccc6c3ff1512dbced664228237cf4d8ad6815088f6",
+                                keyId: "ZQJBKqZ0VN",
+                                __typename: "ImageSignature",
+                            },
+                            rendition: {
+                                name: "videoSixteenByNine3000",
+                                height: 1688,
+                                width: 3000,
+                                url: "https:\u002F\u002Fstatic01.nyt.com\u002Fimages\u002F2022\u002F10\u002F29\u002Fbusiness\u002F00jpTWITTER-PRIVATE2-print\u002F00MUSK-TWITTER-videoSixteenByNine3000.jpg",
+                                __typename: "ImageRendition",
+                            },
+                            __typename: "SignableImageRendition",
+                        },
+                        image: {
+                            id: "SW1hZ2U6bnl0Oi8vaW1hZ2UvOWQ2MjIzMWMtMGYwYi01NmVhLTlmMWYtYjQwNGU3NzUwZTE1",
+                            caption: {
+                                text: "Elon Musk plans to change Twitter from a public to a privately held company.",
+                                __typename: "TextOnlyDocumentBlock",
+                            },
+                            __typename: "Image",
+                        },
+                        __typename: "PromotionalImage",
+                    },
+                    slug: "28twitter-private",
+                    newsStatus: "DEFAULT",
+                    sourcePublisher: "scoop",
+                    episodeProperties: {
+                        episodeLabel: "",
+                        linksLeadIn: "",
+                        links: [],
+                        __typename: "ArticleEpisodeProperties",
+                    },
+                    reviewSummary: "",
+                    reviewItems: [],
+                    storylines: [
+                        {
+                            storyline: {
+                                uri: "nyt:\u002F\u002Fstoryline\u002F1a6f39b1-d67c-47a1-a51a-db0640037643",
+                                displayName: "Elon Musk’s Twitter Takeover",
+                                hubAssets: [],
+                                promotedLiveAssets: [],
+                                __typename: "Storyline",
+                                experimentalJsonBlob:
+                                  '{"data":[{"version":1,"type":"experimentalJsonBlob","data":[{"version":1,"type":"context","data":{"title":"Changes at Elon Musk’s Twitter","items":[{"subtitle":"A swift overhaul.","text":"Elon Musk has moved quickly to revamp Twitter since he completed his \u003Ca href=\\"https:\u002F\u002Fwww.nytimes.com\u002F2022\u002F11\u002F11\u002Ftechnology\u002Felon-musk-twitter-takeover.html\\"\u003E$44 billion buyout\u003C\u002Fa\u003E of the social media company in October, warning of a bleak financial picture and a need for new products. Here’s a look at some of the changes so far:"},{"subtitle":"Going private.","text":"As part of Mr. Musk’s acquisition of Twitter, he is delisting the company’s stock and taking it out of the hands of public shareholders. Making Twitter a private company \u003Ca href=\\"https:\u002F\u002Fwww.nytimes.com\u002F2022\u002F10\u002F28\u002Ftechnology\u002Ftwitter-changes.html\\"\u003Egives Mr. \u003C\u002Fa\u003E\u003Ca href=\\"https:\u002F\u002Fwww.nytimes.com\u002F2022\u002F10\u002F28\u002Ftechnology\u002Ftwitter-changes.html\\"\u003EMusk some\u003C\u002Fa\u003E\u003Ca href=\\"https:\u002F\u002Fwww.nytimes.com\u002F2022\u002F10\u002F28\u002Ftechnology\u002Ftwitter-changes.html\\"\u003E advantages\u003C\u002Fa\u003E, including not having to make quarterly financial disclosures. Private companies are also subject to less regulatory scrutiny."},{"subtitle":"Layoffs.","text":"Just over a week after closing the deal, Mr. Musk \u003Ca href=\\"https:\u002F\u002Fwww.nytimes.com\u002F2022\u002F11\u002F04\u002Ftechnology\u002Felon-musk-twitter-layoffs.html\\"\u003Eeliminated nearly half of Twitter’s \u003C\u002Fa\u003E\u003Ca href=\\"https:\u002F\u002Fwww.nytimes.com\u002F2022\u002F11\u002F04\u002Ftechnology\u002Felon-musk-twitter-layoffs.html\\"\u003Ework force\u003C\u002Fa\u003E, or about 3,700 jobs. The layoffs hit many divisions across the company, including the engineering and machine learning units, the teams that manage content moderation, and the sales and advertising departments."},{"subtitle":"Verification subscriptions.","text":"Twitter began charging customers \u003Ca href=\\"https:\u002F\u002Fwww.nytimes.com\u002F2022\u002F11\u002F05\u002Fbusiness\u002Ftwitter-verification-check-marks.html\\"\u003E$7.99 a month to receive a coveted verification check mark\u003C\u002Fa\u003E on their profiles. But the subscription service was paused after some users exploited it to \u003Ca href=\\"https:\u002F\u002Fwww.nytimes.com\u002F2022\u002F11\u002F11\u002Ftechnology\u002Ftwitter-blue-fake-accounts.html\\"\u003Ecreate havoc on the platform\u003C\u002Fa\u003E by pretending to be high-profile brands and sending disruptive tweets."},{"subtitle":"Content moderation.","text":"Shortly after closing the deal to buy Twitter, Mr. Musk said that the company would form a \u003Ca href=\\"https:\u002F\u002Fwww.nytimes.com\u002F2022\u002F10\u002F28\u002Ftechnology\u002Ftwitter-elon-musk-content-moderation.html\\"\u003Econtent moderation council\u003C\u002Fa\u003E to decide what kinds of posts to keep up and what to take down. But advertisers have \u003Ca href=\\"https:\u002F\u002Fwww.nytimes.com\u002F2022\u002F11\u002F04\u002Ftechnology\u002Ftwitter-advertisers.html\\"\u003Epaused their spending on Twitter\u003C\u002Fa\u003E over fears that Mr. Musk will loosen content rules on the platform."},{"subtitle":"Other possible changes.","text":"As Mr. Musk and his advisers look for ways to generate more revenue at the company, they are said to have discussed \u003Ca href=\\"https:\u002F\u002Fwww.nytimes.com\u002F2022\u002F11\u002F03\u002Ftechnology\u002Felon-musk-twitter-money-finances.html\\"\u003Eadding paid direct messages\u003C\u002Fa\u003E, which would let users send private messages to high-profile users. The company has also filed registration paperwork to pave the way for it to \u003Ca href=\\"https:\u002F\u002Fwww.nytimes.com\u002F2022\u002F11\u002F09\u002Ftechnology\u002Ftwitter-payments-business.html\\"\u003Eprocess payments\u003C\u002Fa\u003E."}]}},{"version":1,"type":"topLinks","data":{"title":"More on Elon Musk’s Twitter Takeover","imageUrl":"","leadIn":"","bulletedList":["\u003Cstrong\u003EAn Established Pattern:\u003C\u002Fstrong\u003E Firing people. Talking of bankruptcy. Telling workers to be “hard core.” Twitter isn’t the first company that witnessed Elon Musk \u003Ca href=\\"https:\u002F\u002Fwww.nytimes.com\u002F2022\u002F11\u002F21\u002Ftechnology\u002Felon-musk-twitter-management.html\\"\u003Euse those tactics\u003C\u002Fa\u003E.","\u003Cstrong\u003ETargeting Critics: \u003C\u002Fstrong\u003EAfter laying off \u003Ca href=\\"https:\u002F\u002Fwww.nytimes.com\u002F2022\u002F11\u002F04\u002Ftechnology\u002Felon-musk-twitter-layoffs.html\\"\u003Enearly half the company\u003C\u002Fa\u003E, Mr. Musk has continued cutting Twitter’s work force by \u003Ca href=\\"https:\u002F\u002Fwww.nytimes.com\u002F2022\u002F11\u002F15\u002Ftechnology\u002Felon-musk-twitter-fired-criticism.html\\"\u003Efiring employees who had criticized him\u003C\u002Fa\u003E.","\u003Cstrong\u003EOn the Edge: \u003C\u002Fstrong\u003EMr. Musk gave the employees still with the company \u003Ca href=\\"https:\u002F\u002Fwww.nytimes.com\u002F2022\u002F11\u002F18\u002Fbusiness\u002Fdealbook\u002Ftwitter-employees-quit-musk.html\\"\u003Ea deadline\u003C\u002Fa\u003E to decide whether to stay or leave. \u003Ca href=\\"https:\u002F\u002Fwww.nytimes.com\u002F2022\u002F11\u002F17\u002Ftechnology\u002Ftwitter-elon-musk-ftc.html\\"\u003EHundreds resigned\u003C\u002Fa\u003E, leading users to question \u003Ca href=\\"https:\u002F\u002Fwww.nytimes.com\u002F2022\u002F11\u002F18\u002Ftechnology\u002Felon-musk-twitter-workers-quit.html\\"\u003Ewhether the site would survive\u003C\u002Fa\u003E.","\u003Cstrong\u003EUnpaid Bills\u003C\u002Fstrong\u003E\u003Cstrong\u003E: \u003C\u002Fstrong\u003EMr. Musk and his advisers have scrutinized all types of costs at Twitter, instructing staff to review, renegotiate and in some cases \u003Ca href=\\"https:\u002F\u002Fwww.nytimes.com\u002F2022\u002F11\u002F22\u002Ftechnology\u002Felon-musk-twitter-cost-cutting.html\\"\u003Enot pay outside vendors at all\u003C\u002Fa\u003E."]}}]}]}',
+                                url: "https:\u002F\u002Fwww.nytimes.com\u002Fstoryline\u002F1a6f39b1-d67c-47a1-a51a-db0640037643",
+                                tone: "NEWS",
+                                primaryAssets: [
+                                    {
+                                        displayName: "Who Is Paying for Twitter?",
+                                        status: null,
+                                        asset: {
+                                            uri: "nyt:\u002F\u002Finteractive\u002F6605657a-f2a2-5cd8-b073-23b66fb20d91",
+                                            url: "https:\u002F\u002Fwww.nytimes.com\u002Finteractive\u002F2022\u002F11\u002F23\u002Ftechnology\u002Ftwitter-elon-musk-twitter-blue-check-verification.html",
+                                            __typename: "Interactive",
+                                            headline: {
+                                                default:
+                                                  "Adult Performers, Trump Supporters and Parodies: Who Is Paying for Twitter?",
+                                                __typename: "CreativeWorkHeadline",
+                                            },
+                                        },
+                                        __typename: "StorylinePrimaryAsset",
+                                    },
+                                    {
+                                        displayName: "Inside the Takeover",
+                                        status: null,
+                                        asset: {
+                                            uri: "nyt:\u002F\u002Farticle\u002Fdf79aa79-be2d-5340-a41a-9089ff237fd6",
+                                            url: "https:\u002F\u002Fwww.nytimes.com\u002F2022\u002F11\u002F11\u002Ftechnology\u002Felon-musk-twitter-takeover.html",
+                                            __typename: "Article",
+                                            headline: {
+                                                default:
+                                                  "Two Weeks of Chaos: Inside Elon Musk’s Takeover of Twitter",
+                                                __typename: "CreativeWorkHeadline",
+                                            },
+                                        },
+                                        __typename: "StorylinePrimaryAsset",
+                                    },
+                                    {
+                                        displayName: "Twitter’s Essential Workers",
+                                        status: null,
+                                        asset: {
+                                            uri: "nyt:\u002F\u002Farticle\u002Fdf330977-b3b9-5a6c-88dd-abb065dad23b",
+                                            url: "https:\u002F\u002Fwww.nytimes.com\u002F2022\u002F11\u002F18\u002Ftechnology\u002Ftwitter-employees-needed.html",
+                                            __typename: "Article",
+                                            headline: {
+                                                default:
+                                                  "What Employees Does Twitter Need, Anyway?",
+                                                __typename: "CreativeWorkHeadline",
+                                            },
+                                        },
+                                        __typename: "StorylinePrimaryAsset",
+                                    },
+                                    {
+                                        displayName: "Download Your Twitter Data",
+                                        status: null,
+                                        asset: {
+                                            uri: "nyt:\u002F\u002Farticle\u002F1cfa9eee-34b6-5182-80f2-08a6266fd88a",
+                                            url: "https:\u002F\u002Fwww.nytimes.com\u002F2022\u002F11\u002F18\u002Ftechnology\u002Fhow-to-download-your-twitter-archive.html",
+                                            __typename: "Article",
+                                            headline: {
+                                                default: "How to Download Your Twitter Archive",
+                                                __typename: "CreativeWorkHeadline",
+                                            },
+                                        },
+                                        __typename: "StorylinePrimaryAsset",
+                                    },
+                                ],
+                            },
+                            __typename: "AssociatedStoryline",
+                            ruleName: "styln-elon-musk",
+                            testName: "",
+                        },
+                        {
+                            storyline: {
+                                uri: "nyt:\u002F\u002Fstoryline\u002Fc54a136c-1420-4022-b3ce-ef87aafe7354",
+                                displayName: "Elon Musk",
+                                hubAssets: [],
+                                promotedLiveAssets: [],
+                                __typename: "Storyline",
+                                experimentalJsonBlob:
+                                  '{"data":[{"version":1,"type":"experimentalJsonBlob","data":[{"version":1,"type":"guide","data":{"title":"The World of Elon Musk","leadIn":"The billionaire’s story includes the world’s most valuable automaker, an innovative rocket company and plenty of drama in his personal and professional life.","sections":[{"section":[{"type":"bulletedList","value":["\u003Cstrong\u003ETwitter:\u003C\u002Fstrong\u003E The billionaire \u003Ca href=\\"https:\u002F\u002Fwww.nytimes.com\u002F2022\u002F11\u002F16\u002Ftechnology\u002Felon-musk-twitter-employee-deadline.html\\"\u003Ehas been unrelenting\u003C\u002Fa\u003E in \u003Ca href=\\"https:\u002F\u002Fwww.nytimes.com\u002F2022\u002F11\u002F11\u002Ftechnology\u002Felon-musk-twitter-takeover.html\\"\u003Erapidly transforming Twitter\u003C\u002Fa\u003E since completing his $44 billion acquisition of the company.\u003Cstrong\u003E \u003C\u002Fstrong\u003EBut \u003Ca href=\\"https:\u002F\u002Fwww.nytimes.com\u002F2022\u002F11\u002F14\u002Fbusiness\u002Fmedia\u002Ftwitter-users-confessions.html\\"\u003Emany fear the platform’s days might be numbered\u003C\u002Fa\u003E.","\u003Cstrong\u003EAn Established Pattern:\u003C\u002Fstrong\u003E Firing people. Talking of bankruptcy. Telling workers to be “hard core.” Twitter isn’t the first company that witnessed Elon Musk \u003Ca href=\\"https:\u002F\u002Fwww.nytimes.com\u002F2022\u002F11\u002F21\u002Ftechnology\u002Felon-musk-twitter-management.html\\"\u003Euse those tactics\u003C\u002Fa\u003E.","\u003Cstrong\u003E‘Elon Musk’s Crash Course’: \u003C\u002Fstrong\u003EWatch an episode of “The New York Times Presents” on the challenges Mr. Musk faces \u003Ca href=\\"https:\u002F\u002Fwww.nytimes.com\u002Fvideo\u002FNYT-Presents\u002F100000008464087\u002Fthe-new-york-times-presents-elon-musks-crash-course.html\\"\u003Ein making automated driving a reality\u003C\u002Fa\u003E.","\u003Cstrong\u003ESpaceX: \u003C\u002Fstrong\u003ECharges filed with federal regulators \u003Ca href=\\"https:\u002F\u002Fwww.nytimes.com\u002F2022\u002F11\u002F17\u002Fbusiness\u002Fspacex-workers-elon-musk.html\\"\u003Eaccused the company of retaliating\u003C\u002Fa\u003E against eight workers over an open letter critical of Mr. Musk, raising new questions about the management practices at his companies.","\u003Cstrong\u003EX Factor: \u003C\u002Fstrong\u003EThe letter X \u003Ca href=\\"https:\u002F\u002Fwww.nytimes.com\u002F2022\u002F10\u002F06\u002Ftechnology\u002Felon-musk-x.html\\"\u003Ehas been a recurring theme\u003C\u002Fa\u003E in Mr. Musk’s life, from his early days as an entrepreneur to his current pursuit of Twitter.","\u003Cstrong\u003EAn Eclectic Social Calendar\u003C\u002Fstrong\u003E\u003Cstrong\u003E: \u003C\u002Fstrong\u003EWhen he isn’t tweeting, Mr. Musk is \u003Ca href=\\"https:\u002F\u002Fwww.nytimes.com\u002F2022\u002F10\u002F11\u002Fstyle\u002Felon-musk-social-calendar.html\\"\u003Eflying to Burning Man, trying to impress comedians and hopping on yachts\u003C\u002Fa\u003E."]}]}]}}]}]}',
+                                url: "https:\u002F\u002Fwww.nytimes.com\u002Fstoryline\u002Fc54a136c-1420-4022-b3ce-ef87aafe7354",
+                                tone: "NEWS",
+                                primaryAssets: [],
+                            },
+                            __typename: "AssociatedStoryline",
+                            ruleName: "styln-elon-musk-general",
+                            testName: "",
+                        },
+                        {
+                            storyline: {
+                                uri: "nyt:\u002F\u002Fstoryline\u002Fadbd0bee-ba66-4ac1-9244-efa83da6322f",
+                                displayName: "Big Tech",
+                                hubAssets: [],
+                                promotedLiveAssets: [],
+                                __typename: "Storyline",
+                                experimentalJsonBlob:
+                                  '{"data":[{"version":1,"type":"experimentalJsonBlob","data":[{"version":1,"type":"topLinks","data":{"title":"More on Big Tech","imageUrl":"","leadIn":"","bulletedList":["\u003Cstrong\u003EMicrosoft: \u003C\u002Fstrong\u003EThe company’s $69 billion deal for Activision Blizzard, which rests on winning the approval by 16 governments, \u003Ca href=\\"https:\u002F\u002Fwww.nytimes.com\u002F2022\u002F11\u002F21\u002Ftechnology\u002Fmicrosoft-activision-deal.html\\"\u003Ehas become a test\u003C\u002Fa\u003E for whether tech giants can buy companies amid a backlash.","\u003Cstrong\u003EApple: \u003C\u002Fstrong\u003EApple’s largest iPhone factory, in the city of Zhengzhou, China, is dealing with a shortage of workers. Now, that plant \u003Ca href=\\"https:\u002F\u002Fwww.nytimes.com\u002F2022\u002F11\u002F18\u002Fbusiness\u002Fapple-foxconn-china.html\\"\u003Eis getting help from an unlikely source\u003C\u002Fa\u003E: the Chinese government.","\u003Cstrong\u003EAmazon:\u003C\u002Fstrong\u003E The company appears set to \u003Ca href=\\"https:\u002F\u002Fwww.nytimes.com\u002F2022\u002F11\u002F14\u002Ftechnology\u002Famazon-layoffs.html\\"\u003Elay off approximately 10,000 people in corporate and technology jobs\u003C\u002Fa\u003E, in what would be the largest cuts in the company’s history.","\u003Cstrong\u003EMeta: \u003C\u002Fstrong\u003EThe parent of Facebook said it was \u003Ca href=\\"https:\u002F\u002Fwww.nytimes.com\u002F2022\u002F11\u002F09\u002Ftechnology\u002Fmeta-layoffs-facebook.html\\"\u003Elaying off more than 11,000 people\u003C\u002Fa\u003E, or about 13 percent of its work force"]}}]}]}',
+                                url: "https:\u002F\u002Fwww.nytimes.com\u002Fstoryline\u002Fadbd0bee-ba66-4ac1-9244-efa83da6322f",
+                                tone: null,
+                                primaryAssets: [],
+                            },
+                            __typename: "AssociatedStoryline",
+                            ruleName: "styln-big-tech",
+                            testName: "",
+                        },
+                    ],
+                    associatedAssets: [],
+                },
+            },
+        },
+        initialState: {},
+        config: {
+            gqlUrlClient:
+              "https:\u002F\u002Fsamizdat-graphql.nytimes.com\u002Fgraphql\u002Fv2",
+            gqlRequestHeaders: {
+                "nyt-app-type": "project-vi",
+                "nyt-app-version": "0.0.5",
+                "nyt-token":
+                  "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAs+\u002FoUCTBmD\u002FcLdmcecrnBMHiU\u002FpxQCn2DDyaPKUOXxi4p0uUSZQzsuq1pJ1m5z1i0YGPd1U1OeGHAChWtqoxC7bFMCXcwnE1oyui9G1uobgpm1GdhtwkR7ta7akVTcsF8zxiXx7DNXIPd2nIJFH83rmkZueKrC4JVaNzjvD+Z03piLn5bHWU6+w+rA+kyJtGgZNTXKyPh6EC6o5N+rknNMG5+CdTq35p8f99WjFawSvYgP9V64kgckbTbtdJ6YhVP58TnuYgr12urtwnIqWP9KSJ1e5vmgf3tunMqWNm6+AnsqNj8mCLdCuc5cEB74CwUeQcP2HQQmbCddBy2y0mEwIDAQAB",
+            },
+            gqlFetchTimeout: 1500,
+            disablePersistedQueries: false,
+            fastlyHeaders: {},
+            initialDeviceType: "desktop",
+            fastlyAbraConfig: {
+                ".ver": "10910.000",
+                HOME_chartbeat: "0_Control",
+                INT_cwv_dfp_deferAds_0322: "",
+                MX_NewArchitecture_gamesLP: "0_Control",
+            },
+            internalPreviewConfig: { meter: undefined, swg: undefined },
+            webviewEnvironment: { isInWebview: false },
+            serviceWorkerFile: "service-worker-test-1669657616122.js",
+        },
+        ssrQuery: {},
+        initialLocation: {
+            pathname:
+              "\u002F2022\u002F10\u002F28\u002Ftechnology\u002Ftwitter-changes.html",
+            search: "",
+        },
+    };
+</script>
+
+<script>
+    !(function (e) {
+        function a(a) {
+            for (
+              var d, n, o = a[0], b = a[1], s = a[2], i = 0, l = [];
+              i < o.length;
+              i++
+            )
+                (n = o[i]),
+                Object.prototype.hasOwnProperty.call(r, n) &&
+                r[n] &&
+                l.push(r[n][0]),
+                  (r[n] = 0);
+            for (d in b)
+                Object.prototype.hasOwnProperty.call(b, d) && (e[d] = b[d]);
+            for (f && f(a); l.length; ) l.shift()();
+            return t.push.apply(t, s || []), c();
+        }
+        function c() {
+            for (var e, a = 0; a < t.length; a++) {
+                for (var c = t[a], d = !0, o = 1; o < c.length; o++) {
+                    var b = c[o];
+                    0 !== r[b] && (d = !1);
+                }
+                d && (t.splice(a--, 1), (e = n((n.s = c[0]))));
+            }
+            return e;
+        }
+        var d = {},
+          r = { 97: 0 },
+          t = [];
+        function n(a) {
+            if (d[a]) return d[a].exports;
+            var c = (d[a] = { i: a, l: !1, exports: {} });
+            return e[a].call(c.exports, c, c.exports, n), (c.l = !0), c.exports;
+        }
+        (n.e = function (e) {
+            var a = [],
+              c = r[e];
+            if (0 !== c)
+                if (c) a.push(c[2]);
+                else {
+                    var d = new Promise(function (a, d) {
+                        c = r[e] = [a, d];
+                    });
+                    a.push((c[2] = d));
+                    var t,
+                      o = document.createElement("script");
+                    (o.charset = "utf-8"),
+                      (o.timeout = 120),
+                    n.nc && o.setAttribute("nonce", n.nc),
+                      (o.src = (function (e) {
+                          return (
+                            n.p +
+                            "" +
+                            ({
+                                0: "vendor",
+                                1: "vendors~audio~bestsellers~byline~capsule~collections~explainer~home~liveAsset~markets~paidpost~revie~4a3ef3d2",
+                                2: "vendors~audio~byline~capsule~clientSideCapsule~collections~explainer~liveAsset~paidpost~slideshow~st~5ec95911",
+                                3: "vendors~audio~capsule~card~clientSideCapsule~collections~explainer~home~liveAsset~paidpost~story~tre~698cb9e2",
+                                5: "bestsellers~gamesLandingPage~markets~privacy~reviews~search~timeswire~trending~weddings",
+                                6: "account~activateaccess~newslettersmanage~newslettersoptout~newslettersreengagement",
+                                7: "bestsellers~markets~reviews~trending~your-list",
+                                8: "freeaccess~getstarted~newsletter~welcomeBannerRecirculationBlock~welcomesubscriber",
+                                9: "vendors~clientSideCapsule~newsletter~newsletters~newsletterssubscriberonly~recirculation",
+                                10: "vendors~byline~card~timeswire~your-list",
+                                11: "freeaccess~getstarted~welcomesubscriber",
+                                12: "getstarted~postLoginInterrupter~welcomesubscriber",
+                                13: "vendors~newsletter~newsletters~newsletterssubscriberonly",
+                                15: "coderedeem~freeaccess",
+                                16: "newslettersmanage",
+                                17: "newsletters~recirculation",
+                                18: "vendors~commentsForm~weddings",
+                                19: "vendors~explainerRecirculation~liveRecirculation",
+                                22: "ChineseHanLogo",
+                                23: "DealbookLogo",
+                                24: "InsiderLogo",
+                                25: "Rio2016",
+                                26: "TMagazineLogo",
+                                27: "UpshotLogo",
+                                28: "WorldCupLogo2018",
+                                29: "account",
+                                30: "activateaccess",
+                                31: "additionalPlaylists",
+                                33: "ask",
+                                34: "audio",
+                                35: "audioblock",
+                                36: "bestsellers",
+                                37: "blank",
+                                38: "bonusredemption",
+                                39: "byline",
+                                40: "canadaHamburgerNavData",
+                                41: "canadaSiteIndexData",
+                                42: "capsule",
+                                43: "card",
+                                44: "clientSideCapsule",
+                                45: "coderedeem",
+                                46: "collections",
+                                47: "comments",
+                                48: "commentsForm",
+                                49: "datasubjectrequest",
+                                50: "datasubjectrequestverification",
+                                51: "dealbook",
+                                52: "defaultHamburgerNavData",
+                                53: "defaultSiteIndexData",
+                                54: "desktopNav",
+                                55: "emailsignup",
+                                56: "episodefooter",
+                                57: "explainer",
+                                58: "explainerPostHeader",
+                                59: "explainerRecirculation",
+                                60: "foo",
+                                61: "footerBlock",
+                                62: "freeaccess",
+                                63: "gamesLandingPage",
+                                64: "getstarted",
+                                65: "headerfullbleedhorizontal",
+                                66: "headerfullbleedvertical",
+                                67: "headerlivebriefingvi",
+                                68: "home",
+                                70: "internationalHamburgerNavData",
+                                71: "internationalSiteIndexData",
+                                72: "lens",
+                                73: "liveAsset",
+                                74: "livePostHeader",
+                                75: "liveRecirculation",
+                                77: "markets",
+                                78: "mortgagecalculator",
+                                79: "newsletter",
+                                80: "newsletterRecirculation",
+                                81: "newsletters",
+                                82: "newslettersoptout",
+                                83: "newslettersreengagement",
+                                84: "newsletterssubscriberonly",
+                                85: "opinion",
+                                86: "paidpost",
+                                87: "phone-number-input",
+                                88: "postLoginInterrupter",
+                                89: "privacy",
+                                90: "producernotes",
+                                91: "recirculation",
+                                92: "related-coverage-chunk",
+                                93: "reviewheader",
+                                94: "reviews",
+                                98: "search",
+                                99: "siteIndexContent",
+                                100: "sitemap",
+                                101: "slideshow",
+                                102: "slideshowinline",
+                                103: "stickyfilljs",
+                                104: "story",
+                                105: "surveywithdrawconsent",
+                                106: "timeswire",
+                                107: "trending",
+                                108: "upshot",
+                                110: "vendors~LiveAlertsToggle",
+                                111: "vendors~ask",
+                                112: "vendors~audioblock",
+                                113: "vendors~card",
+                                114: "vendors~charlatan-select",
+                                115: "vendors~datasubjectrequest",
+                                116: "vendors~emailsignup",
+                                117: "vendors~episodefooter",
+                                118: "vendors~footerBlock",
+                                119: "vendors~headerfullbleedhorizontal",
+                                120: "vendors~home",
+                                121: "vendors~mortgagecalculator",
+                                122: "vendors~phone-number-input",
+                                123: "vendors~producernotes",
+                                124: "vendors~recirculation",
+                                125: "vendors~reviewheader",
+                                126: "vendors~search",
+                                127: "vendors~slideshow",
+                                128: "vendors~slideshowinline",
+                                129: "vendors~videoblock",
+                                130: "vendors~weddings",
+                                131: "vendors~well",
+                                132: "video",
+                                133: "videoblock",
+                                134: "weddings",
+                                135: "welcomeBannerRecirculationBlock",
+                                136: "welcomesubscriber",
+                                137: "well",
+                                138: "world-cup-2019",
+                                139: "your-list",
+                            }[e] || e) +
+                            "-" +
+                            {
+                                0: "08c1b617cd319b136ad1",
+                                1: "9b11509cafd2f7cd8e1b",
+                                2: "824144bf9c921d79b374",
+                                3: "3fafe57b731fc315298f",
+                                4: "4d8375d048856708ca58",
+                                5: "cb4b51b6bd02afdb8165",
+                                6: "6a40a50725dc3a22987f",
+                                7: "623507284e9af3ec6a98",
+                                8: "6c47bb22c89bd73bacbc",
+                                9: "e89531b09834a532264c",
+                                10: "18cae75174080ebf011f",
+                                11: "14678562a0c7db153287",
+                                12: "8ec19c749f9ea59634f0",
+                                13: "d5c0494d72437f887421",
+                                14: "cce45083cf6cd976c19f",
+                                15: "606a3049dbd6c7aba17d",
+                                16: "9d778b1fc81be713f495",
+                                17: "3abd4b16a64733a36e78",
+                                18: "3fabeef5a9d485b694dd",
+                                19: "5eb1ca68787cedbf3df8",
+                                20: "a23eca038f75eff69ea4",
+                                21: "db63c677eed63a8cc65c",
+                                22: "8475272d2007394b2f87",
+                                23: "7f40907d99da9196a1b5",
+                                24: "0c3023780cb766b27e69",
+                                25: "40b8aa9a965510bc4901",
+                                26: "7bce9c1040172314fa83",
+                                27: "69093bffaa4d1f49c8e3",
+                                28: "e70999b0563117b55e16",
+                                29: "11b333adfb701f3e0ab5",
+                                30: "3981188880ff2e7889bd",
+                                31: "7eff51602c5c6bb1d67c",
+                                33: "cc06de631db2e7a43b2e",
+                                34: "ae896fc1fe2b90f95003",
+                                35: "a0bb046d77694b5f0e00",
+                                36: "44755f1fc1b046ed4242",
+                                37: "f1d12341635e7b939322",
+                                38: "6834dcea2fc8cd4190ab",
+                                39: "9c7f48fba9259655d60f",
+                                40: "6651ed8361c8daa5215a",
+                                41: "ec72794ae82c48f8039e",
+                                42: "4b96a6da90a692d1ee74",
+                                43: "dc0e45cc000bf00ca5ba",
+                                44: "e7c968aaf31e7ac91629",
+                                45: "f69d27a5a019333980d3",
+                                46: "675c0553c9fa77b7dbe4",
+                                47: "ae5d58260b72c642d7aa",
+                                48: "2f898b0f440a93228ad1",
+                                49: "6cbdbe8b9fdf1f91ccc4",
+                                50: "efdbfecf4dabdc81f34c",
+                                51: "5333b7823f0a1ab20fab",
+                                52: "e78a4cd860148813bbf5",
+                                53: "3974cc4fdfeef1196cf0",
+                                54: "f511f399e486c8fc38b6",
+                                55: "4ef12b9c69f75d793ea4",
+                                56: "3fe0719f2da2bd356bc9",
+                                57: "3aa8458818bed54bddd2",
+                                58: "1f9be12bc3dd5cc795a7",
+                                59: "f1cec09e98b2e31a6a72",
+                                60: "4837c2ef79bc98d487ab",
+                                61: "83a1eb4ec6077c6c0ba0",
+                                62: "fbe9927f5e985f1b757f",
+                                63: "340ea5884b5ee8904263",
+                                64: "33e0b81e63d4f9fe5a91",
+                                65: "c50c7b812407402d1f27",
+                                66: "08de6e708e3ac99f0daa",
+                                67: "44d716cacfca7573ab77",
+                                68: "e694662c584671533b2a",
+                                70: "655d4abfb0a02aec1648",
+                                71: "f9472fb9dac46c7f1470",
+                                72: "7b6681f03644a1caf24e",
+                                73: "4ca2bfa3550c1b55c2a6",
+                                74: "e77bc02f8aef73e20aa2",
+                                75: "73eb5c48693a91bcbc42",
+                                77: "c6b85b71c60b0782e72b",
+                                78: "9ea201d46420b82a563a",
+                                79: "b279cd513ae53c2b86b1",
+                                80: "e1e17a850e5b04a1ac84",
+                                81: "977d5f71af2a3db6a36d",
+                                82: "407bcd4624fb9e0abf6c",
+                                83: "9fd96d707a5a2b25ed71",
+                                84: "e8aae4eba7eda8afcf3a",
+                                85: "812d625b4454691bcc69",
+                                86: "4ec17e6a17bc621c3084",
+                                87: "b940c8af2586281a06c2",
+                                88: "c232aface5485a3e5a51",
+                                89: "cb7857962e714c322316",
+                                90: "1b713d826d2299c27125",
+                                91: "9352ab078918c397fd0f",
+                                92: "98c09b0c2af5f91241a4",
+                                93: "c885ae598deedab8f435",
+                                94: "4b2d861464aec135a235",
+                                98: "f19521a22a853bc79aca",
+                                99: "9ce6b149822c6ba4d2a9",
+                                100: "d918a5fddb5e9bf30a2b",
+                                101: "4653491560d9237daa36",
+                                102: "9b8d44008920c5bfd869",
+                                103: "614675f9956efb694826",
+                                104: "9beb46cfaf777792b97f",
+                                105: "1495d5fa7164e2e49da4",
+                                106: "f09d0a7d71a83c76d586",
+                                107: "584534ca12234a8a2481",
+                                108: "7da04faad21e86ce34f8",
+                                110: "6465ee4e7223ebfd37f8",
+                                111: "22d1fa211eb0f3741e88",
+                                112: "cec1c304a25c4e5d1f1d",
+                                113: "c4b3d33ccc6d0d507ad7",
+                                114: "7898fbe324e0ed97e153",
+                                115: "fda89e8a05793c2dba31",
+                                116: "2378a6edbcb8e8db6a7c",
+                                117: "72f21321dc8abb0cafa7",
+                                118: "ea6a0e0eab49969d8939",
+                                119: "ca864bacfcef1b71bc90",
+                                120: "c71d72d426b77f98130a",
+                                121: "8780a7b5c13de2b3a5f0",
+                                122: "97ec2aa940d1d21a197f",
+                                123: "4a07dbf878d8b9ea7540",
+                                124: "9296993a1375918a538d",
+                                125: "f8503b3532c17cd93657",
+                                126: "1f78daa0f3c5a4bacd9c",
+                                127: "9606793d560cedd917a1",
+                                128: "1887beac92feeac9b17f",
+                                129: "fdab84822cb9fd619bd9",
+                                130: "ca84cf1e21009cd47df6",
+                                131: "54c39118bb40234366e5",
+                                132: "4cae5ecd902c2e71e0a2",
+                                133: "e8293c3086e406dc5227",
+                                134: "6937ca437822b68653fe",
+                                135: "d5ae5ce8f07779d8d074",
+                                136: "77904e86d2b3249e358f",
+                                137: "5dd286bacdd6184cf85b",
+                                138: "d0fa6686ad0c1f4f724e",
+                                139: "279538bc2f0efb2a2c77",
+                                140: "5692fdff46702acc8dec",
+                                141: "48638fa29a71b709f61b",
+                                142: "66537b0ccd97eaa86868",
+                                143: "c7a659dba2f8a0f2ab66",
+                                144: "dde88ce3d058730caebe",
+                                145: "583ae58f5757d716ae8a",
+                                146: "0e8940391c723da9df65",
+                                147: "d796f48144df653445dc",
+                                148: "68234c5b941c139cd0f9",
+                                149: "7aeca0cebe05b8740682",
+                                150: "4095ced5eee0bc721178",
+                                151: "030f8e0a26a95a62b709",
+                            }[e] +
+                            ".js"
+                          );
+                      })(e));
+                    var b = new Error();
+                    t = function (a) {
+                        (o.onerror = o.onload = null), clearTimeout(s);
+                        var c = r[e];
+                        if (0 !== c) {
+                            if (c) {
+                                var d = a && ("load" === a.type ? "missing" : a.type),
+                                  t = a && a.target && a.target.src;
+                                (b.message =
+                                  "Loading chunk " +
+                                  e +
+                                  " failed.\n(" +
+                                  d +
+                                  ": " +
+                                  t +
+                                  ")"),
+                                  (b.name = "ChunkLoadError"),
+                                  (b.type = d),
+                                  (b.request = t),
+                                  c[1](b);
+                            }
+                            r[e] = void 0;
+                        }
+                    };
+                    var s = setTimeout(function () {
+                        t({ type: "timeout", target: o });
+                    }, 12e4);
+                    (o.onerror = o.onload = t), document.head.appendChild(o);
+                }
+            return Promise.all(a);
+        }),
+          (n.m = e),
+          (n.c = d),
+          (n.d = function (e, a, c) {
+              n.o(e, a) ||
+              Object.defineProperty(e, a, { enumerable: !0, get: c });
+          }),
+          (n.r = function (e) {
+              "undefined" != typeof Symbol &&
+              Symbol.toStringTag &&
+              Object.defineProperty(e, Symbol.toStringTag, { value: "Module" }),
+                Object.defineProperty(e, "__esModule", { value: !0 });
+          }),
+          (n.t = function (e, a) {
+              if ((1 & a && (e = n(e)), 8 & a)) return e;
+              if (4 & a && "object" == typeof e && e && e.__esModule) return e;
+              var c = Object.create(null);
+              if (
+                (n.r(c),
+                  Object.defineProperty(c, "default", { enumerable: !0, value: e }),
+                2 & a && "string" != typeof e)
+              )
+                  for (var d in e)
+                      n.d(
+                        c,
+                        d,
+                        function (a) {
+                            return e[a];
+                        }.bind(null, d)
+                      );
+              return c;
+          }),
+          (n.n = function (e) {
+              var a =
+                e && e.__esModule
+                  ? function () {
+                      return e.default;
+                  }
+                  : function () {
+                      return e;
+                  };
+              return n.d(a, "a", a), a;
+          }),
+          (n.o = function (e, a) {
+              return Object.prototype.hasOwnProperty.call(e, a);
+          }),
+          (n.p = "/vi-assets/static-assets/"),
+          (n.oe = function (e) {
+              throw (console.error(e), e);
+          });
+        var o = (window.webpackJsonp = window.webpackJsonp || []),
+          b = o.push.bind(o);
+        (o.push = a), (o = o.slice());
+        for (var s = 0; s < o.length; s++) a(o[s]);
+        var f = b;
+        c();
+    })([]);
+    //# sourceMappingURL=runtime~main-ee1cc717ad72a198f73a.js.map
+</script>
+<script
+  defer
+  src="/vi-assets/static-assets/vendor-08c1b617cd319b136ad1.js"
+></script>
+<script
+  defer
+  src="/vi-assets/static-assets/story-9beb46cfaf777792b97f.js"
+></script>
+<script
+  defer
+  src="/vi-assets/static-assets/collections-675c0553c9fa77b7dbe4.js"
+></script>
+<script
+  defer
+  src="/vi-assets/static-assets/liveAsset-4ca2bfa3550c1b55c2a6.js"
+></script>
+<script
+  defer
+  src="/vi-assets/static-assets/main-e2dd0c472d8e0ec4ed6d.js"
+></script>
+<script>
+    (function () {
+        var _f = function () {
+            try {
+                var e = [
+                    "first-paint",
+                    "first-contentful-paint",
+                    "userBtnRender",
+                    "appRenderTime",
+                ];
+                new window.PerformanceObserver(function (r) {
+                    for (var n = r.getEntries(), a = 0; a < n.length; a += 1) {
+                        var t = n[a];
+                        if (e.indexOf(t.name) > -1) {
+                            var i = {};
+                            (i[t.name] = Math.round(t.duration || t.startTime)),
+                              (window.dataLayer = window.dataLayer || []).push({
+                                  event: "performance",
+                                  pageview: { performance: i },
+                              });
+                        }
+                    }
+                }).observe({ entryTypes: ["mark", "measure", "paint"] });
+            } catch (e) {}
+        };
+        _f.apply(null, []);
+    })();
+    (function () {
+        var _f = function () {
+            !(function () {
+                if (
+                  1 === Math.floor(20 * Math.random()) &&
+                  (!window.BOOMR ||
+                    (!window.BOOMR.version && !window.BOOMR.snippetExecuted))
+                ) {
+                    (window.BOOMR = window.BOOMR || {}),
+                      (window.BOOMR.snippetStart = new Date().getTime()),
+                      (window.BOOMR.snippetExecuted = !0),
+                      (window.BOOMR.snippetVersion = 14),
+                      (window.BOOMR.url =
+                        "https://s.go-mpulse.net/boomerang/ATH8A-MAMN8-XPXCH-N5KAX-8D239");
+                    var e = (
+                        document.currentScript ||
+                        document.getElementsByTagName("script")[0]
+                      ).parentNode,
+                      n = !1,
+                      t = document.createElement("link");
+                    t.relList &&
+                    "function" == typeof t.relList.supports &&
+                    t.relList.supports("preload") &&
+                    "as" in t
+                      ? ((window.BOOMR.snippetMethod = "p"),
+                        (t.href = window.BOOMR.url),
+                        (t.rel = "preload"),
+                        (t.as = "script"),
+                        t.addEventListener("load", function () {
+                            if (!n) {
+                                var t = document.createElement("script");
+                                (t.id = "boomr-scr-as"),
+                                  (t.src = window.BOOMR.url),
+                                  (t.async = !0),
+                                  e.appendChild(t),
+                                  (n = !0);
+                            }
+                        }),
+                        t.addEventListener("error", function () {
+                            o(!0);
+                        }),
+                        setTimeout(function () {
+                            n || o(!0);
+                        }, 3e3),
+                        (BOOMR_lstart = new Date().getTime()),
+                        e.appendChild(t))
+                      : o(!1),
+                      window.addEventListener
+                        ? window.addEventListener("load", i, !1)
+                        : window.attachEvent && window.attachEvent("onload", i);
+                }
+                function o(t) {
+                    n = !0;
+                    var o,
+                      i,
+                      d,
+                      a,
+                      r = document,
+                      s = window;
+                    if (
+                      ((window.BOOMR.snippetMethod = t ? "if" : "i"),
+                        (i = function (e, n) {
+                            var t = r.createElement("script");
+                            (t.id = n || "boomr-if-as"),
+                              (t.src = window.BOOMR.url),
+                              (BOOMR_lstart = new Date().getTime()),
+                              (e = e || r.body).appendChild(t);
+                        }),
+                      !window.addEventListener &&
+                      window.attachEvent &&
+                      navigator.userAgent.match(/MSIE [67]./))
+                    )
+                        return (
+                          (window.BOOMR.snippetMethod = "s"), void i(e, "boomr-async")
+                        );
+                    ((d = document.createElement("IFRAME")).src = "about:blank"),
+                      (d.title = ""),
+                      (d.role = "presentation"),
+                      (d.loading = "eager"),
+                      ((a = (d.frameElement || d).style).width = 0),
+                      (a.height = 0),
+                      (a.border = 0),
+                      (a.display = "none"),
+                      e.appendChild(d);
+                    try {
+                        (s = d.contentWindow), (r = s.document.open());
+                    } catch (e) {
+                        (o = document.domain),
+                          (d.src =
+                            "javascript:var d=document.open();d.domain='" +
+                            o +
+                            "';void 0;"),
+                          (s = d.contentWindow),
+                          (r = s.document.open());
+                    }
+                    o
+                      ? ((r._boomrl = function () {
+                          (this.domain = o), i();
+                      }),
+                        r.write("<body onload='document._boomrl();'>"))
+                      : ((s._boomrl = function () {
+                          i();
+                      }),
+                        s.addEventListener
+                          ? s.addEventListener("load", s._boomrl, !1)
+                          : s.attachEvent && s.attachEvent("onload", s._boomrl)),
+                      r.close();
+                }
+                function i(e) {
+                    window.BOOMR_onload = (e && e.timeStamp) || new Date().getTime();
+                }
+            })();
+        };
+        _f.apply(null, []);
+    })();
+</script>
+
+<script>
+    (function () {
+        if (document.cookie.indexOf("NYT-S") === -1) {
+            var iframe = document.createElement("iframe");
+            iframe.height = 0;
+            iframe.width = 0;
+            iframe.style.display = "none";
+            iframe.style.visibility = "hidden";
+            iframe.src = "https://myaccount.nytimes.com/auth/prefetch-assets";
+            document.body.appendChild(iframe);
+        }
+    })();
+</script>
+
+<script>
+    (function (w, l) {
+        w[l] = w[l] || [];
+        w[l].push({
+            "gtm.start": new Date().getTime(),
+            event: "gtm.js",
+        });
+    })(window, "dataLayer");
+</script>
+<script
+  defer
+  src="https://www.googletagmanager.com/gtm.js?id=GTM-P528B3&gtm_auth=tfAzqo1rYDLgYhmTnSjPqw&gtm_preview=env-130&gtm_cookies_win=x"
+></script>
+<noscript>
+    <iframe
+      src="https://www.googletagmanager.com/ns.html?id=GTM-P528B3&gtm_auth=tfAzqo1rYDLgYhmTnSjPqw&gtm_preview=env-130&gtm_cookies_win=x"
+      height="0"
+      width="0"
+      style="display: none; visibility: hidden"
+    ></iframe>
+</noscript>
+
+<!-- RELEASE 3c1954f16c628adac7f75074613cc5f18af9a916 -->
+</body>
+</html>

--- a/packages/readabilityjs/test/test-pages/nytimes.com/url.txt
+++ b/packages/readabilityjs/test/test-pages/nytimes.com/url.txt
@@ -1,0 +1,1 @@
+https://www.nytimes.com/2022/10/28/technology/twitter-changes.html


### PR DESCRIPTION
The first few paragraphs are deleted by readability because there are too many links in them but these links are not advertisements so I added the class name of the element of the paragraphs to the skipping list when cleaning the nodes.

Test case added too