### PR TITLE
Fix issue with spaces dissapearing when highlights are created

### DIFF
--- a/packages/web/lib/highlights/highlightGenerator.ts
+++ b/packages/web/lib/highlights/highlightGenerator.ts
@@ -126,7 +126,7 @@ export function makeHighlightNodeAttributes(
       // If we are not in preformatted text, prevent hardcoded \n,
       // we'll create new-lines based on the startsParagraph data
       const text = isPre ? rawText : rawText.replace(/\n/g, '')
-      const newTextNode = document.createTextNode(text)
+      const newTextNode = document.createTextNode(rawText)
 
       if (!highlight) {
         return parentNode?.insertBefore(newTextNode, nextSibling)


### PR DESCRIPTION
Use the raw text when creating a highlight node instead of the
escaped text. This means \n spaces will be preserved in the
node and prevent spaces from being removed.
