### PR TITLE
Dont loadItems onAppear as controllerDidChangeContent already does this

### DIFF
--- a/apple/OmnivoreKit/Sources/App/Views/Home/HomeFeedViewIOS.swift
+++ b/apple/OmnivoreKit/Sources/App/Views/Home/HomeFeedViewIOS.swift
@@ -39,9 +39,6 @@ import Views
           prefersListLayout: $prefersListLayout,
           viewModel: viewModel
         )
-        .onAppear {
-          loadItems(isRefresh: true)
-        }
         .refreshable {
           loadItems(isRefresh: true)
         }


### PR DESCRIPTION
This prevents a double refresh when returning to the library view.
