### PR TITLE
Remove the popular subscriptions table

### DIFF
--- a/packages/web/pages/settings/subscriptions.tsx
+++ b/packages/web/pages/settings/subscriptions.tsx
@@ -62,24 +62,6 @@ export default function SubscriptionsPage(): JSX.Element {
         rows={rows}
         onDelete={setConfirmUnsubscribeName}
       />
-
-      {/* TODO: Dynamically loaded from API response */}
-      <Table
-        heading={'Popular Newsletters'}
-        headers={['Substack', 'Axios', 'Bloomberg']}
-        rows={
-          new Map([
-            [
-              '0',
-              [
-                'https://substack.com/',
-                'https://www.axios.com/newsletters',
-                'https://www.bloomberg.com/account/newsletters',
-              ],
-            ],
-          ])
-        }
-      />
     </PrimaryLayout>
   )
 }


### PR DESCRIPTION
We probably need a standalone page for this in the future, but
removing this now allows people to use this page to see their
subscriptions on web.
