### PR TITLE
Set title for YouTube based on oembed data

### DIFF
--- a/packages/content-handler/src/websites/youtube-handler.ts
+++ b/packages/content-handler/src/websites/youtube-handler.ts
@@ -69,8 +69,6 @@ export class YoutubeHandler extends ContentHandler {
       </body>
     </html>`
 
-    console.log('got video id', videoId)
-
-    return { content, title: 'Youtube Content' }
+    return { content, title }
   }
 }


### PR DESCRIPTION
Tested with this URL: https://www.youtube.com/watch?v=TqYQ0kA1yAo 

<img width="766" alt="Screen Shot 2023-01-16 at 20 06 13" src="https://user-images.githubusercontent.com/75189/212674593-fed72024-66ec-4f25-aec0-ff19efdc58ce.png">
