### PR TITLE
Fix not showing images in wechat articles

### DIFF
--- a/packages/readabilityjs/Readability.js
+++ b/packages/readabilityjs/Readability.js
@@ -526,7 +526,8 @@ Readability.prototype = {
       // replace all images' href source
       const images = articleContent.getElementsByTagName('img');
       Array.from(images).forEach(image => {
-        const src = image.getAttribute("src");
+        // for some reason, some images have no src attribute, so we need to use data-src
+        const src = image.getAttribute("data-src") || image.getAttribute("src");
 
         // do not proxy data uri
         if (src && !dataUriRegex.test(src)) {
@@ -545,6 +546,9 @@ Readability.prototype = {
           const proxySrc = this.createImageProxyUrl(absoluteSrc, width, height);
           image.setAttribute('src', proxySrc);
         }
+
+        // remove crossorigin attribute to avoid CORS errors
+        image.removeAttribute('crossorigin');
       });
 
       // replace all srcset's

--- a/packages/readabilityjs/Readability.js
+++ b/packages/readabilityjs/Readability.js
@@ -526,7 +526,7 @@ Readability.prototype = {
       // replace all images' href source
       const images = articleContent.getElementsByTagName('img');
       Array.from(images).forEach(image => {
-        // for some reason, some images have no src attribute, so we need to use data-src
+        // use data-src if lazy loading
         const src = image.getAttribute("data-src") || image.getAttribute("src");
 
         // do not proxy data uri


### PR DESCRIPTION
For `<img>` elements:
- use data-src as src if lazy loading
- remove crossorigin attribute to avoid CORS errors
