### PR TITLE
Fix incorrect title on page hosted on notion.site

### DIFF
--- a/pkg/extension/src/scripts/content/page-info.js
+++ b/pkg/extension/src/scripts/content/page-info.js
@@ -6,7 +6,7 @@
   function getDocumentTitle () {
     const opengraphTitleEl = document.querySelector(SELECTORS.TITLE);
     const openGraphTitle = opengraphTitleEl && opengraphTitleEl.content;
-    return openGraphTitle || document.title || '';
+    return document.title || openGraphTitle || '';
   }
 
   function getCanonicalUrl () {


### PR DESCRIPTION
Use `document.title` as the default title and fallback to the open graph title when saving articles with the extension