### PR TITLE
Fix labels cannot have chinese characters in iOS App

### DIFF
--- a/apple/OmnivoreKit/Sources/App/Views/Labels/LabelsView.swift
+++ b/apple/OmnivoreKit/Sources/App/Views/Labels/LabelsView.swift
@@ -115,7 +115,7 @@ struct CreateLabelView: View {
 
       TextField("Label Name", text: $newLabelName)
       #if os(iOS)
-        .keyboardType(.alphabet)
+        .keyboardType(.default)
       #endif
       .textFieldStyle(StandardTextFieldStyle())
 


### PR DESCRIPTION
Use `default` keyboard for the TextField of label name.

Reference: https://developer.apple.com/documentation/uikit/uikeyboardtype