### PR TITLE
fix/substack email not forwarded

### DIFF
--- a/packages/api/src/routers/svc/emails.ts
+++ b/packages/api/src/routers/svc/emails.ts
@@ -36,13 +36,7 @@ interface EmailMessage {
 }
 
 function isEmailMessage(data: any): data is EmailMessage {
-  return (
-    'from' in data &&
-    'to' in data &&
-    'subject' in data &&
-    'html' in data &&
-    'text' in data
-  )
+  return 'from' in data && 'to' in data && 'subject' in data
 }
 
 const logger = buildLogger('app.dispatch')

--- a/packages/api/src/routers/svc/emails.ts
+++ b/packages/api/src/routers/svc/emails.ts
@@ -36,7 +36,7 @@ interface EmailMessage {
 }
 
 function isEmailMessage(data: any): data is EmailMessage {
-  return 'from' in data && 'to' in data && 'subject' in data
+  return 'from' in data && 'to' in data
 }
 
 const logger = buildLogger('app.dispatch')

--- a/packages/api/test/routers/emails.test.ts
+++ b/packages/api/test/routers/emails.test.ts
@@ -163,5 +163,20 @@ describe('Emails Router', () => {
 
       expect(res.body.id).not.to.be.undefined
     })
+
+    it('saves the email if subject is empty', async () => {
+      const data = {
+        from,
+        to: newsletterEmail,
+        html,
+      }
+      const res = await request
+        .post(url)
+        .set('Authorization', `${authToken}`)
+        .send(data)
+        .expect(200)
+
+      expect(res.body.id).not.to.be.undefined
+    })
   })
 })

--- a/packages/api/test/routers/emails.test.ts
+++ b/packages/api/test/routers/emails.test.ts
@@ -125,6 +125,7 @@ describe('Emails Router', () => {
   })
 
   describe('create', () => {
+    const url = '/svc/pubsub/emails/save'
     const html = '<html>test html</html>'
     const text = 'test text'
     const from = 'fake from'
@@ -140,12 +141,26 @@ describe('Emails Router', () => {
         subject,
       }
       const res = await request
-        .post('/svc/pubsub/emails/save')
+        .post(url)
         .set('Authorization', `${authToken}`)
         .send(data)
         .expect(200)
 
-      console.log(res.body)
+      expect(res.body.id).not.to.be.undefined
+    })
+
+    it('saves the email if body is empty', async () => {
+      const data = {
+        from,
+        to: newsletterEmail,
+        subject,
+      }
+      const res = await request
+        .post(url)
+        .set('Authorization', `${authToken}`)
+        .send(data)
+        .expect(200)
+
       expect(res.body.id).not.to.be.undefined
     })
   })

--- a/packages/db/migrations/0110.do.add_default_value_to_text_in_received_emails.sql
+++ b/packages/db/migrations/0110.do.add_default_value_to_text_in_received_emails.sql
@@ -1,0 +1,9 @@
+-- Type: DO
+-- Name: add_default_value_to_text_in_received_emails
+-- Description: Add default value to the text field in received_emails table
+
+BEGIN;
+
+ALTER TABLE omnivore.received_emails ALTER COLUMN text SET DEFAULT '';
+
+COMMIT;

--- a/packages/db/migrations/0110.undo.add_default_value_to_text_in_received_emails.sql
+++ b/packages/db/migrations/0110.undo.add_default_value_to_text_in_received_emails.sql
@@ -1,0 +1,9 @@
+-- Type: UNDO
+-- Name: add_default_value_to_text_in_received_emails
+-- Description: Add default value to the text field in received_emails table
+
+BEGIN;
+
+ALTER TABLE omnivore.received_emails ALTER COLUMN text DROP DEFAULT;
+
+COMMIT;


### PR DESCRIPTION
- Add default empty value to the text field in received_emails table
- Accept null value for text in an email
