### PR TITLE
Snooze calculation

### DIFF
--- a/apple/OmnivoreKit/Sources/Views/SnoozeView.swift
+++ b/apple/OmnivoreKit/Sources/Views/SnoozeView.swift
@@ -21,15 +21,15 @@ public struct SnoozeView: View {
       Spacer()
 
       HStack {
-        SnoozeIconButtonView(snooze: Snooze.snoozeValues[0], action: { snoozeItem($0) })
-        SnoozeIconButtonView(snooze: Snooze.snoozeValues[1], action: { snoozeItem($0) })
+        SnoozeIconButtonView(snooze: Snooze.currentValues[0], action: { snoozeItem($0) })
+        SnoozeIconButtonView(snooze: Snooze.currentValues[1], action: { snoozeItem($0) })
       }
 
       Spacer(minLength: 32)
 
       HStack {
-        SnoozeIconButtonView(snooze: Snooze.snoozeValues[2], action: { snoozeItem($0) })
-        SnoozeIconButtonView(snooze: Snooze.snoozeValues[3], action: { snoozeItem($0) })
+        SnoozeIconButtonView(snooze: Snooze.currentValues[2], action: { snoozeItem($0) })
+        SnoozeIconButtonView(snooze: Snooze.currentValues[3], action: { snoozeItem($0) })
       }
       Spacer()
     }.padding(EdgeInsets(top: 8, leading: 16, bottom: 8, trailing: 16))
@@ -102,14 +102,12 @@ struct Snooze {
     self.untilStr = formatter.string(from: until)
   }
 
-  static var snoozeValues: [Snooze] {
-    let now = Date()
-    return snoozeValuesForDate(now: now)
+  static var currentValues: [Snooze] {
+    calculateValues(for: Date(), calendar: Calendar.current)
   }
 
-  static func snoozeValuesForDate(now: Date) -> [Snooze] {
+  static func calculateValues(for now: Date, calendar: Calendar) -> [Snooze] {
     var res: [Snooze] = []
-    let calendar = Calendar.current
     let components = calendar.dateComponents([.year, .month, .day, .hour, .timeZone, .weekday], from: now)
 
     var tonightComponent = components

--- a/apple/OmnivoreKit/Tests/ViewsTests/SnoozeTests.swift
+++ b/apple/OmnivoreKit/Tests/ViewsTests/SnoozeTests.swift
@@ -1,7 +1,7 @@
 @testable import Views
 import XCTest
 
-final class HomeFeedViewTests: XCTestCase {
+final class SnoozeTests: XCTestCase {
   func parse(_ str: String) -> Date {
     let dateFormatter = DateFormatter()
     dateFormatter.locale = Locale(identifier: "en_US_POSIX") // set locale to reliable US_POSIX

--- a/apple/OmnivoreKit/Tests/ViewsTests/SnoozeTests.swift
+++ b/apple/OmnivoreKit/Tests/ViewsTests/SnoozeTests.swift
@@ -9,9 +9,11 @@ final class SnoozeTests: XCTestCase {
     return dateFormatter.date(from: str)!
   }
 
-  func test_weekdayBefore8PM() {
+  func test_weekdayBefore8PM_minus8() {
+    var calendar = Calendar(identifier: .gregorian)
+    calendar.timeZone = TimeZone(secondsFromGMT: -8 * 3600)!
     let now = parse("2022-01-31T10:11:12-08:00")
-    let snoozes = Snooze.snoozeValuesForDate(now: now)
+    let snoozes = Snooze.calculateValues(for: now, calendar: calendar)
 
     XCTAssertEqual(snoozes[0].until, parse("2022-01-31T20:00:00-08:00"))
     XCTAssertEqual(snoozes[1].until, parse("2022-02-01T08:00:00-08:00"))
@@ -19,9 +21,23 @@ final class SnoozeTests: XCTestCase {
     XCTAssertEqual(snoozes[3].until, parse("2022-02-07T08:00:00-08:00"))
   }
 
-  func test_weekdayAfter8PM() {
+  func test_weekdayBefore8PM_zulu() {
+    var calendar = Calendar(identifier: .gregorian)
+    calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+    let now = parse("2022-01-31T13:14:15Z")
+    let snoozes = Snooze.calculateValues(for: now, calendar: calendar)
+
+    XCTAssertEqual(snoozes[0].until, parse("2022-01-31T20:00:00Z"))
+    XCTAssertEqual(snoozes[1].until, parse("2022-02-01T08:00:00Z"))
+    XCTAssertEqual(snoozes[2].until, parse("2022-02-05T08:00:00Z"))
+    XCTAssertEqual(snoozes[3].until, parse("2022-02-07T08:00:00Z"))
+  }
+
+  func test_weekdayAfter8PM_minus8() {
+    var calendar = Calendar(identifier: .gregorian)
+    calendar.timeZone = TimeZone(secondsFromGMT: -8 * 3600)!
     let now = parse("2022-01-31T20:11:12-08:00")
-    let snoozes = Snooze.snoozeValuesForDate(now: now)
+    let snoozes = Snooze.calculateValues(for: now, calendar: calendar)
 
     XCTAssertEqual(snoozes[0].until, parse("2022-02-01T08:00:00-08:00"))
     XCTAssertEqual(snoozes[1].until, parse("2022-02-01T20:00:00-08:00"))
@@ -29,8 +45,22 @@ final class SnoozeTests: XCTestCase {
     XCTAssertEqual(snoozes[3].until, parse("2022-02-07T08:00:00-08:00"))
   }
 
+  func test_weekdayAfter8PM_plus5() {
+    var calendar = Calendar(identifier: .gregorian)
+    calendar.timeZone = TimeZone(secondsFromGMT: 5 * 3600)!
+    let now = parse("2022-01-31T22:33:44+05:00")
+    let snoozes = Snooze.calculateValues(for: now, calendar: calendar)
+
+    XCTAssertEqual(snoozes[0].until, parse("2022-02-01T08:00:00+05:00"))
+    XCTAssertEqual(snoozes[1].until, parse("2022-02-01T20:00:00+05:00"))
+    XCTAssertEqual(snoozes[2].until, parse("2022-02-05T08:00:00+05:00"))
+    XCTAssertEqual(snoozes[3].until, parse("2022-02-07T08:00:00+05:00"))
+  }
+
   static var allTests = [
-    ("test_weekdayBefore8PM", test_weekdayBefore8PM),
-    ("test_weekdayAfter8PM", test_weekdayAfter8PM)
+    ("test_weekdayBefore8PM_minus8", test_weekdayBefore8PM_minus8),
+    ("test_weekdayBefore8PM_zulu", test_weekdayBefore8PM_zulu),
+    ("test_weekdayAfter8PM_minus8", test_weekdayAfter8PM_minus8),
+    ("test_weekdayAfter8PM_plus5", test_weekdayAfter8PM_plus5)
   ]
 }


### PR DESCRIPTION
The snooze tests were failing for me. Upon closer inspection, this appears to be because the strings in the test cases specified a UTC offset of `-08:00`, which is not the time zone I'm in.

To fix this, I've refactored the method that calculates the target dates to take a date and a calendar as arguments. The app code continues to use `Calendar.current`, while the test code now specifically passes a Gregorian calendar with a matching time zone. While still nowhere near exhaustive, I've added a couple more test cases in other time zones.

The test changes are more clear if you look at the commits separately, rather than the branch-wise diff.
