### PR TITLE
Clear local files when reseting local storage

### DIFF
--- a/apple/OmnivoreKit/Sources/App/Views/Home/HomeFeedViewModel.swift
+++ b/apple/OmnivoreKit/Sources/App/Views/Home/HomeFeedViewModel.swift
@@ -6,8 +6,6 @@ import Utils
 import Views
 
 @MainActor final class HomeFeedViewModel: NSObject, ObservableObject {
-  let dateFormatter = DateFormatter.formatterISO8601
-
   var currentDetailViewModel: LinkItemDetailViewModel?
 
   private var fetchedResultsController: NSFetchedResultsController<LinkedItem>?
@@ -110,7 +108,7 @@ import Views
 
   func syncItems(dataService: DataService) async {
     let syncStart = Date.now
-    let lastSyncDate = dateFormatter.date(from: dataService.lastItemSyncTime) ?? Date(timeIntervalSinceReferenceDate: 0)
+    let lastSyncDate = dataService.lastItemSyncTime
 
     try? await dataService.syncOfflineItemsWithServerIfNeeded()
 
@@ -124,7 +122,7 @@ import Views
         self.isLoading = false
       }
     } else {
-      dataService.lastItemSyncTime = DateFormatter.formatterISO8601.string(from: syncStart)
+      dataService.lastItemSyncTime = syncStart
     }
 
     // If possible start prefetching new pages in the background

--- a/apple/OmnivoreKit/Sources/App/Views/Profile/ManageAccountView.swift
+++ b/apple/OmnivoreKit/Sources/App/Views/Profile/ManageAccountView.swift
@@ -39,7 +39,7 @@ struct ManageAccountView: View {
         )
         Button(
           action: {
-            dataService.resetCoreData()
+            dataService.resetLocalStorage()
           },
           label: { Text(LocalText.manageAccountResetCache) }
         )

--- a/apple/OmnivoreKit/Sources/Services/AudioSession/AudioController.swift
+++ b/apple/OmnivoreKit/Sources/Services/AudioSession/AudioController.swift
@@ -543,8 +543,7 @@
     }
 
     public static func pathForAudioDirectory(itemID: String) -> URL {
-      FileManager.default
-        .urls(for: .documentDirectory, in: .userDomainMask)[0]
+      URL.om_documentsDirectory
         .appendingPathComponent("audio-\(itemID)/")
     }
 

--- a/apple/OmnivoreKit/Sources/Services/AudioSession/SpeechSynthesizer.swift
+++ b/apple/OmnivoreKit/Sources/Services/AudioSession/SpeechSynthesizer.swift
@@ -56,8 +56,7 @@ struct SpeechDocument: Decodable {
   }
 
   static func audioDirectory(pageId: String) -> URL {
-    FileManager.default
-      .urls(for: .documentDirectory, in: .userDomainMask)[0]
+    URL.om_documentsDirectory
       .appendingPathComponent("audio-\(pageId)")
   }
 }
@@ -213,12 +212,10 @@ struct SpeechSynthesizer {
 
     let data = try await downloadData(session: session, request: speechItem.urlRequest)
 
-    let tempPath = FileManager.default
-      .urls(for: .cachesDirectory, in: .userDomainMask)[0]
+    let tempPath = URL.om_cachesDirectory
       .appendingPathComponent(UUID().uuidString + ".mp3")
 
-    let tempSMPath = FileManager.default
-      .urls(for: .cachesDirectory, in: .userDomainMask)[0]
+    let tempSMPath = URL.om_cachesDirectory
       .appendingPathComponent(UUID().uuidString + ".speechMarks")
 
     do {

--- a/apple/OmnivoreKit/Sources/Services/Authentication/Authenticator.swift
+++ b/apple/OmnivoreKit/Sources/Services/Authentication/Authenticator.swift
@@ -38,7 +38,7 @@ public final class Authenticator: ObservableObject {
   }
 
   public func logout(dataService: DataService, isAccountDeletion: Bool = false) {
-    dataService.resetCoreData()
+    dataService.resetLocalStorage()
     clearCreds()
     Authenticator.unregisterIntercomUser?()
     isLoggedIn = false

--- a/apple/OmnivoreKit/Sources/Services/DataService/DataService.swift
+++ b/apple/OmnivoreKit/Sources/Services/DataService/DataService.swift
@@ -29,9 +29,22 @@ public final class DataService: ObservableObject {
     persistentContainer.viewContext
   }
 
-  @AppStorage(UserDefaultKey.lastItemSyncTime.rawValue) public var lastItemSyncTime: String = {
-    DateFormatter.formatterISO8601.string(from: Date(timeIntervalSinceReferenceDate: 0))
-  }()
+  public var lastItemSyncTime: Date {
+    get {
+      guard
+        let str = UserDefaults.standard.string(forKey: UserDefaultKey.lastItemSyncTime.rawValue),
+        let date = DateFormatter.formatterISO8601.date(from: str)
+      else {
+        return Date(timeIntervalSinceReferenceDate: 0)
+      }
+      return date
+    }
+    set {
+      logger.trace("last item sync updated to \(newValue)")
+      let str = DateFormatter.formatterISO8601.string(from: newValue)
+      UserDefaults.standard.set(str, forKey: UserDefaultKey.lastItemSyncTime.rawValue)
+    }
+  }
 
   public init(appEnvironment: AppEnvironment, networker: Networker) {
     self.appEnvironment = appEnvironment
@@ -150,7 +163,7 @@ public final class DataService: ObservableObject {
   }
 
   public func resetLocalStorage() {
-    lastItemSyncTime = DateFormatter.formatterISO8601.string(from: Date(timeIntervalSinceReferenceDate: 0))
+    lastItemSyncTime = Date(timeIntervalSinceReferenceDate: 0)
 
     clearCoreData()
     clearDownloadedFiles()

--- a/apple/OmnivoreKit/Sources/Services/DataService/Public/LinkedItemLoading.swift
+++ b/apple/OmnivoreKit/Sources/Services/DataService/Public/LinkedItemLoading.swift
@@ -93,7 +93,7 @@ public extension DataService {
         }
       }
       DispatchQueue.main.sync {
-        self.lastItemSyncTime = DateFormatter.formatterISO8601.string(from: Date.now)
+        self.lastItemSyncTime = Date.now
         onComplete()
       }
     }

--- a/apple/OmnivoreKit/Sources/Services/DataService/Public/PDFLoading.swift
+++ b/apple/OmnivoreKit/Sources/Services/DataService/Public/PDFLoading.swift
@@ -21,8 +21,7 @@ public extension DataService {
 
     var localPdfURL: URL?
 
-    let tempPath = FileManager.default
-      .urls(for: .cachesDirectory, in: .userDomainMask)[0]
+    let tempPath = URL.om_cachesDirectory
       .appendingPathComponent(UUID().uuidString + ".pdf")
 
     try await backgroundContext.perform { [weak self] in

--- a/apple/OmnivoreKit/Sources/Utils/PDFUtils.swift
+++ b/apple/OmnivoreKit/Sources/Utils/PDFUtils.swift
@@ -10,8 +10,7 @@ import QuickLookThumbnailing
 public enum PDFUtils {
   public static func copyToLocal(url: URL) throws -> String {
     let subPath = UUID().uuidString + ".pdf"
-    let dest = FileManager.default
-      .urls(for: .documentDirectory, in: .userDomainMask)[0]
+    let dest = URL.om_documentsDirectory
       .appendingPathComponent(subPath)
 
     try FileManager.default.copyItem(at: url, to: dest)
@@ -20,8 +19,7 @@ public enum PDFUtils {
 
   public static func moveToLocal(url: URL) throws -> String {
     let subPath = UUID().uuidString + ".pdf"
-    let dest = FileManager.default
-      .urls(for: .documentDirectory, in: .userDomainMask)[0]
+    let dest = URL.om_documentsDirectory
       .appendingPathComponent(subPath)
 
     try FileManager.default.moveItem(at: url, to: dest)
@@ -29,8 +27,7 @@ public enum PDFUtils {
   }
 
   public static func localPdfURL(filename: String) -> URL? {
-    let url = FileManager.default
-      .urls(for: .documentDirectory, in: .userDomainMask)[0]
+    let url = URL.om_documentsDirectory
       .appendingPathComponent(filename)
 
     return url

--- a/apple/OmnivoreKit/Sources/Utils/URLExtension.swift
+++ b/apple/OmnivoreKit/Sources/Utils/URLExtension.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+public extension URL {
+  // swiftlint:disable:next identifier_name
+  static var om_documentsDirectory: URL {
+    if #unavailable(iOS 16, tvOS 16, macOS 13) {
+      guard let url = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first else {
+        fatalError("Could not determine the user's documents directory")
+      }
+      return url
+    } else {
+      return URL.documentsDirectory
+    }
+  }
+
+  // swiftlint:disable:next identifier_name
+  static var om_cachesDirectory: URL {
+    if #unavailable(iOS 16, tvOS 16, macOS 13) {
+      guard let url = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first else {
+        fatalError("Could not determine the user's caches directory")
+      }
+      return url
+    } else {
+      return URL.cachesDirectory
+    }
+  }
+}


### PR DESCRIPTION
This PR implements #1094, removing PDF and audio files from the caches and Documents directories when reseting the app's local storage.

There are two other changes here:

1. I've added a wrapper around the new `URL` directory APIs in iOS 16/macOS 13, and refactored some existing file path code to use it.
1. I've reworked `DataService.lastItemSyncTime` not to use the `@AppStorage` attribute, so that the serialization logic for the date is now hidden in the property implementation. It doesn't appear that anything in the app was depending on the property publishing its value, so I don't think this breaks anything. But it would be straightforward to revert the change.