### PR TITLE
improve urlParse for puppeteer-parse

### DIFF
--- a/packages/puppeteer-parse/index.js
+++ b/packages/puppeteer-parse/index.js
@@ -402,13 +402,13 @@ function tryParseUrl(urlStr) {
     return null;
   }
   
-  // a regular expression to match URLs
-  var regex = /(https?:\/\/[^\s]+)/g;
+  // a regular expression to match all URLs
+  const regex = /(https?:\/\/[^\s]+)/g;
   
-  var match = regex.exec(urlStr);
+  const matches = urlStr.match(regex);
   
-  if (match) {
-    return match[1];
+  if (matches) {
+    return matches[0]; // only return first match
   } else {
     return null;
   }

--- a/packages/puppeteer-parse/index.js
+++ b/packages/puppeteer-parse/index.js
@@ -397,15 +397,33 @@ function validateUrlString(url) {
   }
 }
 
+function tryParseUrl(urlStr) {
+  if (!urlStr) {
+    return null;
+  }
+  
+  // a regular expression to match URLs
+  var regex = /(https?:\/\/[^\s]+)/g;
+  
+  var match = regex.exec(urlStr);
+  
+  if (match) {
+    return match[1];
+  } else {
+    return null;
+  }
+}
+
 function getUrl(req) {
   const urlStr = (req.query ? req.query.url : undefined) || (req.body ? req.body.url : undefined);
-  if (!urlStr) {
+  const url = tryParseUrl(urlStr)
+  if (!url) {
     throw new Error('No URL specified');
   }
 
-  validateUrlString(urlStr);
+  validateUrlString(url);
 
-  const parsed = Url.parse(urlStr);
+  const parsed = Url.parse(url);
   return parsed.href;
 }
 


### PR DESCRIPTION
**Background**: When use Android app, for links shared from some apps, links are not pure url but with additional text such as article title.
Example: "The Missing Semester of Your CS Education - https://new.ycombinator.com/item?id=34934216"

**Solution**: To improve user experience, instead of just returning parse error, it could be better to try to parse the urlStr first and check whether any valid url. So I add a check with regex before that, the code change is rather simple and understandable.

Thanks for any comments, this is my first PR.