### PR TITLE
Switch express-http-context dependency to express-http-context2

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -55,7 +55,7 @@
     "dot-case": "^3.0.4",
     "dotenv": "^8.2.0",
     "express": "^4.17.1",
-    "express-http-context": "^1.2.4",
+    "express-http-context2": "^1.0.0",
     "express-rate-limit": "^6.3.0",
     "firebase-admin": "^10.0.2",
     "googleapis": "^105.0.0",

--- a/packages/api/src/resolvers/article/index.ts
+++ b/packages/api/src/resolvers/article/index.ts
@@ -105,7 +105,7 @@ import {
 import { searchHighlights } from '../../elastic/highlights'
 import { saveSearchHistory } from '../../services/search_history'
 import { parsedContentToPage } from '../../services/save_page'
-import * as httpContext from 'express-http-context'
+import * as httpContext from 'express-http-context2'
 
 enum ArticleFormat {
   Markdown = 'markdown',
@@ -946,7 +946,7 @@ export const searchResolver = authorized<
 
   // save query, including advanced search terms, in search history
   if (params.query) {
-    const client = httpContext.get('client') as string | undefined
+    const client = httpContext.get('client')
     // don't save search history for rule based queries
     client !== 'rule-handler' &&
       (await saveSearchHistory(claims.uid, params.query))

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -46,7 +46,7 @@ import rateLimit from 'express-rate-limit'
 import { webhooksServiceRouter } from './routers/svc/webhooks'
 import { integrationsServiceRouter } from './routers/svc/integrations'
 import { textToSpeechRouter } from './routers/text_to_speech'
-import * as httpContext from 'express-http-context'
+import * as httpContext from 'express-http-context2'
 import { notificationRouter } from './routers/notification_router'
 import { userRouter } from './routers/user_router'
 

--- a/packages/api/src/services/popular_reads.ts
+++ b/packages/api/src/services/popular_reads.ts
@@ -5,7 +5,7 @@ import { PageType } from '../generated/graphql'
 import { generateSlug, stringToHash } from '../utils/helpers'
 import { readFileSync } from 'fs'
 import path from 'path'
-import * as httpContext from 'express-http-context'
+import * as httpContext from 'express-http-context2'
 
 type PopularRead = {
   url: string
@@ -124,7 +124,7 @@ export const addPopularReadsForNewUser = async (
   const defaultReads = ['omnivore_organize', 'power_read_it_later']
 
   // get client from request context
-  const client = httpContext.get('client') as string | undefined
+  const client = httpContext.get<string>('client')
 
   switch (client) {
     case 'web':

--- a/yarn.lock
+++ b/yarn.lock
@@ -7936,13 +7936,6 @@
     "@types/filesystem" "*"
     "@types/har-format" "*"
 
-"@types/cls-hooked@^4.2.1":
-  version "4.3.3"
-  resolved "https://registry.yarnpkg.com/@types/cls-hooked/-/cls-hooked-4.3.3.tgz#c09e2f8dc62198522eaa18a5b6b873053154bd00"
-  integrity sha512-gNstDTb/ty5h6gJd6YpSPgsLX9LmRpaKJqGFp7MRlYxhwp4vXXKlJ9+bt1TZ9KbVNXE+Mbxy2AYXcpY21DDtJw==
-  dependencies:
-    "@types/node" "*"
-
 "@types/color-convert@^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@types/color-convert/-/color-convert-2.0.0.tgz#8f5ee6b9e863dcbee5703f5a517ffb13d3ea4e22"
@@ -8079,7 +8072,7 @@
   dependencies:
     "@types/express" "*"
 
-"@types/express@*", "@types/express@^4.16.0", "@types/express@^4.17.13", "@types/express@^4.17.14", "@types/express@^4.17.2", "@types/express@^4.17.7":
+"@types/express@*", "@types/express@^4.17.13", "@types/express@^4.17.14", "@types/express@^4.17.2", "@types/express@^4.17.7":
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.15.tgz#9290e983ec8b054b65a5abccb610411953d417ff"
   integrity sha512-Yv0k4bXGOH+8a+7bELd2PqHQsuiANB+A8a4gnQrkRWzrkKlb6KHaVvyXhqs04sVW/OWlbPyYxRgYlIXLfrufMQ==
@@ -10140,13 +10133,6 @@ async-each@^1.0.1:
   resolved "https://registry.yarnpkg.com/async-each/-/async-each-1.0.3.tgz#b727dbf87d7651602f06f4d4ac387f47d91b0cbf"
   integrity sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==
 
-async-hook-jl@^1.7.6:
-  version "1.7.6"
-  resolved "https://registry.yarnpkg.com/async-hook-jl/-/async-hook-jl-1.7.6.tgz#4fd25c2f864dbaf279c610d73bf97b1b28595e68"
-  integrity sha512-gFaHkFfSxTjvoxDMYqDuGHlcRyUuamF8s+ZTtJdDzqjws4mCt7v0vuV79/E2Wr2/riMQgtG4/yUtXWs1gZ7JMg==
-  dependencies:
-    stack-chain "^1.3.7"
-
 async-retry@^1.2.1, async-retry@^1.3.3:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/async-retry/-/async-retry-1.3.3.tgz#0e7f36c04d8478e7a58bdbed80cedf977785f280"
@@ -11648,15 +11634,6 @@ cloudevents@^6.0.0:
     ajv-formats "^2.1.1"
     util "^0.12.4"
     uuid "^8.3.2"
-
-cls-hooked@^4.2.2:
-  version "4.2.2"
-  resolved "https://registry.yarnpkg.com/cls-hooked/-/cls-hooked-4.2.2.tgz#ad2e9a4092680cdaffeb2d3551da0e225eae1908"
-  integrity sha512-J4Xj5f5wq/4jAvcdgoGsL3G103BtWpZrMo8NEinRltN+xpTZdI+M38pyQqhuFU/P792xkMFvnKSf+Lm81U1bxw==
-  dependencies:
-    async-hook-jl "^1.7.6"
-    emitter-listener "^1.0.1"
-    semver "^5.4.1"
 
 clsx@^1.1.1:
   version "1.1.1"
@@ -13417,13 +13394,6 @@ elliptic@^6.5.3:
     minimalistic-assert "^1.0.1"
     minimalistic-crypto-utils "^1.0.1"
 
-emitter-listener@^1.0.1:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/emitter-listener/-/emitter-listener-1.1.2.tgz#56b140e8f6992375b3d7cb2cab1cc7432d9632e8"
-  integrity sha512-Bt1sBAGFHY9DKY+4/2cV6izcKJUf5T7/gkdmkxzX/qv9CcGH8xSwVRW5mtX03SWJtRTWSOpzCuWN9rBFYZepZQ==
-  dependencies:
-    shimmer "^1.2.0"
-
 emittery@^0.8.1:
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/emittery/-/emittery-0.8.1.tgz#bb23cc86d03b30aa75a7f734819dee2e1ba70860"
@@ -14196,14 +14166,10 @@ expect@^27.5.1:
     jest-matcher-utils "^27.5.1"
     jest-message-util "^27.5.1"
 
-express-http-context@^1.2.4:
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/express-http-context/-/express-http-context-1.2.4.tgz#49769d0e260836278996e728d9a3e7f3735f0531"
-  integrity sha512-jPpBbF1MWWdRcUU1rxsX0CPnA8ueEj8xgWvpRGHoXWGI4l5KqhPY4Bq+Gt6s2IhqHQQ0g0wIvJ3jFfbUuJJycQ==
-  dependencies:
-    "@types/cls-hooked" "^4.2.1"
-    "@types/express" "^4.16.0"
-    cls-hooked "^4.2.2"
+express-http-context2@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/express-http-context2/-/express-http-context2-1.0.0.tgz#58cd9fb0d233739e0dcd7aabb766d1dc74522d77"
+  integrity sha512-xdukoNNpWcuMn5ZJcjDe/tA+2A96rQ1MyAB/oWUU7qP15Tkz3txQyFsw/QG8YgRzTJ1sNAA8Bdq0o5b/1Y4zLA==
 
 express-rate-limit@^6.3.0:
   version "6.3.0"
@@ -24236,7 +24202,7 @@ shebang-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
-shimmer@^1.2.0, shimmer@^1.2.1:
+shimmer@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/shimmer/-/shimmer-1.2.1.tgz#610859f7de327b587efebf501fb43117f9aff337"
   integrity sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==
@@ -24682,11 +24648,6 @@ stable@^0.1.8:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/stable/-/stable-0.1.8.tgz#836eb3c8382fe2936feaf544631017ce7d47a3cf"
   integrity sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==
-
-stack-chain@^1.3.7:
-  version "1.3.7"
-  resolved "https://registry.yarnpkg.com/stack-chain/-/stack-chain-1.3.7.tgz#d192c9ff4ea6a22c94c4dd459171e3f00cea1285"
-  integrity sha512-D8cWtWVdIe/jBA7v5p5Hwl5yOSOrmZPWDPe2KxQ5UAGD+nxbxU0lKXA4h85Ta6+qgdKVL3vUxsbIZjc1kBG7ug==
 
 stack-trace@0.0.x:
   version "0.0.10"


### PR DESCRIPTION
`express-http-context2` is a drop-in replacement for `express-http-context` that uses the more performant `async_hooks` Node.js native module instead of the (nowadays unnecessary) `cls-hooked` community provided CLS library. ([More info](https://itnext.io/one-node-js-cls-api-to-rule-them-all-1670ac66a9e8)).