### PR TITLE
Use local timezone for the date in the reader

### DIFF
--- a/packages/web/components/templates/homeFeed/EditItemModals.tsx
+++ b/packages/web/components/templates/homeFeed/EditItemModals.tsx
@@ -237,7 +237,7 @@ function EditItemModal(props: EditItemModalProps): JSX.Element {
                   <StyledText css={titleStyle}>SAVED AT:</StyledText>
                   <FormInput
                     type="datetime-local"
-                    value={props.savedAt.format('YYYY-MM-DDTHH:mm:ss')}
+                    value={props.savedAt.format('YYYY-MM-DDTHH:mm')}
                     placeholder="Edit Date"
                     onChange={(event) => {
                       const dateStr = event.target.value

--- a/packages/web/components/templates/homeFeed/EditItemModals.tsx
+++ b/packages/web/components/templates/homeFeed/EditItemModals.tsx
@@ -1,9 +1,9 @@
 import {
-  ModalRoot,
   ModalContent,
   ModalOverlay,
+  ModalRoot,
 } from '../../elements/ModalPrimitives'
-import { VStack, HStack, Box, SpanBox } from '../../elements/LayoutPrimitives'
+import { Box, HStack, SpanBox, VStack } from '../../elements/LayoutPrimitives'
 import { Button } from '../../elements/Button'
 import { StyledText } from '../../elements/StyledText'
 
@@ -237,7 +237,7 @@ function EditItemModal(props: EditItemModalProps): JSX.Element {
                   <StyledText css={titleStyle}>SAVED AT:</StyledText>
                   <FormInput
                     type="datetime-local"
-                    value={props.savedAt.format('YYYY-MM-DDThh:mm')}
+                    value={props.savedAt.format('YYYY-MM-DDTHH:mm:ss')}
                     placeholder="Edit Date"
                     onChange={(event) => {
                       const dateStr = event.target.value
@@ -255,7 +255,7 @@ function EditItemModal(props: EditItemModalProps): JSX.Element {
                     type="datetime-local"
                     value={
                       props.publishedAt
-                        ? props.publishedAt.format('YYYY-MM-DDThh:mm')
+                        ? props.publishedAt.format('YYYY-MM-DDTHH:mm')
                         : undefined
                     }
                     placeholder="Edit Published Date"

--- a/packages/web/lib/dateFormatting.ts
+++ b/packages/web/lib/dateFormatting.ts
@@ -1,15 +1,19 @@
 //https://github.com/you-dont-need/You-Dont-Need-Momentjs
 
 const locale = Intl.DateTimeFormat().resolvedOptions().locale || 'en-US'
+// get the user's time zone
+const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone
 
 export function formattedLongDate(rawDate: string): string {
   return new Intl.DateTimeFormat(locale, {
     dateStyle: 'long',
+    timeZone,
   }).format(new Date(rawDate))
 }
 
 export function formattedShortDate(rawDate: string): string {
   return new Intl.DateTimeFormat(locale, {
     dateStyle: 'short',
+    timeZone,
   }).format(new Date(rawDate))
 }


### PR DESCRIPTION
- Use local timezone for the date in the reader
- [Fix wrong AM/PM of the time in edit article modal](https://github.com/omnivore-app/omnivore/pull/1883/commits/83da1d6242b712669706afe3c03d7879122a8717)