### PR TITLE
Use POSTGRES_USER in the selfhost script 

### DIFF
--- a/self-hosting/selfhost.sh
+++ b/self-hosting/selfhost.sh
@@ -1,14 +1,14 @@
 #!/bin/sh
 
-echo "creating omnivore database with $(which psql)"
+echo "creating omnivore database with $(which psql) and user: $POSTGRES_USER"
 psql --host $PG_HOST -c "CREATE DATABASE omnivore;"
 
 echo "creating app_user"
-psql --host $PG_HOST -d $PG_DB -c "CREATE USER app_user WITH PASSWORD 'app_pass';"
+psql --host $PG_HOST -d $PG_DB -c "CREATE USER app_user WITH ENCRYPTED PASSWORD '$PG_PASSWORD';"
 echo "created app_user"
 
-echo "running migrations"
-yarn workspace @omnivore/db migrate
+echo "running migrations as $POSTGRES_USER"
+PG_USER=$POSTGRES_USER PG_PASSWORD=$POSTGRES_PASSWORD yarn workspace @omnivore/db migrate
 
 psql --host $PG_HOST -d $PG_DB -c "GRANT omnivore_user TO app_user;"
 echo "granted omnivore_user to app_user"

--- a/self-hosting/selfhost.sh
+++ b/self-hosting/selfhost.sh
@@ -1,16 +1,16 @@
 #!/bin/sh
 
 echo "creating omnivore database with $(which psql)"
-psql --host $PG_HOST -U $PG_USER -c "CREATE DATABASE omnivore;"
+psql --host $PG_HOST -c "CREATE DATABASE omnivore;"
 
 echo "creating app_user"
-psql --host $PG_HOST -U $PG_USER -d $PG_DB -c "CREATE USER app_user WITH PASSWORD 'app_pass';"
+psql --host $PG_HOST -d $PG_DB -c "CREATE USER app_user WITH PASSWORD 'app_pass';"
 echo "created app_user"
 
 echo "running migrations"
 yarn workspace @omnivore/db migrate
 
-psql --host $PG_HOST -U $PG_USER -d $PG_DB -c "GRANT omnivore_user TO app_user;"
+psql --host $PG_HOST -d $PG_DB -c "GRANT omnivore_user TO app_user;"
 echo "granted omnivore_user to app_user"
 
 yarn workspace @omnivore/api start 


### PR DESCRIPTION
- Remove PG_USER from script, we will rely on POSTGRES_USER for this
- Use the POSTGRES_USER when running self hosting migrations
