### PR TITLE
Prevent width scrollbar on windows in primary layout

### DIFF
--- a/apple/OmnivoreKit/Sources/Views/FeedItem/LibraryItemCard.swift
+++ b/apple/OmnivoreKit/Sources/Views/FeedItem/LibraryItemCard.swift
@@ -17,13 +17,11 @@ public extension View {
 
 public struct LibraryItemCard: View {
   let viewer: Viewer?
-  let tapHandler: () -> Void
   @ObservedObject var item: LinkedItem
 
-  public init(item: LinkedItem, viewer: Viewer?, tapHandler: @escaping () -> Void = {}) {
+  public init(item: LinkedItem, viewer: Viewer?) {
     self.item = item
     self.viewer = viewer
-    self.tapHandler = tapHandler
   }
 
   public var body: some View {
@@ -204,10 +202,5 @@ public struct LibraryItemCard: View {
   var labels: some View {
     LabelsFlowLayout(labels: item.sortedLabels)
       .padding(.top, 0)
-    #if os(macOS)
-      .onTapGesture {
-        tapHandler()
-      }
-    #endif
   }
 }

--- a/packages/web/components/templates/PrimaryLayout.tsx
+++ b/packages/web/components/templates/PrimaryLayout.tsx
@@ -87,6 +87,7 @@ export function PrimaryLayout(props: PrimaryLayoutProps): JSX.Element {
         css={{
           height: '100%',
           width: '100vw',
+          overflowX: 'clip',
           bg: '$thBackground2',
         }}
       >


### PR DESCRIPTION
- Remove unused tap handler
- Dont overlfow X in our primary layout
