### PR TITLE
Use normalized URLs when querying article saving requests

### DIFF
--- a/packages/api/src/resolvers/article_saving_request/index.ts
+++ b/packages/api/src/resolvers/article_saving_request/index.ts
@@ -1,4 +1,5 @@
 /* eslint-disable prefer-const */
+import normalizeUrl from 'normalize-url'
 import { getPageByParam } from '../../elastic/pages'
 import { User } from '../../entity/user'
 import { getRepository } from '../../entity/utils'
@@ -73,9 +74,17 @@ export const articleSavingRequestResolver = authorized<
   if (!user) {
     return { errorCodes: [ArticleSavingRequestErrorCode.Unauthorized] }
   }
+
+  const normalizedUrl = url
+    ? normalizeUrl(url, {
+        stripHash: true,
+        stripWWW: false,
+      })
+    : undefined
+
   const params = {
     _id: id || undefined,
-    url: url || undefined,
+    url: normalizedUrl,
     userId: claims.uid,
     state: [
       ArticleSavingRequestStatus.Succeeded,


### PR DESCRIPTION
When we save pages we save the normalized URL, so if a user saves
a URL like https://foo.com/ in elastic it will be saved as
https://foo.com but the browser will redirect to this url:

https://omnivore.app/article?url=https://foo.com/ and the URL
lookup will fail.
