### PR TITLE
fix: readwise button not clickable on integrations page

### DIFF
--- a/packages/web/pages/settings/integrations.tsx
+++ b/packages/web/pages/settings/integrations.tsx
@@ -232,7 +232,7 @@ export default function Integrations(): JSX.Element {
           css={{
             width: '80%',
             margin: '0 auto',
-            height: '800px',
+            height: '100%',
             '@smDown': {
               width: '100%',
             },
@@ -307,7 +307,6 @@ export default function Integrations(): JSX.Element {
             )
           })}
         </VStack>
-        <Box css={{ height: '400px', width: '100% ' }} />
       </VStack>
     </SettingsLayout>
   )


### PR DESCRIPTION
We have set the height of the container to 800px which is too small.

* set height of the container to 100%
* remove unused <Box> component
