### PR TITLE
Fix line-height when sub/sup is present

### DIFF
--- a/packages/web/styles/articleInnerStyling.css
+++ b/packages/web/styles/articleInnerStyling.css
@@ -262,6 +262,10 @@ on smaller screens we display the note icon
 
 .article-inner-css sup,
 .article-inner-css sub {
+  font-size: 75%;
+  line-height: 0;
+  position: relative;
+  vertical-align: baseline;
   a {
     color: inherit;
     pointer-events: none;
@@ -269,7 +273,7 @@ on smaller screens we display the note icon
 }
 
 .article-inner-css sup {
-  top: -0.3em;
+  top: -0.75em;
 }
 
 .article-inner-css sub {


### PR DESCRIPTION
Hi there! Love omnivore, this tweak fixes some typography issues with superscript/subscript. Hope I did it in the right place!

Without fix: 
<img width="648" alt="Screenshot 2023-07-23 at 21 25 13" src="https://github.com/omnivore-app/omnivore/assets/70747/36f5bd25-c47d-44fd-9aab-b2c20515523e">

With fix:
<img width="661" alt="Screenshot 2023-07-23 at 21 24 24" src="https://github.com/omnivore-app/omnivore/assets/70747/3035612d-48f8-4827-af1a-5b7decc97ab3">

Thanks,
Hans
