### PR TITLE
Control article margins on small viewports

### DIFF
--- a/packages/web/components/templates/article/ArticleContainer.tsx
+++ b/packages/web/components/templates/article/ArticleContainer.tsx
@@ -344,6 +344,13 @@ export function ArticleContainer(props: ArticleContainerProps): JSX.Element {
     readerHeadersColor: theme.colors.readerFont.toString(),
   }
 
+  const maxWidthStyles = {
+    default: styles.maxWidthPercentage
+      ? `${styles.maxWidthPercentage}%`
+      : 1024 - styles.margin,
+    small: styles.maxWidthPercentage ? `${styles.maxWidthPercentage}%` : `${120 - Math.round((styles.margin * 10) / 100)}%`,
+  }
+
   const recommendationsWithNotes = useMemo(() => {
     return (
       props.article.recommendations?.filter((recommendation) => {
@@ -357,10 +364,9 @@ export function ArticleContainer(props: ArticleContainerProps): JSX.Element {
       <Box
         id="article-container"
         css={{
-          padding: '30px',
-          paddingTop: '30px',
+          padding: 30,
           minHeight: '100vh',
-          maxWidth: `${styles.maxWidthPercentage ?? 100}%`,
+          maxWidth: maxWidthStyles.default,
           background: theme.colors.readerBg.toString(),
           '--text-align':
             justifyTextOverride != undefined
@@ -380,15 +386,10 @@ export function ArticleContainer(props: ArticleContainerProps): JSX.Element {
             '--blockquote-icon-font-size': '1.7rem',
             '--figure-margin': '2.6875rem auto',
             '--hr-margin': '2em',
-            margin: `0px 0px`,
-          },
-          '@md': {
-            maxWidth: styles.maxWidthPercentage
-              ? `${styles.maxWidthPercentage}%`
-              : 1024 - styles.margin,
           },
           '@mdDown': {
-            padding: '15px',
+            maxWidth: maxWidthStyles.small,
+            padding: 15,
           },
         }}
       >


### PR DESCRIPTION
This change is only for devices with viewport < 678px. Anything bigger like tablets and desktops will keep the current behavior.

Basically I had to find a width percentage that would behave similarly as the fixed widths used on desktop. Knowing that the margin selector goes from 200 to 560 in steps of 45 I came up the following calc:
For mobile the max width will be 120% - (10% of margin selector value)
10% seems to be the percentage that best fit the current behavior on desktop.

I also removed a unused margin.

Phone
![Kapture 2023-07-25 at 18 27 37](https://github.com/omnivore-app/omnivore/assets/9200155/8bacb36c-7b84-4c35-8d78-f7a9acfa6ee8)

Small Tablet
![Kapture 2023-07-25 at 18 30 33](https://github.com/omnivore-app/omnivore/assets/9200155/ddf28453-8daa-4b23-b00a-0396c12d9d95)