### PR TITLE
fix(web): Set input type for AddLinkModal

### DIFF
--- a/packages/web/components/templates/homeFeed/AddLinkModal.tsx
+++ b/packages/web/components/templates/homeFeed/AddLinkModal.tsx
@@ -101,7 +101,7 @@ export function AddLinkModal(props: AddLinkModalProps): JSX.Element {
               }}
             >
               <FormInput
-                type="text"
+                type="url"
                 value={link}
                 autoFocus
                 placeholder="https://example.com"


### PR DESCRIPTION
The input type for the AddLinkModal was set to `text` instead of `url`. This causes various frustrations when using the web app on mobile; for example, autocorrect is applied to URLs that are manually typed.

https://developer.mozilla.org/en-US/docs/Learn/Forms/HTML5_input_types#url_field

Thank you for making this amazing software! I'm currently daily-driving it and it just *works*.