### PR TITLE
Ars Technica Multipage handling

### DIFF
--- a/packages/content-handler/src/index.ts
+++ b/packages/content-handler/src/index.ts
@@ -37,6 +37,7 @@ import { WeixinQqHandler } from './websites/weixin-qq-handler'
 import { WikipediaHandler } from './websites/wikipedia-handler'
 import { YoutubeHandler } from './websites/youtube-handler'
 import { TheAtlanticHandler } from './websites/the-atlantic-handler'
+import { ArsTechnicaHandler } from './websites/ars-technica-handler'
 
 const validateUrlString = (url: string): boolean => {
   const u = new URL(url)
@@ -57,6 +58,7 @@ const validateUrlString = (url: string): boolean => {
 }
 
 const contentHandlers: ContentHandler[] = [
+  new ArsTechnicaHandler(),
   new TheAtlanticHandler(),
   new AppleNewsHandler(),
   new BloombergHandler(),

--- a/packages/content-handler/src/websites/ars-technica-handler.ts
+++ b/packages/content-handler/src/websites/ars-technica-handler.ts
@@ -49,7 +49,6 @@ export class ArsTechnicaHandler extends ContentHandler {
         ?.slice(0, pageLinkNodes.length - 1)
         ?.map(({ href }) => href) ?? []
 
-
     const pageContents = await Promise.all(
       pageLinks.map(this.extractArticleContentsFromLink.bind(this))
     )

--- a/packages/content-handler/src/websites/ars-technica-handler.ts
+++ b/packages/content-handler/src/websites/ars-technica-handler.ts
@@ -1,0 +1,87 @@
+import axios from 'axios'
+import { parseHTML } from 'linkedom'
+import { ContentHandler, PreHandleResult } from '../content-handler'
+
+/**
+ * Some of the content on Ars Technica is split over several pages.
+ * If this is the case we should unfurl the entire article into one. l
+ */
+export class ArsTechnicaHandler extends ContentHandler {
+  constructor() {
+    super()
+    this.name = 'ArsTechnica'
+  }
+
+  shouldPreHandle(url: string): boolean {
+    const u = new URL(url)
+    return u.hostname.endsWith('arstechnica.com')
+  }
+
+  hasMultiplePages(document: Document): boolean {
+    return document.querySelectorAll('nav.page-numbers')?.length != 0
+  }
+
+  async grabContentFromUrl(url: string): Promise<Document> {
+    const response = await axios.get(url)
+    const data = response.data as string
+    return parseHTML(data).document
+  }
+
+  async extractArticleContentsFromLink(url: string): Promise<Document[]> {
+    const dom = await this.grabContentFromUrl(url)
+    const articleContent = dom.querySelector('[itemprop="articleBody"]')
+    return [].slice.call(articleContent?.childNodes || [])
+  }
+
+  async expandLinksAndCombine(document: Document): Promise<Document> {
+    const pageNumbers = document.querySelector('nav.page-numbers')
+    const articleBody = document.querySelector('[itemprop="articleBody"]')
+
+    if (!pageNumbers || !articleBody) {
+      // We shouldn't ever really get here, but sometimes weird things happen.
+      return document
+    }
+
+    const pageLinkNodes = pageNumbers.querySelectorAll('a')
+    // Remove the "Next" Link, as it will duplicate some content.
+    const pageLinks =
+      Array.from(pageLinkNodes)
+        ?.slice(0, pageLinkNodes.length - 1)
+        ?.map(({ href }) => href) ?? []
+
+
+    const pageContents = await Promise.all(
+      pageLinks.map(this.extractArticleContentsFromLink.bind(this))
+    )
+
+    for (const articleContents of pageContents) {
+      // We place all the content in a span to indicate that a page has been parsed.
+      const span = document.createElement('SPAN')
+      span.className = 'nextPageContents'
+      span.append(...articleContents)
+      articleBody.append(span)
+    }
+    pageNumbers.remove()
+
+    return document
+  }
+
+  async preHandle(url: string): Promise<PreHandleResult> {
+    // We simply retrieve the article without Javascript enabled using a GET command.
+    const dom = await this.grabContentFromUrl(url)
+    if (!this.hasMultiplePages(dom)) {
+      return {
+        content: dom.body.outerHTML,
+        title: dom.title,
+        dom,
+      }
+    }
+
+    const expandedDom = await this.expandLinksAndCombine(dom)
+    return {
+      content: expandedDom.body.outerHTML,
+      title: dom.title,
+      dom: expandedDom,
+    }
+  }
+}

--- a/packages/content-handler/test/ars-technica.test.ts
+++ b/packages/content-handler/test/ars-technica.test.ts
@@ -1,0 +1,84 @@
+import { ArsTechnicaHandler } from '../src/websites/ars-technica-handler'
+import fs from 'fs'
+import nock from 'nock'
+import { expect } from 'chai'
+import { parseHTML } from 'linkedom'
+
+describe('Testing parsing multi-page articles from arstechnica.', () => {
+  let orignalArticle: Document | undefined
+  let htmlPg1: string | null
+  let htmlPg2: string | null
+  let htmlPg3: string | null
+
+  const load = (path: string): string => {
+    return fs.readFileSync(path, 'utf8')
+  }
+
+  before(() => {
+    htmlPg1 = load('./test/data/ars-multipage/ars-technica-page-1.html')
+    htmlPg2 = load('./test/data/ars-multipage/ars-technica-page-2.html')
+    htmlPg3 = load('./test/data/ars-multipage/ars-technica-page-3.html')
+
+    orignalArticle = parseHTML(htmlPg1).document
+  })
+
+  beforeEach(() => {
+    nock('https://arstechnica.com').get('/article/').reply(200, htmlPg1!)
+    nock('https://arstechnica.com').get('/article/2/').reply(200, htmlPg2!)
+    nock('https://arstechnica.com').get('/article/3/').reply(200, htmlPg3!)
+  })
+
+  afterEach(() => { 
+    nock.cleanAll();
+  })
+
+  it('should parse the title of the atlantic article.', async () => {
+    const response = await new ArsTechnicaHandler().preHandle(
+      'https://arstechnica.com/article/'
+    )
+
+    // We grab the title from the doucment.
+    expect(response.title).not.to.be.undefined
+    expect(response.title).to.equal(
+      'What’s going on with the reports of a room-temperature superconductor? | Ars Technica'
+    )
+  })
+
+  it('should remove the navigation links', async () => {
+    const response = await new ArsTechnicaHandler().preHandle(
+      'https://arstechnica.com/article/'
+    )
+
+    console.log(response.dom?.querySelectorAll('nav.page-numbers'));
+    // This should not exist
+    expect(orignalArticle?.querySelector('nav.page-numbers')).not.to.be.null
+    expect(response.dom?.querySelectorAll('nav.page-numbers').length).to.equal(0);
+  })
+
+  it('should append all new content into the main article', async () => {
+    const response = await new ArsTechnicaHandler().preHandle(
+      'https://arstechnica.com/article/'
+    )
+
+    // We name the div to ensure we can validate that it has been inserted.
+    expect(
+      orignalArticle?.getElementsByClassName('nextPageContents')?.length || 0
+    ).to.equal(0)
+    expect(
+      response.dom?.getElementsByClassName('nextPageContents')?.length || 0
+    ).not.to.equal(0)
+  })
+
+  it('should remove any related content links.', async () => {
+    const response = await new ArsTechnicaHandler().preHandle(
+      'https://arstechnica.com/article/'
+    )
+
+    // This exists in the HTML, but we remove it when preparsing.
+    expect(
+      response.dom?.getElementsByClassName(
+        'ArticleRelatedContentModule_root__BBa6g'
+      ).length
+    ).to.eql(0)
+  })
+})

--- a/packages/content-handler/test/ars-technica.test.ts
+++ b/packages/content-handler/test/ars-technica.test.ts
@@ -49,8 +49,6 @@ describe('Testing parsing multi-page articles from arstechnica.', () => {
       'https://arstechnica.com/article/'
     )
 
-    console.log(response.dom?.querySelectorAll('nav.page-numbers'));
-    // This should not exist
     expect(orignalArticle?.querySelector('nav.page-numbers')).not.to.be.null
     expect(response.dom?.querySelectorAll('nav.page-numbers').length).to.equal(0);
   })

--- a/packages/content-handler/test/data/ars-multipage/ars-technica-page-1.html
+++ b/packages/content-handler/test/data/ars-multipage/ars-technica-page-1.html
@@ -1,0 +1,855 @@
+<!DOCTYPE html>
+<html lang="en-us">
+
+<head>
+  <title>What’s going on with the reports of a room-temperature superconductor? | Ars Technica</title>
+<script type="text/javascript">
+  ars = {"ASSETS":"https:\/\/cdn.arstechnica.net\/wp-content\/themes\/ars\/assets","HOME_URL":"https:\/\/arstechnica.com","CIVIS":"\/civis","THEME":"light","VIEW":"grid","MOBILE":false,"SUBSCRIBER":false,"PLUS_PLUS":false,"LOGGED":false,"USER_ID":null,"ENV":"production","AD":{"tags":["chemistry","electrons","physics","superconductivity"],"channel":"science","slug":"whats-going-on-with-the-reports-of-a-room-temperature-superconductor","template_type":"article","queue":[],"server":"production"},"TOTAL":109336,"UNREAD":0,"RECENT":[1958894,1950200,1958504,1958915,1958785,1958895,1953746,1958601,1958766,1958740,1958758,1958728,1958672,1958712,1958544,1958702,1958680,1958662,1958644,1958600,1958632,1958537,1958110,1958563,1958508],"LOGINS":true,"CROSS":false,"PARSELY":"arstechnica.com","COMMENTS":false,"HOMEPAGE":false,"SITE":1,"READY":[],"SHOW_ADS":true,"IMG_PROXY":"https:\/\/cdn.arstechnica.net\/i\/","CATEGORY":"science","PAGETITLE":"","ZEN_MODE":false,"MEMO_PID":"62012a7a19351c07620394e0"};
+</script>
+<link rel="stylesheet" type="text/css" media="all" href="https://cdn.arstechnica.net/wp-content/themes/ars/assets/css/main-4b9af0fe84.css" />
+    <link rel="alternate" type="application/rss+xml" href="http://feeds.arstechnica.com/arstechnica/index" />
+  <link rel="shortcut icon" href="https://cdn.arstechnica.net/favicon.ico" />
+  <link rel="icon" type="image/x-icon" href="https://cdn.arstechnica.net/favicon.ico" />
+  <link rel="apple-touch-icon" sizes="180x180" href="https://cdn.arstechnica.net/wp-content/themes/ars/assets/img/ars-ios-icon-d9a45f558c.png" />
+  <link rel="mask-icon" href="https://cdn.arstechnica.net/wp-content/themes/ars/assets/img/ars-macos-safari-8997f76b21.svg" color="#ff4e00">
+  <link rel="icon" sizes="192x192" href="https://cdn.arstechnica.net/wp-content/themes/ars/assets/img/material-ars-db41652381.png" />
+  <link rel="me" href="https://mastodon.social/@arstechnica" />
+
+    <meta name="application-name" content="Ars Technica"/>
+  <meta name="msapplication-starturl" content="http://arstechnica.com/"/>
+  <meta name="msapplication-tooltip" content="Ars Technica: Serving the technologist for 1.2 decades"/>
+  <meta name="msapplication-task" content="name=News;action-uri=http://arstechnica.com/;icon-uri=https://cdn.arstechnica.net/favicon.ico"/>
+  <meta name="msapplication-task" content="name=Features;action-uri=http://arstechnica.com/features/;icon-uri=https://cdn.arstechnica.net/ie-jump-menu/jump-features.ico"/>
+  <meta name="msapplication-task" content="name=OpenForum;action-uri=http://arstechnica.com/civis/;icon-uri=https://cdn.arstechnica.net/ie-jump-menu/jump-forum.ico"/>
+  <meta name="msapplication-task" content="name=Subscribe;action-uri=http://arstechnica.com/subscriptions/;icon-uri=https://cdn.arstechnica.net/ie-jump-menu/jump-subscribe.ico"/>
+
+
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <meta name="advertising" content="ask" />
+  <meta property="fb:admins" content="592156917" />
+  <meta property="fb:admins" content="108943" />
+  <meta property="fb:pages" content="19374573752" />
+
+  <meta name="format-detection" content="telephone=no" />
+  <meta name="theme-color" content="#000000" />
+
+  
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+
+  <!-- cache hit 192:single/meta:d29d6446a030580dc69054ef5c06dab8 -->
+<meta name='parsely-page' content='{"title":"What\u2019s going on with the reports of a room-temperature superconductor?","link":"https:\/\/arstechnica.com\/science\/2023\/08\/whats-going-on-with-the-reports-of-a-room-temperature-superconductor\/","type":"post","author":"John Timmer","post_id":1958785,"pub_date":"2023-08-04T14:07:48Z","section":"Science","tags":["chemistry","electrons","physics","superconductivity","type: feature"],"image_url":"https:\/\/cdn.arstechnica.net\/wp-content\/uploads\/2023\/08\/LK-99_pellet-150x150.png"}'>
+<meta name='parsely-metadata' content='{"type":"feature","title":"What\u2019s going on with the reports of a room-temperature superconductor?","post_id":1958785,"lower_deck":"Rumors are flying of confirmation, but the situation is still frustratingly vague.","image_url":"https:\/\/cdn.arstechnica.net\/wp-content\/uploads\/2023\/08\/LK-99_pellet-150x150.png","listing_image_url":"https:\/\/cdn.arstechnica.net\/wp-content\/uploads\/2023\/08\/LK-99_pellet-360x200.png"}'>
+
+  <link rel="canonical" href="https://arstechnica.com/science/2023/08/whats-going-on-with-the-reports-of-a-room-temperature-superconductor/" />
+
+<link rel="amphtml" href="https://arstechnica.com/science/2023/08/whats-going-on-with-the-reports-of-a-room-temperature-superconductor/amp/">
+
+<link rel="shorturl" href="https://arstechnica.com/?p=1958785" />
+
+<meta name="description" content="Rumors are flying of confirmation, but the situation is still frustratingly vague." />
+
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:url" content="https://arstechnica.com/science/2023/08/whats-going-on-with-the-reports-of-a-room-temperature-superconductor/">
+<meta name="twitter:title" content="What’s going on with the reports of a room-temperature superconductor?">
+<meta name="twitter:description" content="Rumors are flying of confirmation, but the situation is still frustratingly vague.">
+
+<meta name="twitter:site" content="@arstechnica">
+<meta name="twitter:domain" content="arstechnica.com">
+
+<meta property="og:site_name" content="Ars Technica" />
+
+<meta name="twitter:image:src" content="https://cdn.arstechnica.net/wp-content/uploads/2023/08/LK-99_pellet-760x380.png">
+  <meta name="twitter:image:width" content="760">
+  <meta name="twitter:image:height" content="380">
+
+  <meta name="twitter:creator" content="@j_timmer">
+
+<meta property="og:url" content="https://arstechnica.com/science/2023/08/whats-going-on-with-the-reports-of-a-room-temperature-superconductor/" />
+<meta property="og:title" content="What’s going on with the reports of a room-temperature superconductor?" />
+<meta property="og:image" content="https://cdn.arstechnica.net/wp-content/uploads/2023/08/LK-99_pellet-760x380.png" />
+<meta property="og:description" content="Rumors are flying of confirmation, but the situation is still frustratingly vague." />
+<meta property="og:type" content="article" />
+  <!-- cache hit 192:single/header:d29d6446a030580dc69054ef5c06dab8 -->
+        
+
+<!-- OneTrust Cookies Consent Notice start -->
+<script 
+    src="https://cdn.cookielaw.org/scripttemplates/otSDKStub.js"  
+    type="text/javascript" charset="UTF-8" 
+    data-domain-script="b10882a1-8446-4e7d-bfb2-ce2c770ad910">
+</script>
+<script type="text/javascript">function OptanonWrapper(){};</script>
+<script 
+    src="https://cdn.cookielaw.org/opt-out/otCCPAiab.js" 
+    type="text/javascript" 
+    charset="UTF-8" 
+    ccpa-opt-out-ids="C0002,C0003,C0004,C0005" 
+    ccpa-opt-out-geo="ca" 
+    ccpa-opt-out-lspa="true">
+</script> 
+<!-- OneTrust Cookies Consent Notice end -->
+<!-- Google Tag Manager DataLayer -->
+<script>
+window.dataLayer = window.dataLayer || [];
+window.dataLayer.push({"event":"data-layer-loaded","user":{"ars_userId":undefined,"amg_userId":undefined,"uID":undefined,"sID":undefined,"loginStatus":false,"subscriberStatus":"none","infinityId":undefined,"registrationSource":undefined,"mdw_cnd_id":undefined,"monthlyVisits":undefined,"accessPaywall":undefined,"view":"grid","theme":"light","show_comments":false},"content":{"pageTemplate":"single","pageType":"article|feature","contentCategory":"science","section":"science","subsection":undefined,"contributor":"John Timmer","contentID":1958785,"contentLength":2098,"display":"What\u2019s going on with the reports of a room-temperature superconductor?","contentSource":"web","pageAssets":undefined,"uniqueContentCount":undefined,"monthlyContentCount":undefined,"publishDate":"2023-08-04T14:07:48-04:00","modifiedDate":"2023-08-04T15:56:15-04:00","keywords":"chemistry|electrons|Physics|superconductivity","dataSource":undefined},"marketing":{"campaignName":undefined,"circCampaignId":undefined,"internalCampaignId":undefined,"brand":"Ars Technica","certified_mrc_data":undefined,"condeNastId":undefined},"page":{"pID":undefined,"syndicatorUrl":undefined,"pageURL":"https:\/\/arstechnica.com\/?p=1958785","canonical":"https:\/\/arstechnica.com\/science\/2023\/08\/whats-going-on-with-the-reports-of-a-room-temperature-superconductor\/","canonicalPathName":"\/science\/2023\/08\/whats-going-on-with-the-reports-of-a-room-temperature-superconductor\/"},"search":{"facets":undefined,"searchTerms":undefined},"site":{"appVersion":"1.0.0"}});
+</script>
+<!-- End Google Tag Manager DataLayer -->
+<!-- Google Tag Manager -->
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-NLXNPCQ');</script>
+<!-- End Google Tag Manager -->
+<!-- Start Headline A/B -->
+<script type="text/javascript">
+  class ABTest {
+    constructor(post_id, init_method) {
+      this.post_id = post_id;
+      this.ajaxurl = '/services/ars-ajax-handler.php';
+      this.expireDays = 1 / 48; // 30 min
+      this.group = this.getGroup();
+      this.uid = this.getUid();
+      this.init_method = init_method;
+      this.setTitle();
+
+      if (this.init_method === 'click') {
+        this.click();
+      } else {
+        this.impression();
+      }
+    }
+
+    setCookie(name, value, days) {
+      var expires = "";
+      if (days) {
+        var date = new Date();
+        date.setTime(date.getTime() + (days * 24 * 60 * 60 * 1000));
+        expires = "; expires=" + date.toUTCString();
+      }
+      document.cookie = name + "=" + (value || "") + expires + "; path=/";
+    }
+
+    getCookie(name) {
+      var nameEQ = name + "=";
+      var ca = document.cookie.split(';');
+      for (var i = 0; i < ca.length; i++) {
+        var c = ca[i];
+        while (c.charAt(0) == ' ') c = c.substring(1, c.length);
+        if (c.indexOf(nameEQ) == 0) return c.substring(nameEQ.length, c.length);
+      }
+      return null;
+    }
+
+    // Retrieves a unique id for determining whether the event should be recorded
+    getUid() {
+      var uid = this.getCookie('ars_ab_' + this.post_id + '_uid');
+      if (!uid) {
+        uid = (Math.random() + 1).toString(36).substring(2, 7);
+        this.setCookie('ars_ab_' + this.post_id + '_uid', uid, this.expireDays);
+      }
+      return uid;
+    };
+
+    // Places the user in either A or B for this post id
+    getGroup() {
+      var group = this.getCookie('ars_ab_' + this.post_id + '_group');
+      if (!group) {
+        group = String.fromCharCode(Math.floor(Math.random() * 2) + 65).toLowerCase();
+        this.setCookie('ars_ab_' + this.post_id + '_group', group, this.expireDays);
+      }
+      return group;
+    };
+
+    // Records a headline impression (from homepage or other listing)
+    impression() {
+      // Send fake ajax
+      var params = {
+        nonce: '4dadc83aa5',
+        action: 'ars_ab_impression',
+        id: this.post_id,
+        group: this.group,
+        uid: this.uid,
+        ts: (new Date()).getTime()
+      };
+      var url = this.ajaxurl + '?' + this.encodeParams(params);
+      document.write('\x3Cscript type="text/javascript" src="' + url + '">\x3C/script>');
+    };
+
+    // Records a headline click from the actual post page
+    click() {
+      // Send fake ajax
+      var params = {
+        nonce: '34b2ae4b70',
+        action: 'ars_ab_click',
+        id: this.post_id,
+        group: this.group,
+        uid: this.uid,
+        ts: (new Date()).getTime()
+      };
+      var url = this.ajaxurl + '?' + this.encodeParams(params);
+      document.write('\x3Cscript type="text/javascript" src="' + url + '">\x3C/script>');
+    };
+
+    // If user is in B group, dynamically set title
+    setTitle() {
+      if (this.group == 'b') {
+        var span = document.getElementById('ars_ab_' + this.post_id);
+        var title = span.parentNode;
+        title.innerHTML = span.getAttribute('data-title-b');
+      }
+    };
+
+    encodeParams(data) {
+      var ret = [];
+      for (var d in data)
+        ret.push(encodeURIComponent(d) + "=" + encodeURIComponent(data[d]));
+      return ret.join("&");
+    };
+
+  };
+</script>
+<!-- End Headline A/B -->
+<script src="https://www.googletagservices.com/tag/js/gpt.js" id="gpt-script" async></script>
+<script>
+  window.googletag = window.googletag || {};
+  window.googletag.cmd = window.googletag.cmd || [];
+  window.cns = window.cns || {};
+  window.cns.queue = [];
+  window.cns.async = function(s, c) {
+    cns.queue.push({
+      service: s,
+      callback: c
+    })
+  };
+  window.sparrowQueue = window.sparrowQueue || [];
+</script>
+<script>
+  window.cns.pageContext = {"contentType":"article","templateType":"article","channel":"science","subChannel":"","slug":"whats-going-on-with-the-reports-of-a-room-temperature-superconductor","server":"production","keywords":{"tags":["chemistry","electrons","physics","superconductivity"],"cm":[],"platform":["wordpress"],"copilotid":""}};
+</script>
+<script src="https://ads-static.conde.digital/production/cns/builds/ars-technica/ars-technica.min.js" async></script>
+<script type="text/javascript" src="https://cdn.arstechnica.net/wp-content/themes/ars/assets/js/ars-84a4ab0802.ads.us.js"></script>
+  <script type="text/javascript">!(function(o,_name){function n(){(n.q=n.q||[]).push(arguments)}n.v=1,o[_name]=o[_name]||n;!(function(o,t,n,c){function e(n){(function(){try{return(localStorage.getItem("v4ac1eiZr0")||"").split(",")[4]>0}catch(o){}return!1})()&&(n=o[t].pubads())&&n.setTargeting("admiral-engaged","true")}(c=o[t]=o[t]||{}).cmd=c.cmd||[],typeof c.pubads===n?e():typeof c.cmd.unshift===n?c.cmd.unshift(e):c.cmd.push(e)})(window,"googletag","function");})(window,String.fromCharCode(97,100,109,105,114,97,108));!(function(t,c,i){i=t.createElement(c),t=t.getElementsByTagName(c)[0],i.async=1,i.src="https://shiverscissors.com/v2fumwIJOo-LsCB0dlG18VSTW43CpWhUEPJuKeRTzrEQdSPPlMr5GymU",t.parentNode.insertBefore(i,t)})(document,"script");</script>
+
+  <!-- Taboola -->
+  <script type="text/javascript">
+    window._taboola = window._taboola || [];
+    _taboola.push({
+      article: 'auto'
+    });
+    ! function(e, f, u, i) {
+      if (!document.getElementById(i)) {
+        e.async = 1;
+        e.src = u;
+        e.id = i;
+        f.parentNode.insertBefore(e, f);
+      }
+    }(document.createElement('script'),
+      document.getElementsByTagName('script')[0],
+      '//cdn.taboola.com/libtrc/condenast1-network/loader.js',
+      'tb_loader_script');
+    if (window.performance && typeof window.performance.mark == 'function') {
+      window.performance.mark('tbl_ic');
+    }
+  </script>
+  <meta name='robots' content='max-image-preview:large' />
+<link rel='dns-prefetch' href='//s.w.org' />
+<link rel='dns-prefetch' href='//arstechnica-apps.s3.amazonaws.com' />
+<link rel='stylesheet' id='wp-block-library-css'  href='https://cdn.arstechnica.net/wp/wp-includes/css/dist/block-library/style.min.css?ver=6.0.3' type='text/css' media='all' />
+<style id='global-styles-inline-css' type='text/css'>
+body{--wp--preset--color--black: #000000;--wp--preset--color--cyan-bluish-gray: #abb8c3;--wp--preset--color--white: #ffffff;--wp--preset--color--pale-pink: #f78da7;--wp--preset--color--vivid-red: #cf2e2e;--wp--preset--color--luminous-vivid-orange: #ff6900;--wp--preset--color--luminous-vivid-amber: #fcb900;--wp--preset--color--light-green-cyan: #7bdcb5;--wp--preset--color--vivid-green-cyan: #00d084;--wp--preset--color--pale-cyan-blue: #8ed1fc;--wp--preset--color--vivid-cyan-blue: #0693e3;--wp--preset--color--vivid-purple: #9b51e0;--wp--preset--gradient--vivid-cyan-blue-to-vivid-purple: linear-gradient(135deg,rgba(6,147,227,1) 0%,rgb(155,81,224) 100%);--wp--preset--gradient--light-green-cyan-to-vivid-green-cyan: linear-gradient(135deg,rgb(122,220,180) 0%,rgb(0,208,130) 100%);--wp--preset--gradient--luminous-vivid-amber-to-luminous-vivid-orange: linear-gradient(135deg,rgba(252,185,0,1) 0%,rgba(255,105,0,1) 100%);--wp--preset--gradient--luminous-vivid-orange-to-vivid-red: linear-gradient(135deg,rgba(255,105,0,1) 0%,rgb(207,46,46) 100%);--wp--preset--gradient--very-light-gray-to-cyan-bluish-gray: linear-gradient(135deg,rgb(238,238,238) 0%,rgb(169,184,195) 100%);--wp--preset--gradient--cool-to-warm-spectrum: linear-gradient(135deg,rgb(74,234,220) 0%,rgb(151,120,209) 20%,rgb(207,42,186) 40%,rgb(238,44,130) 60%,rgb(251,105,98) 80%,rgb(254,248,76) 100%);--wp--preset--gradient--blush-light-purple: linear-gradient(135deg,rgb(255,206,236) 0%,rgb(152,150,240) 100%);--wp--preset--gradient--blush-bordeaux: linear-gradient(135deg,rgb(254,205,165) 0%,rgb(254,45,45) 50%,rgb(107,0,62) 100%);--wp--preset--gradient--luminous-dusk: linear-gradient(135deg,rgb(255,203,112) 0%,rgb(199,81,192) 50%,rgb(65,88,208) 100%);--wp--preset--gradient--pale-ocean: linear-gradient(135deg,rgb(255,245,203) 0%,rgb(182,227,212) 50%,rgb(51,167,181) 100%);--wp--preset--gradient--electric-grass: linear-gradient(135deg,rgb(202,248,128) 0%,rgb(113,206,126) 100%);--wp--preset--gradient--midnight: linear-gradient(135deg,rgb(2,3,129) 0%,rgb(40,116,252) 100%);--wp--preset--duotone--dark-grayscale: url('#wp-duotone-dark-grayscale');--wp--preset--duotone--grayscale: url('#wp-duotone-grayscale');--wp--preset--duotone--purple-yellow: url('#wp-duotone-purple-yellow');--wp--preset--duotone--blue-red: url('#wp-duotone-blue-red');--wp--preset--duotone--midnight: url('#wp-duotone-midnight');--wp--preset--duotone--magenta-yellow: url('#wp-duotone-magenta-yellow');--wp--preset--duotone--purple-green: url('#wp-duotone-purple-green');--wp--preset--duotone--blue-orange: url('#wp-duotone-blue-orange');--wp--preset--font-size--small: 13px;--wp--preset--font-size--medium: 20px;--wp--preset--font-size--large: 36px;--wp--preset--font-size--x-large: 42px;}.has-black-color{color: var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-color{color: var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-color{color: var(--wp--preset--color--white) !important;}.has-pale-pink-color{color: var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-color{color: var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-color{color: var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-color{color: var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-color{color: var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-color{color: var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-color{color: var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-color{color: var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-color{color: var(--wp--preset--color--vivid-purple) !important;}.has-black-background-color{background-color: var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-background-color{background-color: var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-background-color{background-color: var(--wp--preset--color--white) !important;}.has-pale-pink-background-color{background-color: var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-background-color{background-color: var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-background-color{background-color: var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-background-color{background-color: var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-background-color{background-color: var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-background-color{background-color: var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-background-color{background-color: var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-background-color{background-color: var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-background-color{background-color: var(--wp--preset--color--vivid-purple) !important;}.has-black-border-color{border-color: var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-border-color{border-color: var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-border-color{border-color: var(--wp--preset--color--white) !important;}.has-pale-pink-border-color{border-color: var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-border-color{border-color: var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-border-color{border-color: var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-border-color{border-color: var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-border-color{border-color: var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-border-color{border-color: var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-border-color{border-color: var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-border-color{border-color: var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-border-color{border-color: var(--wp--preset--color--vivid-purple) !important;}.has-vivid-cyan-blue-to-vivid-purple-gradient-background{background: var(--wp--preset--gradient--vivid-cyan-blue-to-vivid-purple) !important;}.has-light-green-cyan-to-vivid-green-cyan-gradient-background{background: var(--wp--preset--gradient--light-green-cyan-to-vivid-green-cyan) !important;}.has-luminous-vivid-amber-to-luminous-vivid-orange-gradient-background{background: var(--wp--preset--gradient--luminous-vivid-amber-to-luminous-vivid-orange) !important;}.has-luminous-vivid-orange-to-vivid-red-gradient-background{background: var(--wp--preset--gradient--luminous-vivid-orange-to-vivid-red) !important;}.has-very-light-gray-to-cyan-bluish-gray-gradient-background{background: var(--wp--preset--gradient--very-light-gray-to-cyan-bluish-gray) !important;}.has-cool-to-warm-spectrum-gradient-background{background: var(--wp--preset--gradient--cool-to-warm-spectrum) !important;}.has-blush-light-purple-gradient-background{background: var(--wp--preset--gradient--blush-light-purple) !important;}.has-blush-bordeaux-gradient-background{background: var(--wp--preset--gradient--blush-bordeaux) !important;}.has-luminous-dusk-gradient-background{background: var(--wp--preset--gradient--luminous-dusk) !important;}.has-pale-ocean-gradient-background{background: var(--wp--preset--gradient--pale-ocean) !important;}.has-electric-grass-gradient-background{background: var(--wp--preset--gradient--electric-grass) !important;}.has-midnight-gradient-background{background: var(--wp--preset--gradient--midnight) !important;}.has-small-font-size{font-size: var(--wp--preset--font-size--small) !important;}.has-medium-font-size{font-size: var(--wp--preset--font-size--medium) !important;}.has-large-font-size{font-size: var(--wp--preset--font-size--large) !important;}.has-x-large-font-size{font-size: var(--wp--preset--font-size--x-large) !important;}
+</style>
+<link rel='stylesheet' id='article_forum_connect_comments-css'  href='https://cdn.arstechnica.net/wp-content/plugins/article-forum-connect/public/css/comments.css?ver=1.2.2' type='text/css' media='all' />
+<link rel='stylesheet' id='article_forum_connect_paywall-css'  href='https://cdn.arstechnica.net/wp-content/plugins/article-forum-connect/public/css/paywall.css?ver=1.2.2' type='text/css' media='all' />
+<link rel="amphtml" href="https://arstechnica.com/science/2023/08/whats-going-on-with-the-reports-of-a-room-temperature-superconductor/amp/"><meta name="twitter:partner" content="tfwp" />
+<!--
+	generated 191 seconds ago
+	generated in 0.222 seconds
+	served from batcache in 0.002 seconds
+	expires in 109 seconds
+	billboard: forced 
+	view: grid 
+	theme: light 
+ -->
+</head>
+
+<body class="post-template-default single single-post postid-1958785 single-format-standard grid-view light blog-us">
+  <!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-NLXNPCQ" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) -->
+
+      	<aside class="ad ad_crown" aria-label="Top of page advertisement"></aside>
+  
+  <div class="site-wrapper">
+    <a class="screen-reader-text skip-link" href="#main" aria-label="Skip to main content">Skip to main content</a>
+    <header class="site-header">
+      <div class="header-left">
+        <a href="https://arstechnica.com" id="header-logo" title="Ars Technica Homepage">
+      <span class="icon icon-logo-ars-us"></span>
+  </a>
+      </div>
+
+      <div class="header-right">
+        <nav id="header-nav-primary">
+          <ul>
+            
+  <li><a class="nav-link section-information-technology " href="/information-technology/">Biz &amp; IT</a></li>
+  <li><a class="nav-link section-gadgets " href="/gadgets/">Tech</a></li>
+  <li><a class="nav-link section-science active" href="/science/">Science</a></li>
+  <li><a class="nav-link section-tech-policy " href="/tech-policy/">Policy</a></li>
+  <li><a class="nav-link section-cars " href="/cars/">Cars</a></li>
+  <li><a class="nav-link section-gaming " href="/gaming/">Gaming &amp; Culture</a></li>
+  <li><a class="nav-link store" href="/store/">Store</a></li>
+  <li><a class="nav-link forums" href="/civis/">Forums</a></li>
+          </ul>
+        </nav>
+
+                              <a href="/store/product/subscriptions/" class="header-highlight-link">Subscribe</a>
+                                  <div class="dropdown" id="header-search">
+          <a href="/search/" class="dropdown-toggle search-toggle" aria-label="Search" aria-expanded="false">
+            <span class="icon icon-search-mag-glass"></span>
+          </a>
+          <div class="dropdown-content">
+            <form action="/search/" method="GET" id="search_form">
+  <input type="hidden" name="ie" value="UTF-8">
+  <input type="text" name="q" id="hdr_search_input" value="" aria-label="Search..." placeholder="Search...">
+</form>
+<a class="nav-search-close">Close</a>
+          </div>
+        </div>
+        <div class="dropdown dropdown-mega" id="header-burger">
+          <a href="#site-menu" class="dropdown-toggle" aria-label="Menu" aria-expanded="false">
+            <span></span>
+          </a>
+          <div id="site-menu" class="dropdown-content">
+            <section class="burger-navigate">
+  <h3>
+    <span class="icon icon-half-target"></span>
+    Navigate
+  </h3>
+  <ul>
+          <li><a class="nav-link store" href="/store/">Store</a></li>
+      <li><a class="nav-link subscribe" href="/store/product/subscriptions/">Subscribe</a></li>
+        <li><a class="nav-link videos" href="http://video.arstechnica.com/">Videos</a></li>
+    <li><a class="nav-link section-features" href="/features/">Features</a></li>
+    <li><a class="nav-link section-reviews" href="/reviews/">Reviews</a></li>
+  </ul>
+
+  <ul>
+    <li><a class="nav-link page-rss-feeds" href="/rss-feeds/">RSS Feeds</a></li>
+    <li><a class="nav-link mobile" href="/?view=mobile">Mobile Site</a></li>
+  </ul>
+
+  <ul>
+    <li><a class="nav-link page-about-us" href="/about-us/">About Ars</a></li>
+    <li><a class="nav-link page-staff-directory" href="/staff-directory/">Staff Directory</a></li>
+    <li><a class="nav-link page-contact-us" href="/contact-us/">Contact Us</a></li>
+  </ul>
+
+  <ul>
+    <li><a class="nav-link page-advertise-with-us" href="https://www.condenast.com/brands/ars-technica">Advertise with Ars</a></li>
+    <li><a class="nav-link page-reprints" href="/reprints/">Reprints</a></li>
+  </ul>
+</section>
+
+<section class="burger-filter">
+  <h3>
+    <span class="icon icon-half-mag"></span>
+    Filter by topic
+  </h3>
+  <ul id="burger-nav-primary">
+    
+  <li><a class="nav-link section-information-technology " href="/information-technology/">Biz &amp; IT</a></li>
+  <li><a class="nav-link section-gadgets " href="/gadgets/">Tech</a></li>
+  <li><a class="nav-link section-science active" href="/science/">Science</a></li>
+  <li><a class="nav-link section-tech-policy " href="/tech-policy/">Policy</a></li>
+  <li><a class="nav-link section-cars " href="/cars/">Cars</a></li>
+  <li><a class="nav-link section-gaming " href="/gaming/">Gaming &amp; Culture</a></li>
+  <li><a class="nav-link store" href="/store/">Store</a></li>
+  <li><a class="nav-link forums" href="/civis/">Forums</a></li>
+  </ul>
+</section>
+
+<section class="burger-settings">
+  <h3>
+    <span class="icon icon-half-gear"></span>
+    Settings
+  </h3>
+  <div>
+    <div class="burger-layout">
+      
+<p>Front page layout</p>
+<div class="burger-layout-grid">
+  <a rel="nofollow" href="/science/2023/08/whats-going-on-with-the-reports-of-a-room-temperature-superconductor/?view=grid">
+    <span class="icon icon-grid"></span><br>
+    Grid
+    <div class="faux-radio active"></div>
+  </a>
+</div>
+
+<div class="burger-layout-list">
+  <a rel="nofollow" href="/science/2023/08/whats-going-on-with-the-reports-of-a-room-temperature-superconductor/?view=archive">
+    <span class="icon icon-list"></span><br>
+    List
+    <div class="faux-radio "></div>
+  </a>
+</div>
+
+    </div>
+    <div class="burger-theme">
+      <p>Site theme</p>
+  <div class="burger-theme-light">
+    <a rel="nofollow" href="/science/2023/08/whats-going-on-with-the-reports-of-a-room-temperature-superconductor/?theme=light">
+      <span><span>light</span></span>
+      <div class="faux-radio active"></div>
+    </a>
+  </div>
+  <div class="burger-theme-dark">
+    <a rel="nofollow" href="/science/2023/08/whats-going-on-with-the-reports-of-a-room-temperature-superconductor/?theme=dark">
+      <span><span>dark</span></span>
+      <div class="faux-radio "></div>
+    </a>
+  </div>
+    </div>
+  </div>
+</section>
+          </div>
+        </div>
+              <a class="navlink login-link" href="https://arstechnica.com/civis/login?_xfRedirect=%2Fscience%2F2023%2F08%2Fwhats-going-on-with-the-reports-of-a-room-temperature-superconductor%2F">
+      Sign in
+    </a>
+  
+        </div>
+    </header>
+
+              
+    <main id="main" class="content-wrapper">
+
+<script type="text/javascript">
+  ars.ARTICLE = {"url":"https:\/\/arstechnica.com\/science\/2023\/08\/whats-going-on-with-the-reports-of-a-room-temperature-superconductor\/","short_url":"https:\/\/arstechnica.com\/?p=1958785","title":"What\u2019s going on with the reports of a room-temperature superconductor?","author":52979,"authorName":"John Timmer","pubDate":"2023-08-04T14:07:48Z","id":1958785,"topic":1494994,"pages":3,"current_page":1,"superscroll":true,"promoted":[],"single_page":false,"comments":87,"fullwidth":false,"slug":"whats-going-on-with-the-reports-of-a-room-temperature-superconductor","arsStaff":{"104481":{"name":"Aaron Zimmerman","title":"Copy Chief","staff":true},"332715":{"name":"Andrew Cunningham","title":"Senior Technology Reporter","staff":true},"855306":{"name":"Ashley Belanger","title":"Senior Policy Reporter","staff":true},"1002":{"name":"Aurich Lawson","title":"Creative Director","staff":true},"857898":{"name":"Benj Edwards","title":"AI and Machine Learning Reporter","staff":true},"509873":{"name":"Beth Mole","title":"Senior Health Reporter","staff":true},"453791":{"name":"Cathleen O'Grady","title":"Contributing science reporter","staff":true},"102179":{"name":"Chris Lee","title":"Associate writer","staff":true},"821742":{"name":"Corey Gaskin","title":"Senior Commerce Writer","staff":true},"329388":{"name":"Dan Goodin","title":"Security Editor","staff":true},"254631":{"name":"Diana Gitig","title":"Associate Writer","staff":false},"25862":{"name":"Eric Bangeman","title":"Managing Editor","staff":true},"512413":{"name":"Eric Berger","title":"Senior Space Editor","staff":true},"46707":{"name":"Iljitsch van Beijnum","title":"Associate Writer","staff":false},"316010":{"name":"Jason Marlin","title":"Technical Director","staff":true},"746799":{"name":"Jennifer Ouellette","title":"Senior Writer","staff":true},"15365":{"name":"Jeremy Reimer","title":"Senior Niche Technology Historian","staff":false},"52979":{"name":"John Timmer","title":"Senior Science Editor","staff":true},"312082":{"name":"Jon Brodkin","title":"Senior IT Reporter","staff":true},"14317":{"name":"Jonathan M. Gitlin","title":"Automotive Editor","staff":true},"998":{"name":"Ken Fisher","title":"Editor in Chief","staff":true},"440179":{"name":"Kerry Staurseth","title":"Associate Copyeditor","staff":true},"856780":{"name":"Kevin Purdy","title":"Senior Technology Reporter","staff":true},"328283":{"name":"Kyle Orland","title":"Senior Gaming Editor","staff":true},"10243":{"name":"Lee Hutchinson","title":"Senior Technology Editor","staff":true},"173191":{"name":"Matthew Lasar","title":"Associate writer","staff":true},"182268":{"name":"Nate Anderson","title":"Deputy Editor","staff":true},"1991":{"name":"Ohrmazd","title":"","staff":false},"391727":{"name":"Ron Amadeo","title":"Reviews Editor","staff":true},"588289":{"name":"Samuel Axon","title":"Senior Editor","staff":true},"294205":{"name":"Scott K. Johnson","title":"Associate Writer","staff":true},"843451":{"name":"Steve Haske","title":"","staff":false},"173910":{"name":"Timothy B. Lee","title":"Senior tech policy reporter","staff":false}},"tags":["chemistry","electrons","physics","superconductivity"],"zen_mode":false};
+</script>
+
+<article itemscope itemtype="http://schema.org/NewsArticle" class="article-single standalone intro-standard " id="">
+      <div class="column-wrapper">
+    <div class="left-column">
+        <header class="article-header">
+            <h4 class="post-upperdek">
+      No answers yet    &mdash;
+</h4>
+            <h1 itemprop="headline">What’s going on with the reports of a room-temperature superconductor?</h1>
+            <h2 itemprop="description">Rumors are flying of confirmation, but the situation is still frustratingly vague.</h2>
+            <section class="post-meta">
+
+  
+<p class="byline" itemprop="author creator" itemscope itemtype="http://schema.org/Person">
+      <a itemprop="url" href="https://arstechnica.com/author/john-timmer/" rel="author"><span itemprop="name">John Timmer</span></a>
+    -  <time class="date" data-time="1691158068" datetime="2023-08-04T14:07:48+00:00">Aug 4, 2023 2:07 pm UTC</time>
+</p>
+
+
+  
+</section>        </header>
+        <section class="article-guts">
+            <div itemprop="articleBody" class="article-content post-page">
+                                    
+<figure class="intro-image intro-left">
+  <img src="https://cdn.arstechnica.net/wp-content/uploads/2023/08/LK-99_pellet-800x513.png" alt="Pellet of LK-99 being repelled by a magnet.">
+      <figcaption class="caption"><div class="caption-text"><a href="https://cdn.arstechnica.net/wp-content/uploads/2023/08/LK-99_pellet.png" class="enlarge-link" data-height="544" data-width="848">Enlarge</a> <span class="sep">/</span> Pellet of LK-99 being repelled by a magnet.</div><div class="caption-credit"><a rel="nofollow" class="caption-link" href="https://creativecommons.org/licenses/by/4.0/">Hyun-Tak Kim (CC BY 4.0)</a></div></figcaption>  </figure>
+
+  <aside id="social-left" class="social-left" aria-label="Read the comments or share this article">
+          <a class="comment-count icon-comment-bubble-down" href="https://arstechnica.com/science/2023/08/whats-going-on-with-the-reports-of-a-room-temperature-superconductor/?comments=1">
+      <h4 class="comment-count-before">reader comments</h4>
+  
+  <span class="comment-count-number">87</span>
+  <span class="visually-hidden"> with </span>
+  </a>
+        </aside>
+
+
+
+
+<!-- cache hit 192:single/related:d29d6446a030580dc69054ef5c06dab8 --><!-- empty -->
+<p>In late July, a couple of startling papers appeared on the arXiv, a repository of pre-peer-review manuscripts on topics in physics and astronomy. The papers claim to describe the synthesis of a material that is not only able to superconduct above room temperature, but also above the boiling point of water. And it does so at normal atmospheric pressures.</p>
+<p>Instead of having to build upon years of work with exotic materials that only work under extreme conditions, the papers seem to describe a material that could be made via some relatively straightforward chemistry and would work if you set it on your desk. It was like finding a shortcut to a material that would revolutionize society.</p>
+<p>The perfect time to write an article on those results would be when they've been confirmed by multiple labs. But these are not perfect times. Instead, rumors seem to be flying daily about possible confirmation, confusing and contradictory results, and informed discussions of why this material either should or shouldn't work.</p>
+<p>In this article, we'll explain where things stand and why getting to a place of clarity will be challenging, even if these claims are right.</p>
+<h2>What’s the original claim?</h2>
+<p>The <a href="https://arxiv.org/abs/2307.12037">more detailed of the two manuscripts</a> describes how to make the material and measurements of its property. The material itself is a variation of a well-known chemical called lead apatite. Apatites are a class of chemicals that form similar crystal structures; this particular version is primarily composed of lead and phosphate groups—all of its constituents are cheap and readily available.</p>                                            <aside class="ad_wrapper" aria-label="In Content advertisement">
+    <span class="ad_notice">Advertisement </span>    
+    <div class="ad ad_instream"></div>    
+</aside>
+                                                        
+<p>The version developed here, which has been termed LK-99, was made by reacting a lead sulfate with a copper-phosphorus compound (the reaction requires high temperatures for over a day under a vacuum). This strips the phosphorus from the copper, oxidizes it, and allows it to displace the sulfur from its compound with the lead. Critically, though, some fraction of the lead itself ends up replaced by copper in the resulting compound.</p>
+<p>This has a significant impact on the apatite crystal structure because copper is quite a bit smaller than lead. The researchers claim the overall volume of the sample drops by about half of a percentage as a result, and that change is accompanied by shifts in the orientation of various atoms and bonds. That means changes in where the electrons reside within the material.</p>
+<p>That change appears to be critical to the LK-99's behavior. Superconductivity is associated with a number of very specific properties, and the researchers measure two of them: the expulsion of magnetic field lines (called the Meissner effect) and the existence of a critical temperature at which conductivity changes.</p>
+<p>It's hard to explain just how strange these experiments are. Under normal circumstances, the superconducting material starts out behaving as a normal chemical and has to be cooled down to the critical point where exceptional behavior emerges. LK-99, by contrast, starts out superconducting and has to be heated beyond the boiling point of water to reach its critical temperature.</p>
+<p>The only somewhat strange result here comes at temperatures just below the critical temperature. At room temperature and above, the resistance of LK-99 remains at zero as far as the testing equipment is able to measure. But it starts to rise ever so slightly once temperatures reach 60°C and displays a smooth upward slope until the sample hits 90°C, at which point it stays flat until the critical temperature is reached. The researchers did not attempt to explain this.</p>
+
+                                                </div>
+
+            
+                            <nav class="page-numbers">Page: <span class="numbers">1 <a href="https://arstechnica.com/article/2/">2</a> <a href="https://arstechnica.com/article/3/">3</a> <a href="https://arstechnica.com/article/3/"><span class="next">Next <span class="arrow">&rarr;</span></span></a></span></nav>
+            
+        </section>
+    </div>
+    <div class="xrail">
+        <div class="xrail-content">
+            
+            
+            
+                            <div class="ars-interlude-container ad_xrail ad_xrail_top"></div>
+            
+            
+                            <aside class="ad ad_xrail ad_xrail_top ad_xrail_last" aria-label="Top sidebar advertisement"></aside>
+                    </div>
+    </div>
+</div>
+
+<div class="column-wrapper">
+    <div class="left-column">
+        <div id="social-footer">
+                  <a class="comment-count icon-comment-bubble-down" href="https://arstechnica.com/science/2023/08/whats-going-on-with-the-reports-of-a-room-temperature-superconductor/?comments=1">
+      <h4 class="comment-count-before">reader comments</h4>
+  
+  <span class="comment-count-number">87</span>
+  <span class="visually-hidden"> with </span>
+  </a>
+          </div>
+                    <!-- cache hit 192:single/author:edaec1ff064d5323d80a377d6771e515 -->  <section class="article-author">
+          <a style="background-image:url('https://cdn.arstechnica.net/wp-content/uploads/2016/05/j.timmer-5.jpg');" class="author-photo" href="/author/john-timmer" tabindex="-1" role="presentation" aria-hidden="true"></a>
+    
+    <div class="author-bio">
+      <section class="author-bio-top">
+        <a href="/author/john-timmer" class="author-name">John Timmer</a>
+        John is Ars Technica's science editor. He has a Bachelor of Arts in Biochemistry from Columbia University, and a Ph.D. in Molecular and Cell Biology from the University of California, Berkeley. When physically separated from his keyboard, he tends to seek out a bicycle, or a scenic location for communing with his hiking boots.
+      </section>
+    </div>
+
+  </section>
+            </div>
+    <div class="xrail"></div>
+</div>
+<div id="article-footer-wrap">
+            <aside class="ad_wrapper" aria-label="Full width advertisement">
+    <span class="ad_notice">Advertisement </span>        
+    <div class="ad ad_fullwidth fullwidth"></div>
+</aside>
+    
+            <section id="comments-area" class="comments-area column-wrapper">
+      <div class="row comments-row left-column">
+      <a name="comments-bar"></a>
+      
+<div class="wp-forum-connect-container">
+
+    
+
+    
+</div>
+
+    </div>
+          <div class="xrail xrail-comments">
+        <div class="xrail-content-wrapper">
+          <div class="xrail-content xrail-content-comments">
+            <aside class="ad ad_xrail ad_xrail_comments" aria-label="Comments sidebar advertisement"></aside>
+          </div>
+        </div>
+                  <div class="xrail-content-wrapper xrail-content-wrapper-bottom">
+            <div class="xrail-content xrail-content-comments">
+              <aside class="ad ad_xrail ad_xrail_comments" aria-label="Comments sidebar advertisement"></aside>
+            </div>
+          </div>
+              </div>
+      </section>
+                    <section class="inline-playlist">
+  <div class='ars-video-playlist'>
+    <h3 class="ars-video-playlist-module-header">Channel <span>Ars Technica</span></h3>
+    <div class='ars-video-playlist-module' data-playlist-id='arstechnica-channel-ars-science' data-video-options='[]'></div>
+  </div>
+</section>
+                <div class="prev-next-links">
+  <a href="https://arstechnica.com/science/2023/08/frackers-can-use-dangerous-chemicals-without-disclosure-due-to-haliburton-loophole/" rel="prev"><span class="arrow">&larr;</span> Previous story</a>  <a href="https://arstechnica.com/cars/2023/08/fisker-debuts-an-entire-range-of-new-evs-including-one-sub-30000/" rel="next">Next story <span class="arrow">&rarr;</span></a></div>
+        <footer id="article-footer">
+  <div class="recommendations-footer">
+    <div id="story-recommendations">
+  <div class="heading-column">
+    <h3>Related Stories</h3>
+  </div>
+  <ul id="story-recs" class="rec-wrap"></ul>
+</div>
+  </div>
+      <div id="taboola-below-article-thumbnails---at"></div>
+<script type="text/javascript">
+  window._taboola = window._taboola || [];
+  _taboola.push({
+    mode: 'thumbnails-a-6x1',
+    container: 'taboola-below-article-thumbnails---at',
+    placement: 'Below Article Thumbnails - AT',
+    target_type: 'mix'
+  });
+</script>
+    <div class="recommendations-footer">
+    <div id="latest-stories">
+  <div class="heading-column">
+    <h3>Today on Ars</h3>
+  </div>
+  <ul id="latest-recs" class="rec-wrap"></ul>
+</div>
+  </div>
+</footer>
+    </div>
+  </article>
+  </main>
+
+  <footer class="site-footer">
+    <nav class="nav-footer">
+
+  <section>
+    <ul>
+      <li><a href="/store/">Store</a></li>
+      <li><a href="/store/product/subscriptions/">Subscribe</a></li>
+      <li><a href="/about-us/">About Us</a></li>
+      <li><a href="/rss-feeds/">RSS Feeds</a></li>
+      <li><a rel="nofollow" href="/science/2023/08/whats-going-on-with-the-reports-of-a-room-temperature-superconductor/?view=mobile">View Mobile Site</a></li>
+    </ul>
+  </section>
+
+  <section>
+    <ul>
+      <li><a href="/contact-us/">Contact Us</a></li>
+      <li><a href="/staff-directory/">Staff</a></li>
+      <li><a href="https://www.condenast.com/brands/ars-technica">Advertise with us</a></li>
+      <li><a href="/reprints/">Reprints</a></li>
+    </ul>
+  </section>
+
+  <section class="footer-newsletter">
+    <div class="newsletter-wrapper">
+      <h3>
+        <a href="/newsletters/" class="footer-newsletter-sign-up">Newsletter Signup</a>
+      </h3>
+      <p>Join the Ars Orbital Transmission mailing list to get weekly updates delivered to your inbox. <a href="/newsletters/" class="footer-newsletter-sign-up">Sign me up &rarr;</a></p>
+
+      <div class="footer-social-links">
+        <a href="https://twitter.com/arstechnica" class="footer-social-twitter">
+          <svg style="height: 40px; width: 40px;" id="b" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 40 40">
+            <defs>
+              <clipPath id="e">
+                <rect width="40" height="40" fill="none" />
+              </clipPath>
+              <clipPath id="f">
+                <rect width="40" height="40" fill="none" />
+              </clipPath>
+            </defs>
+            <g id="c">
+              <g id="d">
+                <g clip-path="url(#e)">
+                  <g clip-path="url(#f)">
+                    <path d="M16.3,28.1c7.5,0,11.7-6.3,11.7-11.7s0-.4,0-.5c.8-.6,1.5-1.3,2-2.1-.7,.3-1.5,.5-2.4,.6,.9-.5,1.5-1.3,1.8-2.3-.8,.5-1.7,.8-2.6,1-.6-.7-1.4-1.1-2.3-1.2s-1.8,0-2.6,.4c-.8,.4-1.4,1.1-1.8,1.9-.4,.8-.5,1.7-.3,2.6-1.6,0-3.2-.5-4.7-1.2-1.5-.7-2.7-1.8-3.8-3-.5,.9-.7,2-.5,3,.2,1,.9,1.9,1.7,2.5-.7,0-1.3-.2-1.9-.5h0c0,1,.3,1.9,.9,2.7,.6,.7,1.4,1.2,2.4,1.4-.6,.2-1.2,.2-1.9,0,.3,.8,.8,1.5,1.5,2s1.5,.8,2.4,.8c-1.5,1.1-3.2,1.8-5.1,1.8-.3,0-.7,0-1,0,1.9,1.2,4.1,1.8,6.3,1.8" fill="currentColor" />
+                  </g>
+                </g>
+              </g>
+            </g>
+          </svg>
+        </a>
+        <a href="https://mastodon.social/@arstechnica" class="footer-social-mastodon">
+          <svg style="height: 40px; width: 40px;" id="b" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 40 40">
+            <defs>
+              <clipPath id="e">
+                <rect width="40" height="40" fill="none" />
+              </clipPath>
+              <clipPath id="f">
+                <rect width="40" height="40" fill="none" />
+              </clipPath>
+            </defs>
+            <g id="c">
+              <g id="d">
+                <g clip-path="url(#e)">
+                  <g clip-path="url(#f)">
+                    <path d="M29.3,16.6c0-4.3-2.8-5.6-2.8-5.6-1.4-.7-3.9-.9-6.5-1h0c-2.6,0-5,.3-6.4,1,0,0-2.8,1.3-2.8,5.6s0,2.2,0,3.4c.1,4.2,.8,8.4,4.7,9.5,1.8,.5,3.4,.6,4.6,.5,2.3-.1,3.5-.8,3.5-.8v-1.6c0,0-1.7,.5-3.5,.4-1.8,0-3.7-.2-4-2.4,0-.2,0-.4,0-.6,0,0,1.8,.4,4,.5,1.4,0,2.7,0,4-.2,2.5-.3,4.7-1.8,5-3.3,.4-2.2,.4-5.4,.4-5.4h0Zm-3.4,5.6h-2.1v-5.1c0-1.1-.5-1.6-1.4-1.6s-1.5,.6-1.5,1.9v2.8h-2.1v-2.8c0-1.3-.5-1.9-1.5-1.9s-1.4,.5-1.4,1.6v5.1h-2.1v-5.3c0-1.1,.3-1.9,.8-2.6,.6-.6,1.3-1,2.2-1s1.9,.4,2.4,1.2l.5,.9,.5-.9c.5-.8,1.3-1.2,2.4-1.2s1.7,.3,2.2,1c.6,.6,.8,1.5,.8,2.6v5.3Z" fill="currentColor" />
+                  </g>
+                </g>
+              </g>
+            </g>
+          </svg>
+        </a>
+        <a href="https://www.facebook.com/arstechnica" class="footer-social-facebook">
+          <svg style="height: 40px; width: 40px;" id="b" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 40 40">
+            <defs>
+              <clipPath id="e">
+                <rect width="40" height="40" fill="none" />
+              </clipPath>
+              <clipPath id="f">
+                <rect width="40" height="40" fill="none" />
+              </clipPath>
+            </defs>
+            <g id="c">
+              <g id="d">
+                <g clip-path="url(#e)">
+                  <g clip-path="url(#f)">
+                    <path d="M17.3,13.9v2.8h-2v3.4h2v10h4.2v-10h2.8s.3-1.6,.4-3.4h-3.2v-2.3c0-.3,.5-.8,.9-.8h2.3v-3.5h-3.1c-4.4,0-4.3,3.4-4.3,3.9" fill="currentColor" />
+                  </g>
+                </g>
+              </g>
+            </g>
+          </svg>
+        </a>
+        <a href="https://www.youtube.com/@arstechnica" class="footer-social-youtube">
+          <svg style="height: 40px; width: 40px;" id="b" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 40 40">
+            <defs>
+              <clipPath id="e">
+                <rect width="40" height="40" fill="none" />
+              </clipPath>
+              <clipPath id="f">
+                <rect width="40" height="40" fill="none" />
+              </clipPath>
+            </defs>
+            <g id="c">
+              <g id="d">
+                <g clip-path="url(#e)">
+                  <g clip-path="url(#f)">
+                    <path d="M29.6,15.2c-.1-.4-.3-.8-.6-1.1-.3-.3-.7-.5-1.1-.7-1.6-.4-7.8-.4-7.8-.4,0,0-6.3,0-7.8,.4-.4,.1-.8,.3-1.1,.7-.3,.3-.5,.7-.6,1.1-.4,1.6-.4,4.8-.4,4.8,0,0,0,3.3,.4,4.8,.1,.4,.3,.8,.6,1.1,.3,.3,.7,.5,1.1,.7,1.6,.4,7.8,.4,7.8,.4,0,0,6.3,0,7.8-.4,.4-.1,.8-.3,1.1-.7s.5-.7,.6-1.1c.4-1.6,.4-4.8,.4-4.8,0,0,0-3.3-.4-4.8m-11.6,7.8v-5.9l5.2,3-5.2,3Z" fill="currentColor" />
+                  </g>
+                </g>
+              </g>
+            </g>
+          </svg>
+        </a>
+        <a href="https://www.instagram.com/arstechnica/" class="footer-social-instagram">
+          <svg style="height: 40px; width: 40px;" id="b" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 40 40">
+            <defs>
+              <clipPath id="e">
+                <rect width="40" height="40" fill="none" />
+              </clipPath>
+              <clipPath id="f">
+                <rect width="40" height="40" fill="none" />
+              </clipPath>
+            </defs>
+            <g id="c">
+              <g id="d">
+                <g clip-path="url(#e)">
+                  <g clip-path="url(#f)">
+                    <path d="M20,10c2.7,0,3.1,0,4.1,0,1.1,0,1.8,.2,2.4,.5,.7,.3,1.2,.6,1.8,1.2,.6,.6,.9,1.1,1.2,1.8,.2,.6,.4,1.4,.5,2.4,0,1.1,0,1.4,0,4.1s0,3.1,0,4.1c0,1.1-.2,1.8-.5,2.4-.3,.7-.6,1.3-1.2,1.8-.6,.6-1.1,.9-1.8,1.2-.6,.2-1.4,.4-2.4,.5-1.1,0-1.4,0-4.1,0s-3.1,0-4.1,0c-1.1,0-1.8-.2-2.4-.5-.7-.3-1.3-.6-1.8-1.2-.5-.5-.9-1.1-1.2-1.8-.2-.6-.4-1.4-.5-2.4,0-1.1,0-1.4,0-4.1s0-3.1,0-4.1c0-1.1,.2-1.8,.5-2.4,.3-.7,.6-1.2,1.2-1.8,.6-.6,1.1-.9,1.8-1.2,.6-.2,1.4-.4,2.4-.5,1.1,0,1.4,0,4.1,0m0,2.5c-2.4,0-2.7,0-3.7,0-.9,0-1.4,.2-1.7,.3-.4,.1-.8,.4-1.1,.7-.3,.3-.5,.6-.7,1.1-.1,.3-.3,.8-.3,1.7,0,1,0,1.3,0,3.7s0,2.7,0,3.7c0,.9,.2,1.4,.3,1.7,.2,.4,.4,.7,.7,1.1,.3,.3,.6,.5,1.1,.7,.3,.1,.8,.3,1.7,.3,1,0,1.3,0,3.7,0s2.7,0,3.7,0c.9,0,1.4-.2,1.7-.3,.4-.2,.7-.4,1.1-.7,.3-.3,.5-.6,.7-1.1,.1-.3,.3-.8,.3-1.7,0-1,0-1.3,0-3.7s0-2.7,0-3.7c0-.9-.2-1.4-.3-1.7-.1-.4-.4-.8-.7-1.1-.3-.3-.7-.5-1.1-.7-.3-.1-.8-.3-1.7-.3-1,0-1.3,0-3.7,0m0,2.2c.7,0,1.4,.1,2,.4,.6,.3,1.2,.7,1.7,1.1,.5,.5,.9,1.1,1.1,1.7,.3,.6,.4,1.3,.4,2s-.1,1.4-.4,2c-.3,.6-.7,1.2-1.1,1.7-.5,.5-1.1,.9-1.7,1.1-.6,.3-1.3,.4-2,.4-1.4,0-2.7-.6-3.7-1.5-1-1-1.5-2.3-1.5-3.7s.6-2.7,1.5-3.7,2.3-1.5,3.7-1.5m0,8.3c.8,0,1.5-.3,2.1-.9,.6-.6,.9-1.3,.9-2.1s-.3-1.5-.9-2.1c-.6-.6-1.3-.9-2.1-.9s-1.5,.3-2.1,.9c-.6,.6-.9,1.3-.9,2.1s.3,1.5,.9,2.1c.6,.6,1.3,.9,2.1,.9m6.6-8.1c0,.4-.2,.7-.4,1s-.6,.4-1,.4-.7-.2-1-.4c-.3-.3-.4-.6-.4-1s.2-.7,.4-1c.3-.3,.6-.4,1-.4s.7,.2,1,.4c.3,.3,.4,.6,.4,1" fill="currentColor" />
+                  </g>
+                </g>
+              </g>
+            </g>
+          </svg>
+        </a>
+      </div>
+
+    </div>
+  </section>
+</nav>
+
+<section class="footer-terms-logo">
+  <div class="cn-logo">
+    <a href="http://condenast.com/" class="icon icon-logo-cn-us" title="Visit Condé Nast"></a>
+  </div>
+
+  <p id="copyright-terms">
+  CNMN Collection<br>
+  WIRED Media Group<br>
+  © 2023 Condé Nast. All rights reserved. Use of and/or registration on any portion of this site constitutes acceptance of our <a href="https://www.condenast.com/user-agreement/">User Agreement</a> (updated 1/1/20) and <a href="https://www.condenast.com/privacy-policy/">Privacy Policy and Cookie Statement</a> (updated 1/1/20) and <a href="/amendment-to-conde-nast-user-agreement-privacy-policy/">Ars Technica Addendum</a> (effective 8/21/2018). Ars may earn compensation on sales from links on this site. <a href="/affiliate-link-policy/">Read our affiliate link policy</a>.<br>
+  <span style="display: inline-flex; flex-flow: row nowrap; align-items: center; gap: 5px;"><a href="https://www.condenast.com/privacy-policy/#california">Your California Privacy Rights</a> | <img src="https://cdn.arstechnica.net/wp-content/themes/ars/assets/img/privacyoptions123x59-c5c9972158.png" style="height: 1em; width: auto;" /> <a id="ot-sdk-btn" class="ot-sdk-show-settings">Do Not Sell My Personal Information</a></span><br>
+  The material on this site may not be reproduced, distributed, transmitted, cached or otherwise used, except with the prior written permission of Condé Nast.<br>
+  <a href="https://www.condenast.com/online-behavioral-advertising-oba-and-how-to-opt-out-of-oba/#clickheretoreadmoreaboutonlinebehavioraladvertising(oba)">Ad Choices</a>
+</p>
+</section>
+  </footer>
+  </div>
+
+  <script type="text/javascript" src="https://cdn.arstechnica.net/wp-content/themes/ars/assets/js/main-f627adae4a.js"></script>
+
+
+<!-- cache hit 192:single/javascript-footer:d29d6446a030580dc69054ef5c06dab8 -->
+        
+
+
+    <!-- Taboola -->
+  <script type="text/javascript">
+    window._taboola = window._taboola || [];
+    _taboola.push({
+      flush: true
+    });
+  </script>
+
+  <!-- Parse.ly start -->
+<script type="text/plain" class="optanon-category-C0002" id="parsely-cfg" src="//fpa-cdn.arstechnica.com/keys/arstechnica.com/p.js"></script>
+<!-- Parse.ly end -->
+
+<!-- Memo start -->
+<script type="text/javascript">
+__memo_config = {
+	pid: ars.MEMO_PID,
+	url: ars.ARTICLE.url,
+	author: [ars.ARTICLE.authorName],
+	title: ars.ARTICLE.title,
+	date: ars.ARTICLE.pubDate,
+};
+(function(){
+	var s = document.createElement('script'); 
+	s.async = true; 
+	s.type = 'text/javascript'; 
+	s.src = document.location.protocol + '//cdn.memo.co/js/memo.js';
+	(document.getElementsByTagName('head')[0] || document.getElementsByTagName('body') [0]).appendChild(s); 
+})();
+</script>
+<!-- Memo end -->
+
+  
+  
+    
+<script>
+  (function() {
+    var w = window.innerWidth ||
+      document.documentElement.clientWidth ||
+      document.body.clientWidth;
+    var src = 'https://player.cnevids.com/interlude/arstechnica.js';
+    if (!ars.MOBILE && w >= 1000) {
+      src += '?isRightRail=true';
+    }
+    var s = document.createElement('script');
+    s.setAttribute('async', true);
+    s.setAttribute('src', src);
+    document.body.appendChild(s);
+  })();
+</script>
+
+<script id="conde-polar" src="https://cdn.mediavoice.com/nativeads/script/condenastcorporate/conde-asa-polar-master.js" async></script>
+<!-- Sparrow begin -->
+<script type="text/plain" class="optanon-category-C0002">
+  (function() {
+    function DQ() {
+      var queue = window.sparrowQueue;
+      this.push = fn => fn();
+      window.sparrowQueue = this;
+      while (queue.length) {
+        queue.shift()();
+      }
+    }
+
+    function e(t, e) {
+      var n, a, o;
+      a = !1, n = document.createElement("script"), n.type = "text/javascript", n.src = t, n.onload = n.onreadystatechange = function() {
+        a || this.readyState && "complete" != this.readyState || (a = !0, e ? e() : !0)
+      }, o = document.getElementsByTagName("script")[0], o.parentNode.insertBefore(n, o)
+    }
+    if (location.search.indexOf('no_sparrow') < 0) {
+      e("https://pixel.condenastdigital.com/config/v2/production/ars-technica.config.js", function() {
+        e("https://pixel.condenastdigital.com/sparrow.min.js", function() {
+          if (window.SparrowConfigV2) {
+            window.sparrow = new window.Sparrow(window.SparrowConfigV2);
+            new DQ();
+          }
+        })
+      })
+    }
+  })();
+</script>
+<!-- Sparrow end -->
+<script type="text/javascript" src="//s.skimresources.com/js/100098X1555750.skimlinks.js"></script>
+<script type='text/javascript' src='https://cdn.arstechnica.net/wp-content/plugins/article-forum-connect/public/js/iframeResizer.min.js?ver=1.2.2' id='article_forum_connect_iframe_resizer-js'></script>
+<script type='text/javascript' src='https://cdn.arstechnica.net/wp-content/plugins/article-forum-connect/public/js/iframe.js?ver=1.2.2' id='article_forum_connect_iframe-js'></script>
+  </body>
+
+  </html>

--- a/packages/content-handler/test/data/ars-multipage/ars-technica-page-2.html
+++ b/packages/content-handler/test/data/ars-multipage/ars-technica-page-2.html
@@ -1,0 +1,841 @@
+<!DOCTYPE html>
+<html lang="en-us">
+
+<head>
+  <title>What’s going on with the reports of a room-temperature superconductor? | Ars Technica</title>
+<script type="text/javascript">
+  ars = {"ASSETS":"https:\/\/cdn.arstechnica.net\/wp-content\/themes\/ars\/assets","HOME_URL":"https:\/\/arstechnica.com","CIVIS":"\/civis","THEME":"light","VIEW":"grid","MOBILE":false,"SUBSCRIBER":false,"PLUS_PLUS":false,"LOGGED":false,"USER_ID":null,"ENV":"production","AD":{"tags":["chemistry","electrons","physics","superconductivity"],"channel":"science","slug":"whats-going-on-with-the-reports-of-a-room-temperature-superconductor","template_type":"article","queue":[],"server":"production"},"TOTAL":109337,"UNREAD":0,"RECENT":[1958890,1958894,1950200,1958504,1958915,1958785,1958895,1953746,1958601,1958766,1958740,1958758,1958728,1958672,1958712,1958544,1958702,1958680,1958662,1958644,1958600,1958632,1958537,1958110,1958563],"LOGINS":true,"CROSS":false,"PARSELY":"arstechnica.com","COMMENTS":false,"HOMEPAGE":false,"SITE":1,"READY":[],"SHOW_ADS":true,"IMG_PROXY":"https:\/\/cdn.arstechnica.net\/i\/","CATEGORY":"science","PAGETITLE":"","ZEN_MODE":false,"MEMO_PID":"62012a7a19351c07620394e0"};
+</script>
+<link rel="stylesheet" type="text/css" media="all" href="https://cdn.arstechnica.net/wp-content/themes/ars/assets/css/main-4b9af0fe84.css" />
+    <link rel="alternate" type="application/rss+xml" href="http://feeds.arstechnica.com/arstechnica/index" />
+  <link rel="shortcut icon" href="https://cdn.arstechnica.net/favicon.ico" />
+  <link rel="icon" type="image/x-icon" href="https://cdn.arstechnica.net/favicon.ico" />
+  <link rel="apple-touch-icon" sizes="180x180" href="https://cdn.arstechnica.net/wp-content/themes/ars/assets/img/ars-ios-icon-d9a45f558c.png" />
+  <link rel="mask-icon" href="https://cdn.arstechnica.net/wp-content/themes/ars/assets/img/ars-macos-safari-8997f76b21.svg" color="#ff4e00">
+  <link rel="icon" sizes="192x192" href="https://cdn.arstechnica.net/wp-content/themes/ars/assets/img/material-ars-db41652381.png" />
+  <link rel="me" href="https://mastodon.social/@arstechnica" />
+
+    <meta name="application-name" content="Ars Technica"/>
+  <meta name="msapplication-starturl" content="http://arstechnica.com/"/>
+  <meta name="msapplication-tooltip" content="Ars Technica: Serving the technologist for 1.2 decades"/>
+  <meta name="msapplication-task" content="name=News;action-uri=http://arstechnica.com/;icon-uri=https://cdn.arstechnica.net/favicon.ico"/>
+  <meta name="msapplication-task" content="name=Features;action-uri=http://arstechnica.com/features/;icon-uri=https://cdn.arstechnica.net/ie-jump-menu/jump-features.ico"/>
+  <meta name="msapplication-task" content="name=OpenForum;action-uri=http://arstechnica.com/civis/;icon-uri=https://cdn.arstechnica.net/ie-jump-menu/jump-forum.ico"/>
+  <meta name="msapplication-task" content="name=Subscribe;action-uri=http://arstechnica.com/subscriptions/;icon-uri=https://cdn.arstechnica.net/ie-jump-menu/jump-subscribe.ico"/>
+
+
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <meta name="advertising" content="ask" />
+  <meta property="fb:admins" content="592156917" />
+  <meta property="fb:admins" content="108943" />
+  <meta property="fb:pages" content="19374573752" />
+
+  <meta name="format-detection" content="telephone=no" />
+  <meta name="theme-color" content="#000000" />
+
+  
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+
+  <!-- cache hit 193:single/meta:d29d6446a030580dc69054ef5c06dab8 -->
+<meta name='parsely-page' content='{"title":"What\u2019s going on with the reports of a room-temperature superconductor?","link":"https:\/\/arstechnica.com\/science\/2023\/08\/whats-going-on-with-the-reports-of-a-room-temperature-superconductor\/","type":"post","author":"John Timmer","post_id":1958785,"pub_date":"2023-08-04T14:07:48Z","section":"Science","tags":["chemistry","electrons","physics","superconductivity","type: feature"],"image_url":"https:\/\/cdn.arstechnica.net\/wp-content\/uploads\/2023\/08\/LK-99_pellet-150x150.png"}'>
+<meta name='parsely-metadata' content='{"type":"feature","title":"What\u2019s going on with the reports of a room-temperature superconductor?","post_id":1958785,"lower_deck":"Rumors are flying of confirmation, but the situation is still frustratingly vague.","image_url":"https:\/\/cdn.arstechnica.net\/wp-content\/uploads\/2023\/08\/LK-99_pellet-150x150.png","listing_image_url":"https:\/\/cdn.arstechnica.net\/wp-content\/uploads\/2023\/08\/LK-99_pellet-360x200.png"}'>
+
+  <link rel="canonical" href="https://arstechnica.com/science/2023/08/whats-going-on-with-the-reports-of-a-room-temperature-superconductor/" />
+
+<link rel="amphtml" href="https://arstechnica.com/science/2023/08/whats-going-on-with-the-reports-of-a-room-temperature-superconductor/amp/">
+
+<link rel="shorturl" href="https://arstechnica.com/?p=1958785" />
+
+<meta name="description" content="Rumors are flying of confirmation, but the situation is still frustratingly vague." />
+
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:url" content="https://arstechnica.com/science/2023/08/whats-going-on-with-the-reports-of-a-room-temperature-superconductor/">
+<meta name="twitter:title" content="What’s going on with the reports of a room-temperature superconductor?">
+<meta name="twitter:description" content="Rumors are flying of confirmation, but the situation is still frustratingly vague.">
+
+<meta name="twitter:site" content="@arstechnica">
+<meta name="twitter:domain" content="arstechnica.com">
+
+<meta property="og:site_name" content="Ars Technica" />
+
+<meta name="twitter:image:src" content="https://cdn.arstechnica.net/wp-content/uploads/2023/08/LK-99_pellet-760x380.png">
+  <meta name="twitter:image:width" content="760">
+  <meta name="twitter:image:height" content="380">
+
+  <meta name="twitter:creator" content="@j_timmer">
+
+<meta property="og:url" content="https://arstechnica.com/science/2023/08/whats-going-on-with-the-reports-of-a-room-temperature-superconductor/" />
+<meta property="og:title" content="What’s going on with the reports of a room-temperature superconductor?" />
+<meta property="og:image" content="https://cdn.arstechnica.net/wp-content/uploads/2023/08/LK-99_pellet-760x380.png" />
+<meta property="og:description" content="Rumors are flying of confirmation, but the situation is still frustratingly vague." />
+<meta property="og:type" content="article" />
+  <!-- cache hit 193:single/header:d29d6446a030580dc69054ef5c06dab8 -->
+        
+
+<!-- OneTrust Cookies Consent Notice start -->
+<script 
+    src="https://cdn.cookielaw.org/scripttemplates/otSDKStub.js"  
+    type="text/javascript" charset="UTF-8" 
+    data-domain-script="b10882a1-8446-4e7d-bfb2-ce2c770ad910">
+</script>
+<script type="text/javascript">function OptanonWrapper(){};</script>
+<script 
+    src="https://cdn.cookielaw.org/opt-out/otCCPAiab.js" 
+    type="text/javascript" 
+    charset="UTF-8" 
+    ccpa-opt-out-ids="C0002,C0003,C0004,C0005" 
+    ccpa-opt-out-geo="ca" 
+    ccpa-opt-out-lspa="true">
+</script> 
+<!-- OneTrust Cookies Consent Notice end -->
+<!-- Google Tag Manager DataLayer -->
+<script>
+window.dataLayer = window.dataLayer || [];
+window.dataLayer.push({"event":"data-layer-loaded","user":{"ars_userId":undefined,"amg_userId":undefined,"uID":"247ffd43-8ad6-4bf2-b5c2-0e046fa25ef0","sID":"91f9b038-a9f3-4416-870d-c52ef9fb930a","loginStatus":false,"subscriberStatus":"none","infinityId":"25954524-1ed8-4562-bc8b-981da203f2c9","registrationSource":undefined,"mdw_cnd_id":undefined,"monthlyVisits":undefined,"accessPaywall":undefined,"view":"grid","theme":"light","show_comments":false},"content":{"pageTemplate":"single","pageType":"article|feature","contentCategory":"science","section":"science","subsection":undefined,"contributor":"John Timmer","contentID":1958785,"contentLength":2098,"display":"What\u2019s going on with the reports of a room-temperature superconductor?","contentSource":"web","pageAssets":undefined,"uniqueContentCount":undefined,"monthlyContentCount":undefined,"publishDate":"2023-08-04T14:07:48-04:00","modifiedDate":"2023-08-04T15:56:15-04:00","keywords":"chemistry|electrons|Physics|superconductivity","dataSource":undefined},"marketing":{"campaignName":undefined,"circCampaignId":undefined,"internalCampaignId":undefined,"brand":"Ars Technica","certified_mrc_data":undefined,"condeNastId":undefined},"page":{"pID":"24d643da-97a0-49bc-805c-0656f9533d1e","syndicatorUrl":undefined,"pageURL":"https:\/\/arstechnica.com\/?p=1958785","canonical":"https:\/\/arstechnica.com\/science\/2023\/08\/whats-going-on-with-the-reports-of-a-room-temperature-superconductor\/","canonicalPathName":"\/science\/2023\/08\/whats-going-on-with-the-reports-of-a-room-temperature-superconductor\/3\/"},"search":{"facets":undefined,"searchTerms":undefined},"site":{"appVersion":"1.0.0"}});
+</script>
+<!-- End Google Tag Manager DataLayer -->
+<!-- Google Tag Manager -->
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-NLXNPCQ');</script>
+<!-- End Google Tag Manager -->
+<!-- Start Headline A/B -->
+<script type="text/javascript">
+  class ABTest {
+    constructor(post_id, init_method) {
+      this.post_id = post_id;
+      this.ajaxurl = '/services/ars-ajax-handler.php';
+      this.expireDays = 1 / 48; // 30 min
+      this.group = this.getGroup();
+      this.uid = this.getUid();
+      this.init_method = init_method;
+      this.setTitle();
+
+      if (this.init_method === 'click') {
+        this.click();
+      } else {
+        this.impression();
+      }
+    }
+
+    setCookie(name, value, days) {
+      var expires = "";
+      if (days) {
+        var date = new Date();
+        date.setTime(date.getTime() + (days * 24 * 60 * 60 * 1000));
+        expires = "; expires=" + date.toUTCString();
+      }
+      document.cookie = name + "=" + (value || "") + expires + "; path=/";
+    }
+
+    getCookie(name) {
+      var nameEQ = name + "=";
+      var ca = document.cookie.split(';');
+      for (var i = 0; i < ca.length; i++) {
+        var c = ca[i];
+        while (c.charAt(0) == ' ') c = c.substring(1, c.length);
+        if (c.indexOf(nameEQ) == 0) return c.substring(nameEQ.length, c.length);
+      }
+      return null;
+    }
+
+    // Retrieves a unique id for determining whether the event should be recorded
+    getUid() {
+      var uid = this.getCookie('ars_ab_' + this.post_id + '_uid');
+      if (!uid) {
+        uid = (Math.random() + 1).toString(36).substring(2, 7);
+        this.setCookie('ars_ab_' + this.post_id + '_uid', uid, this.expireDays);
+      }
+      return uid;
+    };
+
+    // Places the user in either A or B for this post id
+    getGroup() {
+      var group = this.getCookie('ars_ab_' + this.post_id + '_group');
+      if (!group) {
+        group = String.fromCharCode(Math.floor(Math.random() * 2) + 65).toLowerCase();
+        this.setCookie('ars_ab_' + this.post_id + '_group', group, this.expireDays);
+      }
+      return group;
+    };
+
+    // Records a headline impression (from homepage or other listing)
+    impression() {
+      // Send fake ajax
+      var params = {
+        nonce: '4dadc83aa5',
+        action: 'ars_ab_impression',
+        id: this.post_id,
+        group: this.group,
+        uid: this.uid,
+        ts: (new Date()).getTime()
+      };
+      var url = this.ajaxurl + '?' + this.encodeParams(params);
+      document.write('\x3Cscript type="text/javascript" src="' + url + '">\x3C/script>');
+    };
+
+    // Records a headline click from the actual post page
+    click() {
+      // Send fake ajax
+      var params = {
+        nonce: '34b2ae4b70',
+        action: 'ars_ab_click',
+        id: this.post_id,
+        group: this.group,
+        uid: this.uid,
+        ts: (new Date()).getTime()
+      };
+      var url = this.ajaxurl + '?' + this.encodeParams(params);
+      document.write('\x3Cscript type="text/javascript" src="' + url + '">\x3C/script>');
+    };
+
+    // If user is in B group, dynamically set title
+    setTitle() {
+      if (this.group == 'b') {
+        var span = document.getElementById('ars_ab_' + this.post_id);
+        var title = span.parentNode;
+        title.innerHTML = span.getAttribute('data-title-b');
+      }
+    };
+
+    encodeParams(data) {
+      var ret = [];
+      for (var d in data)
+        ret.push(encodeURIComponent(d) + "=" + encodeURIComponent(data[d]));
+      return ret.join("&");
+    };
+
+  };
+</script>
+<!-- End Headline A/B -->
+<script src="https://www.googletagservices.com/tag/js/gpt.js" id="gpt-script" async></script>
+<script>
+  window.googletag = window.googletag || {};
+  window.googletag.cmd = window.googletag.cmd || [];
+  window.cns = window.cns || {};
+  window.cns.queue = [];
+  window.cns.async = function(s, c) {
+    cns.queue.push({
+      service: s,
+      callback: c
+    })
+  };
+  window.sparrowQueue = window.sparrowQueue || [];
+</script>
+<script>
+  window.cns.pageContext = {"contentType":"article","templateType":"article","channel":"science","subChannel":"","slug":"whats-going-on-with-the-reports-of-a-room-temperature-superconductor","server":"production","keywords":{"tags":["chemistry","electrons","physics","superconductivity"],"cm":[],"platform":["wordpress"],"copilotid":""}};
+</script>
+<script src="https://ads-static.conde.digital/production/cns/builds/ars-technica/ars-technica.min.js" async></script>
+<script type="text/javascript" src="https://cdn.arstechnica.net/wp-content/themes/ars/assets/js/ars-84a4ab0802.ads.us.js"></script>
+  <script type="text/javascript">!(function(o,_name){function n(){(n.q=n.q||[]).push(arguments)}n.v=1,o[_name]=o[_name]||n;!(function(o,t,n,c){function e(n){(function(){try{return(localStorage.getItem("v4ac1eiZr0")||"").split(",")[4]>0}catch(o){}return!1})()&&(n=o[t].pubads())&&n.setTargeting("admiral-engaged","true")}(c=o[t]=o[t]||{}).cmd=c.cmd||[],typeof c.pubads===n?e():typeof c.cmd.unshift===n?c.cmd.unshift(e):c.cmd.push(e)})(window,"googletag","function");})(window,String.fromCharCode(97,100,109,105,114,97,108));!(function(t,c,i){i=t.createElement(c),t=t.getElementsByTagName(c)[0],i.async=1,i.src="https://shiverscissors.com/v2fumwIJOo-LsCB0dlG18VSTW43CpWhUEPJuKeRTzrEQdSPPlMr5GymU",t.parentNode.insertBefore(i,t)})(document,"script");</script>
+
+  <!-- Taboola -->
+  <script type="text/javascript">
+    window._taboola = window._taboola || [];
+    _taboola.push({
+      article: 'auto'
+    });
+    ! function(e, f, u, i) {
+      if (!document.getElementById(i)) {
+        e.async = 1;
+        e.src = u;
+        e.id = i;
+        f.parentNode.insertBefore(e, f);
+      }
+    }(document.createElement('script'),
+      document.getElementsByTagName('script')[0],
+      '//cdn.taboola.com/libtrc/condenast1-network/loader.js',
+      'tb_loader_script');
+    if (window.performance && typeof window.performance.mark == 'function') {
+      window.performance.mark('tbl_ic');
+    }
+  </script>
+  <meta name='robots' content='max-image-preview:large' />
+<link rel='dns-prefetch' href='//s.w.org' />
+<link rel='dns-prefetch' href='//arstechnica-apps.s3.amazonaws.com' />
+<link rel='stylesheet' id='wp-block-library-css'  href='https://cdn.arstechnica.net/wp/wp-includes/css/dist/block-library/style.min.css?ver=6.0.3' type='text/css' media='all' />
+<style id='global-styles-inline-css' type='text/css'>
+body{--wp--preset--color--black: #000000;--wp--preset--color--cyan-bluish-gray: #abb8c3;--wp--preset--color--white: #ffffff;--wp--preset--color--pale-pink: #f78da7;--wp--preset--color--vivid-red: #cf2e2e;--wp--preset--color--luminous-vivid-orange: #ff6900;--wp--preset--color--luminous-vivid-amber: #fcb900;--wp--preset--color--light-green-cyan: #7bdcb5;--wp--preset--color--vivid-green-cyan: #00d084;--wp--preset--color--pale-cyan-blue: #8ed1fc;--wp--preset--color--vivid-cyan-blue: #0693e3;--wp--preset--color--vivid-purple: #9b51e0;--wp--preset--gradient--vivid-cyan-blue-to-vivid-purple: linear-gradient(135deg,rgba(6,147,227,1) 0%,rgb(155,81,224) 100%);--wp--preset--gradient--light-green-cyan-to-vivid-green-cyan: linear-gradient(135deg,rgb(122,220,180) 0%,rgb(0,208,130) 100%);--wp--preset--gradient--luminous-vivid-amber-to-luminous-vivid-orange: linear-gradient(135deg,rgba(252,185,0,1) 0%,rgba(255,105,0,1) 100%);--wp--preset--gradient--luminous-vivid-orange-to-vivid-red: linear-gradient(135deg,rgba(255,105,0,1) 0%,rgb(207,46,46) 100%);--wp--preset--gradient--very-light-gray-to-cyan-bluish-gray: linear-gradient(135deg,rgb(238,238,238) 0%,rgb(169,184,195) 100%);--wp--preset--gradient--cool-to-warm-spectrum: linear-gradient(135deg,rgb(74,234,220) 0%,rgb(151,120,209) 20%,rgb(207,42,186) 40%,rgb(238,44,130) 60%,rgb(251,105,98) 80%,rgb(254,248,76) 100%);--wp--preset--gradient--blush-light-purple: linear-gradient(135deg,rgb(255,206,236) 0%,rgb(152,150,240) 100%);--wp--preset--gradient--blush-bordeaux: linear-gradient(135deg,rgb(254,205,165) 0%,rgb(254,45,45) 50%,rgb(107,0,62) 100%);--wp--preset--gradient--luminous-dusk: linear-gradient(135deg,rgb(255,203,112) 0%,rgb(199,81,192) 50%,rgb(65,88,208) 100%);--wp--preset--gradient--pale-ocean: linear-gradient(135deg,rgb(255,245,203) 0%,rgb(182,227,212) 50%,rgb(51,167,181) 100%);--wp--preset--gradient--electric-grass: linear-gradient(135deg,rgb(202,248,128) 0%,rgb(113,206,126) 100%);--wp--preset--gradient--midnight: linear-gradient(135deg,rgb(2,3,129) 0%,rgb(40,116,252) 100%);--wp--preset--duotone--dark-grayscale: url('#wp-duotone-dark-grayscale');--wp--preset--duotone--grayscale: url('#wp-duotone-grayscale');--wp--preset--duotone--purple-yellow: url('#wp-duotone-purple-yellow');--wp--preset--duotone--blue-red: url('#wp-duotone-blue-red');--wp--preset--duotone--midnight: url('#wp-duotone-midnight');--wp--preset--duotone--magenta-yellow: url('#wp-duotone-magenta-yellow');--wp--preset--duotone--purple-green: url('#wp-duotone-purple-green');--wp--preset--duotone--blue-orange: url('#wp-duotone-blue-orange');--wp--preset--font-size--small: 13px;--wp--preset--font-size--medium: 20px;--wp--preset--font-size--large: 36px;--wp--preset--font-size--x-large: 42px;}.has-black-color{color: var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-color{color: var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-color{color: var(--wp--preset--color--white) !important;}.has-pale-pink-color{color: var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-color{color: var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-color{color: var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-color{color: var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-color{color: var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-color{color: var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-color{color: var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-color{color: var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-color{color: var(--wp--preset--color--vivid-purple) !important;}.has-black-background-color{background-color: var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-background-color{background-color: var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-background-color{background-color: var(--wp--preset--color--white) !important;}.has-pale-pink-background-color{background-color: var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-background-color{background-color: var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-background-color{background-color: var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-background-color{background-color: var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-background-color{background-color: var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-background-color{background-color: var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-background-color{background-color: var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-background-color{background-color: var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-background-color{background-color: var(--wp--preset--color--vivid-purple) !important;}.has-black-border-color{border-color: var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-border-color{border-color: var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-border-color{border-color: var(--wp--preset--color--white) !important;}.has-pale-pink-border-color{border-color: var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-border-color{border-color: var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-border-color{border-color: var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-border-color{border-color: var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-border-color{border-color: var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-border-color{border-color: var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-border-color{border-color: var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-border-color{border-color: var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-border-color{border-color: var(--wp--preset--color--vivid-purple) !important;}.has-vivid-cyan-blue-to-vivid-purple-gradient-background{background: var(--wp--preset--gradient--vivid-cyan-blue-to-vivid-purple) !important;}.has-light-green-cyan-to-vivid-green-cyan-gradient-background{background: var(--wp--preset--gradient--light-green-cyan-to-vivid-green-cyan) !important;}.has-luminous-vivid-amber-to-luminous-vivid-orange-gradient-background{background: var(--wp--preset--gradient--luminous-vivid-amber-to-luminous-vivid-orange) !important;}.has-luminous-vivid-orange-to-vivid-red-gradient-background{background: var(--wp--preset--gradient--luminous-vivid-orange-to-vivid-red) !important;}.has-very-light-gray-to-cyan-bluish-gray-gradient-background{background: var(--wp--preset--gradient--very-light-gray-to-cyan-bluish-gray) !important;}.has-cool-to-warm-spectrum-gradient-background{background: var(--wp--preset--gradient--cool-to-warm-spectrum) !important;}.has-blush-light-purple-gradient-background{background: var(--wp--preset--gradient--blush-light-purple) !important;}.has-blush-bordeaux-gradient-background{background: var(--wp--preset--gradient--blush-bordeaux) !important;}.has-luminous-dusk-gradient-background{background: var(--wp--preset--gradient--luminous-dusk) !important;}.has-pale-ocean-gradient-background{background: var(--wp--preset--gradient--pale-ocean) !important;}.has-electric-grass-gradient-background{background: var(--wp--preset--gradient--electric-grass) !important;}.has-midnight-gradient-background{background: var(--wp--preset--gradient--midnight) !important;}.has-small-font-size{font-size: var(--wp--preset--font-size--small) !important;}.has-medium-font-size{font-size: var(--wp--preset--font-size--medium) !important;}.has-large-font-size{font-size: var(--wp--preset--font-size--large) !important;}.has-x-large-font-size{font-size: var(--wp--preset--font-size--x-large) !important;}
+</style>
+<link rel='stylesheet' id='article_forum_connect_comments-css'  href='https://cdn.arstechnica.net/wp-content/plugins/article-forum-connect/public/css/comments.css?ver=1.2.2' type='text/css' media='all' />
+<link rel='stylesheet' id='article_forum_connect_paywall-css'  href='https://cdn.arstechnica.net/wp-content/plugins/article-forum-connect/public/css/paywall.css?ver=1.2.2' type='text/css' media='all' />
+<link rel="amphtml" href="https://arstechnica.com/science/2023/08/whats-going-on-with-the-reports-of-a-room-temperature-superconductor/3/amp/"><meta name="twitter:partner" content="tfwp" />
+<!--
+	generated 102 seconds ago
+	generated in 0.220 seconds
+	served from batcache in 0.001 seconds
+	expires in 198 seconds
+	billboard: forced 
+	view: grid 
+	theme: light 
+ -->
+</head>
+
+<body class="post-template-default single single-post postid-1958785 single-format-standard paged-3 single-paged-3 grid-view light blog-us">
+  <!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-NLXNPCQ" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) -->
+
+      	<aside class="ad ad_crown" aria-label="Top of page advertisement"></aside>
+  
+  <div class="site-wrapper">
+    <a class="screen-reader-text skip-link" href="#main" aria-label="Skip to main content">Skip to main content</a>
+    <header class="site-header">
+      <div class="header-left">
+        <a href="https://arstechnica.com" id="header-logo" title="Ars Technica Homepage">
+      <span class="icon icon-logo-ars-us"></span>
+  </a>
+      </div>
+
+      <div class="header-right">
+        <nav id="header-nav-primary">
+          <ul>
+            
+  <li><a class="nav-link section-information-technology " href="/information-technology/">Biz &amp; IT</a></li>
+  <li><a class="nav-link section-gadgets " href="/gadgets/">Tech</a></li>
+  <li><a class="nav-link section-science active" href="/science/">Science</a></li>
+  <li><a class="nav-link section-tech-policy " href="/tech-policy/">Policy</a></li>
+  <li><a class="nav-link section-cars " href="/cars/">Cars</a></li>
+  <li><a class="nav-link section-gaming " href="/gaming/">Gaming &amp; Culture</a></li>
+  <li><a class="nav-link store" href="/store/">Store</a></li>
+  <li><a class="nav-link forums" href="/civis/">Forums</a></li>
+          </ul>
+        </nav>
+
+                              <a href="/store/product/subscriptions/" class="header-highlight-link">Subscribe</a>
+                                  <div class="dropdown" id="header-search">
+          <a href="/search/" class="dropdown-toggle search-toggle" aria-label="Search" aria-expanded="false">
+            <span class="icon icon-search-mag-glass"></span>
+          </a>
+          <div class="dropdown-content">
+            <form action="/search/" method="GET" id="search_form">
+  <input type="hidden" name="ie" value="UTF-8">
+  <input type="text" name="q" id="hdr_search_input" value="" aria-label="Search..." placeholder="Search...">
+</form>
+<a class="nav-search-close">Close</a>
+          </div>
+        </div>
+        <div class="dropdown dropdown-mega" id="header-burger">
+          <a href="#site-menu" class="dropdown-toggle" aria-label="Menu" aria-expanded="false">
+            <span></span>
+          </a>
+          <div id="site-menu" class="dropdown-content">
+            <section class="burger-navigate">
+  <h3>
+    <span class="icon icon-half-target"></span>
+    Navigate
+  </h3>
+  <ul>
+          <li><a class="nav-link store" href="/store/">Store</a></li>
+      <li><a class="nav-link subscribe" href="/store/product/subscriptions/">Subscribe</a></li>
+        <li><a class="nav-link videos" href="http://video.arstechnica.com/">Videos</a></li>
+    <li><a class="nav-link section-features" href="/features/">Features</a></li>
+    <li><a class="nav-link section-reviews" href="/reviews/">Reviews</a></li>
+  </ul>
+
+  <ul>
+    <li><a class="nav-link page-rss-feeds" href="/rss-feeds/">RSS Feeds</a></li>
+    <li><a class="nav-link mobile" href="/?view=mobile">Mobile Site</a></li>
+  </ul>
+
+  <ul>
+    <li><a class="nav-link page-about-us" href="/about-us/">About Ars</a></li>
+    <li><a class="nav-link page-staff-directory" href="/staff-directory/">Staff Directory</a></li>
+    <li><a class="nav-link page-contact-us" href="/contact-us/">Contact Us</a></li>
+  </ul>
+
+  <ul>
+    <li><a class="nav-link page-advertise-with-us" href="https://www.condenast.com/brands/ars-technica">Advertise with Ars</a></li>
+    <li><a class="nav-link page-reprints" href="/reprints/">Reprints</a></li>
+  </ul>
+</section>
+
+<section class="burger-filter">
+  <h3>
+    <span class="icon icon-half-mag"></span>
+    Filter by topic
+  </h3>
+  <ul id="burger-nav-primary">
+    
+  <li><a class="nav-link section-information-technology " href="/information-technology/">Biz &amp; IT</a></li>
+  <li><a class="nav-link section-gadgets " href="/gadgets/">Tech</a></li>
+  <li><a class="nav-link section-science active" href="/science/">Science</a></li>
+  <li><a class="nav-link section-tech-policy " href="/tech-policy/">Policy</a></li>
+  <li><a class="nav-link section-cars " href="/cars/">Cars</a></li>
+  <li><a class="nav-link section-gaming " href="/gaming/">Gaming &amp; Culture</a></li>
+  <li><a class="nav-link store" href="/store/">Store</a></li>
+  <li><a class="nav-link forums" href="/civis/">Forums</a></li>
+  </ul>
+</section>
+
+<section class="burger-settings">
+  <h3>
+    <span class="icon icon-half-gear"></span>
+    Settings
+  </h3>
+  <div>
+    <div class="burger-layout">
+      
+<p>Front page layout</p>
+<div class="burger-layout-grid">
+  <a rel="nofollow" href="/science/2023/08/whats-going-on-with-the-reports-of-a-room-temperature-superconductor/3/?view=grid">
+    <span class="icon icon-grid"></span><br>
+    Grid
+    <div class="faux-radio active"></div>
+  </a>
+</div>
+
+<div class="burger-layout-list">
+  <a rel="nofollow" href="/science/2023/08/whats-going-on-with-the-reports-of-a-room-temperature-superconductor/3/?view=archive">
+    <span class="icon icon-list"></span><br>
+    List
+    <div class="faux-radio "></div>
+  </a>
+</div>
+
+    </div>
+    <div class="burger-theme">
+      <p>Site theme</p>
+  <div class="burger-theme-light">
+    <a rel="nofollow" href="/science/2023/08/whats-going-on-with-the-reports-of-a-room-temperature-superconductor/3/?theme=light">
+      <span><span>light</span></span>
+      <div class="faux-radio active"></div>
+    </a>
+  </div>
+  <div class="burger-theme-dark">
+    <a rel="nofollow" href="/science/2023/08/whats-going-on-with-the-reports-of-a-room-temperature-superconductor/3/?theme=dark">
+      <span><span>dark</span></span>
+      <div class="faux-radio "></div>
+    </a>
+  </div>
+    </div>
+  </div>
+</section>
+          </div>
+        </div>
+              <a class="navlink login-link" href="https://arstechnica.com/civis/login?_xfRedirect=%2Fscience%2F2023%2F08%2Fwhats-going-on-with-the-reports-of-a-room-temperature-superconductor%2F3%2F">
+      Sign in
+    </a>
+  
+        </div>
+    </header>
+
+              
+    <main id="main" class="content-wrapper">
+
+<script type="text/javascript">
+  ars.ARTICLE = {"url":"https:\/\/arstechnica.com\/science\/2023\/08\/whats-going-on-with-the-reports-of-a-room-temperature-superconductor\/","short_url":"https:\/\/arstechnica.com\/?p=1958785","title":"What\u2019s going on with the reports of a room-temperature superconductor?","author":52979,"authorName":"John Timmer","pubDate":"2023-08-04T14:07:48Z","id":1958785,"topic":1494994,"pages":3,"current_page":3,"superscroll":true,"promoted":[],"single_page":false,"comments":113,"fullwidth":false,"slug":"whats-going-on-with-the-reports-of-a-room-temperature-superconductor","arsStaff":{"104481":{"name":"Aaron Zimmerman","title":"Copy Chief","staff":true},"332715":{"name":"Andrew Cunningham","title":"Senior Technology Reporter","staff":true},"855306":{"name":"Ashley Belanger","title":"Senior Policy Reporter","staff":true},"1002":{"name":"Aurich Lawson","title":"Creative Director","staff":true},"857898":{"name":"Benj Edwards","title":"AI and Machine Learning Reporter","staff":true},"509873":{"name":"Beth Mole","title":"Senior Health Reporter","staff":true},"453791":{"name":"Cathleen O'Grady","title":"Contributing science reporter","staff":true},"102179":{"name":"Chris Lee","title":"Associate writer","staff":true},"821742":{"name":"Corey Gaskin","title":"Senior Commerce Writer","staff":true},"329388":{"name":"Dan Goodin","title":"Security Editor","staff":true},"254631":{"name":"Diana Gitig","title":"Associate Writer","staff":false},"25862":{"name":"Eric Bangeman","title":"Managing Editor","staff":true},"512413":{"name":"Eric Berger","title":"Senior Space Editor","staff":true},"46707":{"name":"Iljitsch van Beijnum","title":"Associate Writer","staff":false},"316010":{"name":"Jason Marlin","title":"Technical Director","staff":true},"746799":{"name":"Jennifer Ouellette","title":"Senior Writer","staff":true},"15365":{"name":"Jeremy Reimer","title":"Senior Niche Technology Historian","staff":false},"52979":{"name":"John Timmer","title":"Senior Science Editor","staff":true},"312082":{"name":"Jon Brodkin","title":"Senior IT Reporter","staff":true},"14317":{"name":"Jonathan M. Gitlin","title":"Automotive Editor","staff":true},"998":{"name":"Ken Fisher","title":"Editor in Chief","staff":true},"440179":{"name":"Kerry Staurseth","title":"Associate Copyeditor","staff":true},"856780":{"name":"Kevin Purdy","title":"Senior Technology Reporter","staff":true},"328283":{"name":"Kyle Orland","title":"Senior Gaming Editor","staff":true},"10243":{"name":"Lee Hutchinson","title":"Senior Technology Editor","staff":true},"173191":{"name":"Matthew Lasar","title":"Associate writer","staff":true},"182268":{"name":"Nate Anderson","title":"Deputy Editor","staff":true},"1991":{"name":"Ohrmazd","title":"","staff":false},"391727":{"name":"Ron Amadeo","title":"Reviews Editor","staff":true},"588289":{"name":"Samuel Axon","title":"Senior Editor","staff":true},"294205":{"name":"Scott K. Johnson","title":"Associate Writer","staff":true},"843451":{"name":"Steve Haske","title":"","staff":false},"173910":{"name":"Timothy B. Lee","title":"Senior tech policy reporter","staff":false}},"tags":["chemistry","electrons","physics","superconductivity"],"zen_mode":false};
+</script>
+
+<article itemscope itemtype="http://schema.org/NewsArticle" class="article-single standalone intro-standard " id="">
+      <div class="column-wrapper">
+    <div class="left-column">
+        <header class="article-header">
+            <h4 class="post-upperdek">
+      No answers yet    &mdash;
+</h4>
+            <h1 itemprop="headline">What’s going on with the reports of a room-temperature superconductor?</h1>
+            <h2 itemprop="description">Rumors are flying of confirmation, but the situation is still frustratingly vague.</h2>
+            <section class="post-meta">
+
+  
+<p class="byline" itemprop="author creator" itemscope itemtype="http://schema.org/Person">
+      <a itemprop="url" href="https://arstechnica.com/author/john-timmer/" rel="author"><span itemprop="name">John Timmer</span></a>
+    -  <time class="date" data-time="1691158068" datetime="2023-08-04T14:07:48+00:00">Aug 4, 2023 2:07 pm UTC</time>
+</p>
+
+
+  
+</section>        </header>
+        <section class="article-guts">
+            <div itemprop="articleBody" class="article-content post-page">
+                                    
+
+
+
+
+
+<h2>What about those other superconductors?</h2>
+<p>The news comes at a somewhat awkward time for the field. A similar claim was made about a high-pressure material a few years ago, but that paper <a href="https://arstechnica.com/science/2020/10/high-pressure-superconductors-reach-room-temperature/">ended up being retracted</a> because of problems with some of its data. The same research group came back with a <a href="https://arstechnica.com/science/2023/03/room-temperature-superconductor-works-at-lower-pressures/">different material</a> that was said to work at room temperature, but that work <a href="https://arstechnica.com/science/2023/05/high-temperature-superconductor-report-fails-to-replicate/">hasn't been replicated</a>, and the head of the lab has now been <a href="https://www.nytimes.com/2023/07/26/science/ranga-dias-retraction-physics.html">accused of scientific misconduct</a>.</p>
+<p>There is almost no overlap between that work and LK-99. None of the people involved are the same, so there's no reason to suspect problematic research practices. And the chemistry and physics involved are completely different. The earlier work used high pressure to create chemicals with lots of hydrogen and unusual orbital structures. LK-99 uses no hydrogen at all and gets its orbital structures via a conformational change in a crystal lattice that takes place at ambient pressures.</p>
+<p>Hydrogen was the focus of the earlier work because its low atomic weight influences the behavior of vibrations within the material in a way that promotes the formation of superconducting pairs of electrons. The mechanism behind LK-99 is less clear, but clearly not that.</p>
+<p>(The LK-99's creators suggest that the conformational change in the crystal creates a sort of standing wave of electrons called a "charge density wave," and superconductivity involves electrons tunneling between wave sites. The modeling paper, by contrast, suggests that giving electrons the opportunity to both superconduct and participate in additional processes like charge density wave formation increases the probability that they'll superconduct. In any case, neither idea involves phonons.)</p>                                            <aside class="ad_wrapper" aria-label="In Content advertisement">
+    <span class="ad_notice">Advertisement </span>    
+    <div class="ad ad_instream"></div>    
+</aside>
+                                                        
+<h2>So when will we actually know anything?</h2>
+<p>Hopefully soon. The researchers behind the original report are trying to get information out there. In addition to the drafts placed in the arXiv, they have already <a href="http://journal.kci.go.kr/jkcgct/archive/articleView?artiId=ART002955269">published a paper on LK-99</a>, albeit in their native Korean. And a group of South Korean scientists working in the field <a href="https://www.reuters.com/science/skorean-experts-seek-verify-room-temperature-superconductor-claim-2023-08-03/">have also announced</a> that they're going to obtain LK-99 samples and try to confirm its reported behavior.</p>
+<p>There's also lots of activity outside of South Korea. Producing LK-99 is within reach of a lot of labs, and testing it is much easier since it doesn't require low temperatures or high pressures. That will mean a lot of short-term confusion, but it's likely to enable a consensus to emerge sooner.</p>
+<p>Whether or not this chemical superconducts at ambient temperatures might not be the final question, though. Assuming it does, there will be many questions about how to develop it into a useful material, how much current it can carry, and how to use it most effectively in the huge range of applications it can be put to. But I'm sure we'll all be happy if we end up needing answers to those questions.</p>
+
+                                                </div>
+
+            
+                            <nav class="page-numbers">Page: <span class="numbers"><a href="https://arstechnica.com/science/2023/08/whats-going-on-with-the-reports-of-a-room-temperature-superconductor/1/">1</a> <a href="https://arstechnica.com/science/2023/08/whats-going-on-with-the-reports-of-a-room-temperature-superconductor/2/">2</a> 3 </span></nav>
+            
+        </section>
+    </div>
+    <div class="xrail">
+        <div class="xrail-content">
+            
+            
+            
+                            <div class="ars-interlude-container ad_xrail ad_xrail_top"></div>
+            
+            
+                            <aside class="ad ad_xrail ad_xrail_top ad_xrail_last" aria-label="Top sidebar advertisement"></aside>
+                    </div>
+    </div>
+</div>
+
+<div class="column-wrapper">
+    <div class="left-column">
+        <div id="social-footer">
+                  <a class="comment-count icon-comment-bubble-down" href="https://arstechnica.com/science/2023/08/whats-going-on-with-the-reports-of-a-room-temperature-superconductor/?comments=1">
+      <h4 class="comment-count-before">reader comments</h4>
+  
+  <span class="comment-count-number">113</span>
+  <span class="visually-hidden"> with </span>
+  </a>
+          </div>
+                    <!-- cache hit 193:single/author:edaec1ff064d5323d80a377d6771e515 -->  <section class="article-author">
+          <a style="background-image:url('https://cdn.arstechnica.net/wp-content/uploads/2016/05/j.timmer-5.jpg');" class="author-photo" href="/author/john-timmer" tabindex="-1" role="presentation" aria-hidden="true"></a>
+    
+    <div class="author-bio">
+      <section class="author-bio-top">
+        <a href="/author/john-timmer" class="author-name">John Timmer</a>
+        John is Ars Technica's science editor. He has a Bachelor of Arts in Biochemistry from Columbia University, and a Ph.D. in Molecular and Cell Biology from the University of California, Berkeley. When physically separated from his keyboard, he tends to seek out a bicycle, or a scenic location for communing with his hiking boots.
+      </section>
+    </div>
+
+  </section>
+            </div>
+    <div class="xrail"></div>
+</div>
+<div id="article-footer-wrap">
+            <aside class="ad_wrapper" aria-label="Full width advertisement">
+    <span class="ad_notice">Advertisement </span>        
+    <div class="ad ad_fullwidth fullwidth"></div>
+</aside>
+    
+            <section id="comments-area" class="comments-area column-wrapper">
+      <div class="row comments-row left-column">
+      <a name="comments-bar"></a>
+      
+<div class="wp-forum-connect-container">
+
+    
+
+    
+</div>
+
+    </div>
+          <div class="xrail xrail-comments">
+        <div class="xrail-content-wrapper">
+          <div class="xrail-content xrail-content-comments">
+            <aside class="ad ad_xrail ad_xrail_comments" aria-label="Comments sidebar advertisement"></aside>
+          </div>
+        </div>
+                  <div class="xrail-content-wrapper xrail-content-wrapper-bottom">
+            <div class="xrail-content xrail-content-comments">
+              <aside class="ad ad_xrail ad_xrail_comments" aria-label="Comments sidebar advertisement"></aside>
+            </div>
+          </div>
+              </div>
+      </section>
+                    <section class="inline-playlist">
+  <div class='ars-video-playlist'>
+    <h3 class="ars-video-playlist-module-header">Channel <span>Ars Technica</span></h3>
+    <div class='ars-video-playlist-module' data-playlist-id='arstechnica-channel-ars-science' data-video-options='[]'></div>
+  </div>
+</section>
+                <div class="prev-next-links">
+  <a href="https://arstechnica.com/science/2023/08/frackers-can-use-dangerous-chemicals-without-disclosure-due-to-haliburton-loophole/" rel="prev"><span class="arrow">&larr;</span> Previous story</a>  <a href="https://arstechnica.com/cars/2023/08/fisker-debuts-an-entire-range-of-new-evs-including-one-sub-30000/" rel="next">Next story <span class="arrow">&rarr;</span></a></div>
+        <footer id="article-footer">
+  <div class="recommendations-footer">
+    <div id="story-recommendations">
+  <div class="heading-column">
+    <h3>Related Stories</h3>
+  </div>
+  <ul id="story-recs" class="rec-wrap"></ul>
+</div>
+  </div>
+      <div id="taboola-below-article-thumbnails---at"></div>
+<script type="text/javascript">
+  window._taboola = window._taboola || [];
+  _taboola.push({
+    mode: 'thumbnails-a-6x1',
+    container: 'taboola-below-article-thumbnails---at',
+    placement: 'Below Article Thumbnails - AT',
+    target_type: 'mix'
+  });
+</script>
+    <div class="recommendations-footer">
+    <div id="latest-stories">
+  <div class="heading-column">
+    <h3>Today on Ars</h3>
+  </div>
+  <ul id="latest-recs" class="rec-wrap"></ul>
+</div>
+  </div>
+</footer>
+    </div>
+  </article>
+  </main>
+
+  <footer class="site-footer">
+    <nav class="nav-footer">
+
+  <section>
+    <ul>
+      <li><a href="/store/">Store</a></li>
+      <li><a href="/store/product/subscriptions/">Subscribe</a></li>
+      <li><a href="/about-us/">About Us</a></li>
+      <li><a href="/rss-feeds/">RSS Feeds</a></li>
+      <li><a rel="nofollow" href="/science/2023/08/whats-going-on-with-the-reports-of-a-room-temperature-superconductor/3/?view=mobile">View Mobile Site</a></li>
+    </ul>
+  </section>
+
+  <section>
+    <ul>
+      <li><a href="/contact-us/">Contact Us</a></li>
+      <li><a href="/staff-directory/">Staff</a></li>
+      <li><a href="https://www.condenast.com/brands/ars-technica">Advertise with us</a></li>
+      <li><a href="/reprints/">Reprints</a></li>
+    </ul>
+  </section>
+
+  <section class="footer-newsletter">
+    <div class="newsletter-wrapper">
+      <h3>
+        <a href="/newsletters/" class="footer-newsletter-sign-up">Newsletter Signup</a>
+      </h3>
+      <p>Join the Ars Orbital Transmission mailing list to get weekly updates delivered to your inbox. <a href="/newsletters/" class="footer-newsletter-sign-up">Sign me up &rarr;</a></p>
+
+      <div class="footer-social-links">
+        <a href="https://twitter.com/arstechnica" class="footer-social-twitter">
+          <svg style="height: 40px; width: 40px;" id="b" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 40 40">
+            <defs>
+              <clipPath id="e">
+                <rect width="40" height="40" fill="none" />
+              </clipPath>
+              <clipPath id="f">
+                <rect width="40" height="40" fill="none" />
+              </clipPath>
+            </defs>
+            <g id="c">
+              <g id="d">
+                <g clip-path="url(#e)">
+                  <g clip-path="url(#f)">
+                    <path d="M16.3,28.1c7.5,0,11.7-6.3,11.7-11.7s0-.4,0-.5c.8-.6,1.5-1.3,2-2.1-.7,.3-1.5,.5-2.4,.6,.9-.5,1.5-1.3,1.8-2.3-.8,.5-1.7,.8-2.6,1-.6-.7-1.4-1.1-2.3-1.2s-1.8,0-2.6,.4c-.8,.4-1.4,1.1-1.8,1.9-.4,.8-.5,1.7-.3,2.6-1.6,0-3.2-.5-4.7-1.2-1.5-.7-2.7-1.8-3.8-3-.5,.9-.7,2-.5,3,.2,1,.9,1.9,1.7,2.5-.7,0-1.3-.2-1.9-.5h0c0,1,.3,1.9,.9,2.7,.6,.7,1.4,1.2,2.4,1.4-.6,.2-1.2,.2-1.9,0,.3,.8,.8,1.5,1.5,2s1.5,.8,2.4,.8c-1.5,1.1-3.2,1.8-5.1,1.8-.3,0-.7,0-1,0,1.9,1.2,4.1,1.8,6.3,1.8" fill="currentColor" />
+                  </g>
+                </g>
+              </g>
+            </g>
+          </svg>
+        </a>
+        <a href="https://mastodon.social/@arstechnica" class="footer-social-mastodon">
+          <svg style="height: 40px; width: 40px;" id="b" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 40 40">
+            <defs>
+              <clipPath id="e">
+                <rect width="40" height="40" fill="none" />
+              </clipPath>
+              <clipPath id="f">
+                <rect width="40" height="40" fill="none" />
+              </clipPath>
+            </defs>
+            <g id="c">
+              <g id="d">
+                <g clip-path="url(#e)">
+                  <g clip-path="url(#f)">
+                    <path d="M29.3,16.6c0-4.3-2.8-5.6-2.8-5.6-1.4-.7-3.9-.9-6.5-1h0c-2.6,0-5,.3-6.4,1,0,0-2.8,1.3-2.8,5.6s0,2.2,0,3.4c.1,4.2,.8,8.4,4.7,9.5,1.8,.5,3.4,.6,4.6,.5,2.3-.1,3.5-.8,3.5-.8v-1.6c0,0-1.7,.5-3.5,.4-1.8,0-3.7-.2-4-2.4,0-.2,0-.4,0-.6,0,0,1.8,.4,4,.5,1.4,0,2.7,0,4-.2,2.5-.3,4.7-1.8,5-3.3,.4-2.2,.4-5.4,.4-5.4h0Zm-3.4,5.6h-2.1v-5.1c0-1.1-.5-1.6-1.4-1.6s-1.5,.6-1.5,1.9v2.8h-2.1v-2.8c0-1.3-.5-1.9-1.5-1.9s-1.4,.5-1.4,1.6v5.1h-2.1v-5.3c0-1.1,.3-1.9,.8-2.6,.6-.6,1.3-1,2.2-1s1.9,.4,2.4,1.2l.5,.9,.5-.9c.5-.8,1.3-1.2,2.4-1.2s1.7,.3,2.2,1c.6,.6,.8,1.5,.8,2.6v5.3Z" fill="currentColor" />
+                  </g>
+                </g>
+              </g>
+            </g>
+          </svg>
+        </a>
+        <a href="https://www.facebook.com/arstechnica" class="footer-social-facebook">
+          <svg style="height: 40px; width: 40px;" id="b" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 40 40">
+            <defs>
+              <clipPath id="e">
+                <rect width="40" height="40" fill="none" />
+              </clipPath>
+              <clipPath id="f">
+                <rect width="40" height="40" fill="none" />
+              </clipPath>
+            </defs>
+            <g id="c">
+              <g id="d">
+                <g clip-path="url(#e)">
+                  <g clip-path="url(#f)">
+                    <path d="M17.3,13.9v2.8h-2v3.4h2v10h4.2v-10h2.8s.3-1.6,.4-3.4h-3.2v-2.3c0-.3,.5-.8,.9-.8h2.3v-3.5h-3.1c-4.4,0-4.3,3.4-4.3,3.9" fill="currentColor" />
+                  </g>
+                </g>
+              </g>
+            </g>
+          </svg>
+        </a>
+        <a href="https://www.youtube.com/@arstechnica" class="footer-social-youtube">
+          <svg style="height: 40px; width: 40px;" id="b" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 40 40">
+            <defs>
+              <clipPath id="e">
+                <rect width="40" height="40" fill="none" />
+              </clipPath>
+              <clipPath id="f">
+                <rect width="40" height="40" fill="none" />
+              </clipPath>
+            </defs>
+            <g id="c">
+              <g id="d">
+                <g clip-path="url(#e)">
+                  <g clip-path="url(#f)">
+                    <path d="M29.6,15.2c-.1-.4-.3-.8-.6-1.1-.3-.3-.7-.5-1.1-.7-1.6-.4-7.8-.4-7.8-.4,0,0-6.3,0-7.8,.4-.4,.1-.8,.3-1.1,.7-.3,.3-.5,.7-.6,1.1-.4,1.6-.4,4.8-.4,4.8,0,0,0,3.3,.4,4.8,.1,.4,.3,.8,.6,1.1,.3,.3,.7,.5,1.1,.7,1.6,.4,7.8,.4,7.8,.4,0,0,6.3,0,7.8-.4,.4-.1,.8-.3,1.1-.7s.5-.7,.6-1.1c.4-1.6,.4-4.8,.4-4.8,0,0,0-3.3-.4-4.8m-11.6,7.8v-5.9l5.2,3-5.2,3Z" fill="currentColor" />
+                  </g>
+                </g>
+              </g>
+            </g>
+          </svg>
+        </a>
+        <a href="https://www.instagram.com/arstechnica/" class="footer-social-instagram">
+          <svg style="height: 40px; width: 40px;" id="b" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 40 40">
+            <defs>
+              <clipPath id="e">
+                <rect width="40" height="40" fill="none" />
+              </clipPath>
+              <clipPath id="f">
+                <rect width="40" height="40" fill="none" />
+              </clipPath>
+            </defs>
+            <g id="c">
+              <g id="d">
+                <g clip-path="url(#e)">
+                  <g clip-path="url(#f)">
+                    <path d="M20,10c2.7,0,3.1,0,4.1,0,1.1,0,1.8,.2,2.4,.5,.7,.3,1.2,.6,1.8,1.2,.6,.6,.9,1.1,1.2,1.8,.2,.6,.4,1.4,.5,2.4,0,1.1,0,1.4,0,4.1s0,3.1,0,4.1c0,1.1-.2,1.8-.5,2.4-.3,.7-.6,1.3-1.2,1.8-.6,.6-1.1,.9-1.8,1.2-.6,.2-1.4,.4-2.4,.5-1.1,0-1.4,0-4.1,0s-3.1,0-4.1,0c-1.1,0-1.8-.2-2.4-.5-.7-.3-1.3-.6-1.8-1.2-.5-.5-.9-1.1-1.2-1.8-.2-.6-.4-1.4-.5-2.4,0-1.1,0-1.4,0-4.1s0-3.1,0-4.1c0-1.1,.2-1.8,.5-2.4,.3-.7,.6-1.2,1.2-1.8,.6-.6,1.1-.9,1.8-1.2,.6-.2,1.4-.4,2.4-.5,1.1,0,1.4,0,4.1,0m0,2.5c-2.4,0-2.7,0-3.7,0-.9,0-1.4,.2-1.7,.3-.4,.1-.8,.4-1.1,.7-.3,.3-.5,.6-.7,1.1-.1,.3-.3,.8-.3,1.7,0,1,0,1.3,0,3.7s0,2.7,0,3.7c0,.9,.2,1.4,.3,1.7,.2,.4,.4,.7,.7,1.1,.3,.3,.6,.5,1.1,.7,.3,.1,.8,.3,1.7,.3,1,0,1.3,0,3.7,0s2.7,0,3.7,0c.9,0,1.4-.2,1.7-.3,.4-.2,.7-.4,1.1-.7,.3-.3,.5-.6,.7-1.1,.1-.3,.3-.8,.3-1.7,0-1,0-1.3,0-3.7s0-2.7,0-3.7c0-.9-.2-1.4-.3-1.7-.1-.4-.4-.8-.7-1.1-.3-.3-.7-.5-1.1-.7-.3-.1-.8-.3-1.7-.3-1,0-1.3,0-3.7,0m0,2.2c.7,0,1.4,.1,2,.4,.6,.3,1.2,.7,1.7,1.1,.5,.5,.9,1.1,1.1,1.7,.3,.6,.4,1.3,.4,2s-.1,1.4-.4,2c-.3,.6-.7,1.2-1.1,1.7-.5,.5-1.1,.9-1.7,1.1-.6,.3-1.3,.4-2,.4-1.4,0-2.7-.6-3.7-1.5-1-1-1.5-2.3-1.5-3.7s.6-2.7,1.5-3.7,2.3-1.5,3.7-1.5m0,8.3c.8,0,1.5-.3,2.1-.9,.6-.6,.9-1.3,.9-2.1s-.3-1.5-.9-2.1c-.6-.6-1.3-.9-2.1-.9s-1.5,.3-2.1,.9c-.6,.6-.9,1.3-.9,2.1s.3,1.5,.9,2.1c.6,.6,1.3,.9,2.1,.9m6.6-8.1c0,.4-.2,.7-.4,1s-.6,.4-1,.4-.7-.2-1-.4c-.3-.3-.4-.6-.4-1s.2-.7,.4-1c.3-.3,.6-.4,1-.4s.7,.2,1,.4c.3,.3,.4,.6,.4,1" fill="currentColor" />
+                  </g>
+                </g>
+              </g>
+            </g>
+          </svg>
+        </a>
+      </div>
+
+    </div>
+  </section>
+</nav>
+
+<section class="footer-terms-logo">
+  <div class="cn-logo">
+    <a href="http://condenast.com/" class="icon icon-logo-cn-us" title="Visit Condé Nast"></a>
+  </div>
+
+  <p id="copyright-terms">
+  CNMN Collection<br>
+  WIRED Media Group<br>
+  © 2023 Condé Nast. All rights reserved. Use of and/or registration on any portion of this site constitutes acceptance of our <a href="https://www.condenast.com/user-agreement/">User Agreement</a> (updated 1/1/20) and <a href="https://www.condenast.com/privacy-policy/">Privacy Policy and Cookie Statement</a> (updated 1/1/20) and <a href="/amendment-to-conde-nast-user-agreement-privacy-policy/">Ars Technica Addendum</a> (effective 8/21/2018). Ars may earn compensation on sales from links on this site. <a href="/affiliate-link-policy/">Read our affiliate link policy</a>.<br>
+  <span style="display: inline-flex; flex-flow: row nowrap; align-items: center; gap: 5px;"><a href="https://www.condenast.com/privacy-policy/#california">Your California Privacy Rights</a> | <img src="https://cdn.arstechnica.net/wp-content/themes/ars/assets/img/privacyoptions123x59-c5c9972158.png" style="height: 1em; width: auto;" /> <a id="ot-sdk-btn" class="ot-sdk-show-settings">Do Not Sell My Personal Information</a></span><br>
+  The material on this site may not be reproduced, distributed, transmitted, cached or otherwise used, except with the prior written permission of Condé Nast.<br>
+  <a href="https://www.condenast.com/online-behavioral-advertising-oba-and-how-to-opt-out-of-oba/#clickheretoreadmoreaboutonlinebehavioraladvertising(oba)">Ad Choices</a>
+</p>
+</section>
+  </footer>
+  </div>
+
+  <script type="text/javascript" src="https://cdn.arstechnica.net/wp-content/themes/ars/assets/js/main-f627adae4a.js"></script>
+
+
+<!-- cache hit 193:single/javascript-footer:d29d6446a030580dc69054ef5c06dab8 -->
+        
+
+
+    <!-- Taboola -->
+  <script type="text/javascript">
+    window._taboola = window._taboola || [];
+    _taboola.push({
+      flush: true
+    });
+  </script>
+
+  <!-- Parse.ly start -->
+<script type="text/plain" class="optanon-category-C0002" id="parsely-cfg" src="//fpa-cdn.arstechnica.com/keys/arstechnica.com/p.js"></script>
+<!-- Parse.ly end -->
+
+<!-- Memo start -->
+<script type="text/javascript">
+__memo_config = {
+	pid: ars.MEMO_PID,
+	url: ars.ARTICLE.url,
+	author: [ars.ARTICLE.authorName],
+	title: ars.ARTICLE.title,
+	date: ars.ARTICLE.pubDate,
+};
+(function(){
+	var s = document.createElement('script'); 
+	s.async = true; 
+	s.type = 'text/javascript'; 
+	s.src = document.location.protocol + '//cdn.memo.co/js/memo.js';
+	(document.getElementsByTagName('head')[0] || document.getElementsByTagName('body') [0]).appendChild(s); 
+})();
+</script>
+<!-- Memo end -->
+
+  
+  
+    
+<script>
+  (function() {
+    var w = window.innerWidth ||
+      document.documentElement.clientWidth ||
+      document.body.clientWidth;
+    var src = 'https://player.cnevids.com/interlude/arstechnica.js';
+    if (!ars.MOBILE && w >= 1000) {
+      src += '?isRightRail=true';
+    }
+    var s = document.createElement('script');
+    s.setAttribute('async', true);
+    s.setAttribute('src', src);
+    document.body.appendChild(s);
+  })();
+</script>
+
+<script id="conde-polar" src="https://cdn.mediavoice.com/nativeads/script/condenastcorporate/conde-asa-polar-master.js" async></script>
+<!-- Sparrow begin -->
+<script type="text/plain" class="optanon-category-C0002">
+  (function() {
+    function DQ() {
+      var queue = window.sparrowQueue;
+      this.push = fn => fn();
+      window.sparrowQueue = this;
+      while (queue.length) {
+        queue.shift()();
+      }
+    }
+
+    function e(t, e) {
+      var n, a, o;
+      a = !1, n = document.createElement("script"), n.type = "text/javascript", n.src = t, n.onload = n.onreadystatechange = function() {
+        a || this.readyState && "complete" != this.readyState || (a = !0, e ? e() : !0)
+      }, o = document.getElementsByTagName("script")[0], o.parentNode.insertBefore(n, o)
+    }
+    if (location.search.indexOf('no_sparrow') < 0) {
+      e("https://pixel.condenastdigital.com/config/v2/production/ars-technica.config.js", function() {
+        e("https://pixel.condenastdigital.com/sparrow.min.js", function() {
+          if (window.SparrowConfigV2) {
+            window.sparrow = new window.Sparrow(window.SparrowConfigV2);
+            new DQ();
+          }
+        })
+      })
+    }
+  })();
+</script>
+<!-- Sparrow end -->
+<script type="text/javascript" src="//s.skimresources.com/js/100098X1555750.skimlinks.js"></script>
+<script type='text/javascript' src='https://cdn.arstechnica.net/wp-content/plugins/article-forum-connect/public/js/iframeResizer.min.js?ver=1.2.2' id='article_forum_connect_iframe_resizer-js'></script>
+<script type='text/javascript' src='https://cdn.arstechnica.net/wp-content/plugins/article-forum-connect/public/js/iframe.js?ver=1.2.2' id='article_forum_connect_iframe-js'></script>
+  </body>
+
+  </html>

--- a/packages/content-handler/test/data/ars-multipage/ars-technica-page-3.html
+++ b/packages/content-handler/test/data/ars-multipage/ars-technica-page-3.html
@@ -1,0 +1,841 @@
+<!DOCTYPE html>
+<html lang="en-us">
+
+<head>
+  <title>What’s going on with the reports of a room-temperature superconductor? | Ars Technica</title>
+<script type="text/javascript">
+  ars = {"ASSETS":"https:\/\/cdn.arstechnica.net\/wp-content\/themes\/ars\/assets","HOME_URL":"https:\/\/arstechnica.com","CIVIS":"\/civis","THEME":"light","VIEW":"grid","MOBILE":false,"SUBSCRIBER":false,"PLUS_PLUS":false,"LOGGED":false,"USER_ID":null,"ENV":"production","AD":{"tags":["chemistry","electrons","physics","superconductivity"],"channel":"science","slug":"whats-going-on-with-the-reports-of-a-room-temperature-superconductor","template_type":"article","queue":[],"server":"production"},"TOTAL":109337,"UNREAD":0,"RECENT":[1958890,1958894,1950200,1958504,1958915,1958785,1958895,1953746,1958601,1958766,1958740,1958758,1958728,1958672,1958712,1958544,1958702,1958680,1958662,1958644,1958600,1958632,1958537,1958110,1958563],"LOGINS":true,"CROSS":false,"PARSELY":"arstechnica.com","COMMENTS":false,"HOMEPAGE":false,"SITE":1,"READY":[],"SHOW_ADS":true,"IMG_PROXY":"https:\/\/cdn.arstechnica.net\/i\/","CATEGORY":"science","PAGETITLE":"","ZEN_MODE":false,"MEMO_PID":"62012a7a19351c07620394e0"};
+</script>
+<link rel="stylesheet" type="text/css" media="all" href="https://cdn.arstechnica.net/wp-content/themes/ars/assets/css/main-4b9af0fe84.css" />
+    <link rel="alternate" type="application/rss+xml" href="http://feeds.arstechnica.com/arstechnica/index" />
+  <link rel="shortcut icon" href="https://cdn.arstechnica.net/favicon.ico" />
+  <link rel="icon" type="image/x-icon" href="https://cdn.arstechnica.net/favicon.ico" />
+  <link rel="apple-touch-icon" sizes="180x180" href="https://cdn.arstechnica.net/wp-content/themes/ars/assets/img/ars-ios-icon-d9a45f558c.png" />
+  <link rel="mask-icon" href="https://cdn.arstechnica.net/wp-content/themes/ars/assets/img/ars-macos-safari-8997f76b21.svg" color="#ff4e00">
+  <link rel="icon" sizes="192x192" href="https://cdn.arstechnica.net/wp-content/themes/ars/assets/img/material-ars-db41652381.png" />
+  <link rel="me" href="https://mastodon.social/@arstechnica" />
+
+    <meta name="application-name" content="Ars Technica"/>
+  <meta name="msapplication-starturl" content="http://arstechnica.com/"/>
+  <meta name="msapplication-tooltip" content="Ars Technica: Serving the technologist for 1.2 decades"/>
+  <meta name="msapplication-task" content="name=News;action-uri=http://arstechnica.com/;icon-uri=https://cdn.arstechnica.net/favicon.ico"/>
+  <meta name="msapplication-task" content="name=Features;action-uri=http://arstechnica.com/features/;icon-uri=https://cdn.arstechnica.net/ie-jump-menu/jump-features.ico"/>
+  <meta name="msapplication-task" content="name=OpenForum;action-uri=http://arstechnica.com/civis/;icon-uri=https://cdn.arstechnica.net/ie-jump-menu/jump-forum.ico"/>
+  <meta name="msapplication-task" content="name=Subscribe;action-uri=http://arstechnica.com/subscriptions/;icon-uri=https://cdn.arstechnica.net/ie-jump-menu/jump-subscribe.ico"/>
+
+
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <meta name="advertising" content="ask" />
+  <meta property="fb:admins" content="592156917" />
+  <meta property="fb:admins" content="108943" />
+  <meta property="fb:pages" content="19374573752" />
+
+  <meta name="format-detection" content="telephone=no" />
+  <meta name="theme-color" content="#000000" />
+
+  
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+
+  <!-- cache hit 193:single/meta:d29d6446a030580dc69054ef5c06dab8 -->
+<meta name='parsely-page' content='{"title":"What\u2019s going on with the reports of a room-temperature superconductor?","link":"https:\/\/arstechnica.com\/science\/2023\/08\/whats-going-on-with-the-reports-of-a-room-temperature-superconductor\/","type":"post","author":"John Timmer","post_id":1958785,"pub_date":"2023-08-04T14:07:48Z","section":"Science","tags":["chemistry","electrons","physics","superconductivity","type: feature"],"image_url":"https:\/\/cdn.arstechnica.net\/wp-content\/uploads\/2023\/08\/LK-99_pellet-150x150.png"}'>
+<meta name='parsely-metadata' content='{"type":"feature","title":"What\u2019s going on with the reports of a room-temperature superconductor?","post_id":1958785,"lower_deck":"Rumors are flying of confirmation, but the situation is still frustratingly vague.","image_url":"https:\/\/cdn.arstechnica.net\/wp-content\/uploads\/2023\/08\/LK-99_pellet-150x150.png","listing_image_url":"https:\/\/cdn.arstechnica.net\/wp-content\/uploads\/2023\/08\/LK-99_pellet-360x200.png"}'>
+
+  <link rel="canonical" href="https://arstechnica.com/science/2023/08/whats-going-on-with-the-reports-of-a-room-temperature-superconductor/" />
+
+<link rel="amphtml" href="https://arstechnica.com/science/2023/08/whats-going-on-with-the-reports-of-a-room-temperature-superconductor/amp/">
+
+<link rel="shorturl" href="https://arstechnica.com/?p=1958785" />
+
+<meta name="description" content="Rumors are flying of confirmation, but the situation is still frustratingly vague." />
+
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:url" content="https://arstechnica.com/science/2023/08/whats-going-on-with-the-reports-of-a-room-temperature-superconductor/">
+<meta name="twitter:title" content="What’s going on with the reports of a room-temperature superconductor?">
+<meta name="twitter:description" content="Rumors are flying of confirmation, but the situation is still frustratingly vague.">
+
+<meta name="twitter:site" content="@arstechnica">
+<meta name="twitter:domain" content="arstechnica.com">
+
+<meta property="og:site_name" content="Ars Technica" />
+
+<meta name="twitter:image:src" content="https://cdn.arstechnica.net/wp-content/uploads/2023/08/LK-99_pellet-760x380.png">
+  <meta name="twitter:image:width" content="760">
+  <meta name="twitter:image:height" content="380">
+
+  <meta name="twitter:creator" content="@j_timmer">
+
+<meta property="og:url" content="https://arstechnica.com/science/2023/08/whats-going-on-with-the-reports-of-a-room-temperature-superconductor/" />
+<meta property="og:title" content="What’s going on with the reports of a room-temperature superconductor?" />
+<meta property="og:image" content="https://cdn.arstechnica.net/wp-content/uploads/2023/08/LK-99_pellet-760x380.png" />
+<meta property="og:description" content="Rumors are flying of confirmation, but the situation is still frustratingly vague." />
+<meta property="og:type" content="article" />
+  <!-- cache hit 193:single/header:d29d6446a030580dc69054ef5c06dab8 -->
+        
+
+<!-- OneTrust Cookies Consent Notice start -->
+<script 
+    src="https://cdn.cookielaw.org/scripttemplates/otSDKStub.js"  
+    type="text/javascript" charset="UTF-8" 
+    data-domain-script="b10882a1-8446-4e7d-bfb2-ce2c770ad910">
+</script>
+<script type="text/javascript">function OptanonWrapper(){};</script>
+<script 
+    src="https://cdn.cookielaw.org/opt-out/otCCPAiab.js" 
+    type="text/javascript" 
+    charset="UTF-8" 
+    ccpa-opt-out-ids="C0002,C0003,C0004,C0005" 
+    ccpa-opt-out-geo="ca" 
+    ccpa-opt-out-lspa="true">
+</script> 
+<!-- OneTrust Cookies Consent Notice end -->
+<!-- Google Tag Manager DataLayer -->
+<script>
+window.dataLayer = window.dataLayer || [];
+window.dataLayer.push({"event":"data-layer-loaded","user":{"ars_userId":undefined,"amg_userId":undefined,"uID":"247ffd43-8ad6-4bf2-b5c2-0e046fa25ef0","sID":"91f9b038-a9f3-4416-870d-c52ef9fb930a","loginStatus":false,"subscriberStatus":"none","infinityId":"25954524-1ed8-4562-bc8b-981da203f2c9","registrationSource":undefined,"mdw_cnd_id":undefined,"monthlyVisits":undefined,"accessPaywall":undefined,"view":"grid","theme":"light","show_comments":false},"content":{"pageTemplate":"single","pageType":"article|feature","contentCategory":"science","section":"science","subsection":undefined,"contributor":"John Timmer","contentID":1958785,"contentLength":2098,"display":"What\u2019s going on with the reports of a room-temperature superconductor?","contentSource":"web","pageAssets":undefined,"uniqueContentCount":undefined,"monthlyContentCount":undefined,"publishDate":"2023-08-04T14:07:48-04:00","modifiedDate":"2023-08-04T15:56:15-04:00","keywords":"chemistry|electrons|Physics|superconductivity","dataSource":undefined},"marketing":{"campaignName":undefined,"circCampaignId":undefined,"internalCampaignId":undefined,"brand":"Ars Technica","certified_mrc_data":undefined,"condeNastId":undefined},"page":{"pID":"24d643da-97a0-49bc-805c-0656f9533d1e","syndicatorUrl":undefined,"pageURL":"https:\/\/arstechnica.com\/?p=1958785","canonical":"https:\/\/arstechnica.com\/science\/2023\/08\/whats-going-on-with-the-reports-of-a-room-temperature-superconductor\/","canonicalPathName":"\/science\/2023\/08\/whats-going-on-with-the-reports-of-a-room-temperature-superconductor\/3\/"},"search":{"facets":undefined,"searchTerms":undefined},"site":{"appVersion":"1.0.0"}});
+</script>
+<!-- End Google Tag Manager DataLayer -->
+<!-- Google Tag Manager -->
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-NLXNPCQ');</script>
+<!-- End Google Tag Manager -->
+<!-- Start Headline A/B -->
+<script type="text/javascript">
+  class ABTest {
+    constructor(post_id, init_method) {
+      this.post_id = post_id;
+      this.ajaxurl = '/services/ars-ajax-handler.php';
+      this.expireDays = 1 / 48; // 30 min
+      this.group = this.getGroup();
+      this.uid = this.getUid();
+      this.init_method = init_method;
+      this.setTitle();
+
+      if (this.init_method === 'click') {
+        this.click();
+      } else {
+        this.impression();
+      }
+    }
+
+    setCookie(name, value, days) {
+      var expires = "";
+      if (days) {
+        var date = new Date();
+        date.setTime(date.getTime() + (days * 24 * 60 * 60 * 1000));
+        expires = "; expires=" + date.toUTCString();
+      }
+      document.cookie = name + "=" + (value || "") + expires + "; path=/";
+    }
+
+    getCookie(name) {
+      var nameEQ = name + "=";
+      var ca = document.cookie.split(';');
+      for (var i = 0; i < ca.length; i++) {
+        var c = ca[i];
+        while (c.charAt(0) == ' ') c = c.substring(1, c.length);
+        if (c.indexOf(nameEQ) == 0) return c.substring(nameEQ.length, c.length);
+      }
+      return null;
+    }
+
+    // Retrieves a unique id for determining whether the event should be recorded
+    getUid() {
+      var uid = this.getCookie('ars_ab_' + this.post_id + '_uid');
+      if (!uid) {
+        uid = (Math.random() + 1).toString(36).substring(2, 7);
+        this.setCookie('ars_ab_' + this.post_id + '_uid', uid, this.expireDays);
+      }
+      return uid;
+    };
+
+    // Places the user in either A or B for this post id
+    getGroup() {
+      var group = this.getCookie('ars_ab_' + this.post_id + '_group');
+      if (!group) {
+        group = String.fromCharCode(Math.floor(Math.random() * 2) + 65).toLowerCase();
+        this.setCookie('ars_ab_' + this.post_id + '_group', group, this.expireDays);
+      }
+      return group;
+    };
+
+    // Records a headline impression (from homepage or other listing)
+    impression() {
+      // Send fake ajax
+      var params = {
+        nonce: '4dadc83aa5',
+        action: 'ars_ab_impression',
+        id: this.post_id,
+        group: this.group,
+        uid: this.uid,
+        ts: (new Date()).getTime()
+      };
+      var url = this.ajaxurl + '?' + this.encodeParams(params);
+      document.write('\x3Cscript type="text/javascript" src="' + url + '">\x3C/script>');
+    };
+
+    // Records a headline click from the actual post page
+    click() {
+      // Send fake ajax
+      var params = {
+        nonce: '34b2ae4b70',
+        action: 'ars_ab_click',
+        id: this.post_id,
+        group: this.group,
+        uid: this.uid,
+        ts: (new Date()).getTime()
+      };
+      var url = this.ajaxurl + '?' + this.encodeParams(params);
+      document.write('\x3Cscript type="text/javascript" src="' + url + '">\x3C/script>');
+    };
+
+    // If user is in B group, dynamically set title
+    setTitle() {
+      if (this.group == 'b') {
+        var span = document.getElementById('ars_ab_' + this.post_id);
+        var title = span.parentNode;
+        title.innerHTML = span.getAttribute('data-title-b');
+      }
+    };
+
+    encodeParams(data) {
+      var ret = [];
+      for (var d in data)
+        ret.push(encodeURIComponent(d) + "=" + encodeURIComponent(data[d]));
+      return ret.join("&");
+    };
+
+  };
+</script>
+<!-- End Headline A/B -->
+<script src="https://www.googletagservices.com/tag/js/gpt.js" id="gpt-script" async></script>
+<script>
+  window.googletag = window.googletag || {};
+  window.googletag.cmd = window.googletag.cmd || [];
+  window.cns = window.cns || {};
+  window.cns.queue = [];
+  window.cns.async = function(s, c) {
+    cns.queue.push({
+      service: s,
+      callback: c
+    })
+  };
+  window.sparrowQueue = window.sparrowQueue || [];
+</script>
+<script>
+  window.cns.pageContext = {"contentType":"article","templateType":"article","channel":"science","subChannel":"","slug":"whats-going-on-with-the-reports-of-a-room-temperature-superconductor","server":"production","keywords":{"tags":["chemistry","electrons","physics","superconductivity"],"cm":[],"platform":["wordpress"],"copilotid":""}};
+</script>
+<script src="https://ads-static.conde.digital/production/cns/builds/ars-technica/ars-technica.min.js" async></script>
+<script type="text/javascript" src="https://cdn.arstechnica.net/wp-content/themes/ars/assets/js/ars-84a4ab0802.ads.us.js"></script>
+  <script type="text/javascript">!(function(o,_name){function n(){(n.q=n.q||[]).push(arguments)}n.v=1,o[_name]=o[_name]||n;!(function(o,t,n,c){function e(n){(function(){try{return(localStorage.getItem("v4ac1eiZr0")||"").split(",")[4]>0}catch(o){}return!1})()&&(n=o[t].pubads())&&n.setTargeting("admiral-engaged","true")}(c=o[t]=o[t]||{}).cmd=c.cmd||[],typeof c.pubads===n?e():typeof c.cmd.unshift===n?c.cmd.unshift(e):c.cmd.push(e)})(window,"googletag","function");})(window,String.fromCharCode(97,100,109,105,114,97,108));!(function(t,c,i){i=t.createElement(c),t=t.getElementsByTagName(c)[0],i.async=1,i.src="https://shiverscissors.com/v2fumwIJOo-LsCB0dlG18VSTW43CpWhUEPJuKeRTzrEQdSPPlMr5GymU",t.parentNode.insertBefore(i,t)})(document,"script");</script>
+
+  <!-- Taboola -->
+  <script type="text/javascript">
+    window._taboola = window._taboola || [];
+    _taboola.push({
+      article: 'auto'
+    });
+    ! function(e, f, u, i) {
+      if (!document.getElementById(i)) {
+        e.async = 1;
+        e.src = u;
+        e.id = i;
+        f.parentNode.insertBefore(e, f);
+      }
+    }(document.createElement('script'),
+      document.getElementsByTagName('script')[0],
+      '//cdn.taboola.com/libtrc/condenast1-network/loader.js',
+      'tb_loader_script');
+    if (window.performance && typeof window.performance.mark == 'function') {
+      window.performance.mark('tbl_ic');
+    }
+  </script>
+  <meta name='robots' content='max-image-preview:large' />
+<link rel='dns-prefetch' href='//s.w.org' />
+<link rel='dns-prefetch' href='//arstechnica-apps.s3.amazonaws.com' />
+<link rel='stylesheet' id='wp-block-library-css'  href='https://cdn.arstechnica.net/wp/wp-includes/css/dist/block-library/style.min.css?ver=6.0.3' type='text/css' media='all' />
+<style id='global-styles-inline-css' type='text/css'>
+body{--wp--preset--color--black: #000000;--wp--preset--color--cyan-bluish-gray: #abb8c3;--wp--preset--color--white: #ffffff;--wp--preset--color--pale-pink: #f78da7;--wp--preset--color--vivid-red: #cf2e2e;--wp--preset--color--luminous-vivid-orange: #ff6900;--wp--preset--color--luminous-vivid-amber: #fcb900;--wp--preset--color--light-green-cyan: #7bdcb5;--wp--preset--color--vivid-green-cyan: #00d084;--wp--preset--color--pale-cyan-blue: #8ed1fc;--wp--preset--color--vivid-cyan-blue: #0693e3;--wp--preset--color--vivid-purple: #9b51e0;--wp--preset--gradient--vivid-cyan-blue-to-vivid-purple: linear-gradient(135deg,rgba(6,147,227,1) 0%,rgb(155,81,224) 100%);--wp--preset--gradient--light-green-cyan-to-vivid-green-cyan: linear-gradient(135deg,rgb(122,220,180) 0%,rgb(0,208,130) 100%);--wp--preset--gradient--luminous-vivid-amber-to-luminous-vivid-orange: linear-gradient(135deg,rgba(252,185,0,1) 0%,rgba(255,105,0,1) 100%);--wp--preset--gradient--luminous-vivid-orange-to-vivid-red: linear-gradient(135deg,rgba(255,105,0,1) 0%,rgb(207,46,46) 100%);--wp--preset--gradient--very-light-gray-to-cyan-bluish-gray: linear-gradient(135deg,rgb(238,238,238) 0%,rgb(169,184,195) 100%);--wp--preset--gradient--cool-to-warm-spectrum: linear-gradient(135deg,rgb(74,234,220) 0%,rgb(151,120,209) 20%,rgb(207,42,186) 40%,rgb(238,44,130) 60%,rgb(251,105,98) 80%,rgb(254,248,76) 100%);--wp--preset--gradient--blush-light-purple: linear-gradient(135deg,rgb(255,206,236) 0%,rgb(152,150,240) 100%);--wp--preset--gradient--blush-bordeaux: linear-gradient(135deg,rgb(254,205,165) 0%,rgb(254,45,45) 50%,rgb(107,0,62) 100%);--wp--preset--gradient--luminous-dusk: linear-gradient(135deg,rgb(255,203,112) 0%,rgb(199,81,192) 50%,rgb(65,88,208) 100%);--wp--preset--gradient--pale-ocean: linear-gradient(135deg,rgb(255,245,203) 0%,rgb(182,227,212) 50%,rgb(51,167,181) 100%);--wp--preset--gradient--electric-grass: linear-gradient(135deg,rgb(202,248,128) 0%,rgb(113,206,126) 100%);--wp--preset--gradient--midnight: linear-gradient(135deg,rgb(2,3,129) 0%,rgb(40,116,252) 100%);--wp--preset--duotone--dark-grayscale: url('#wp-duotone-dark-grayscale');--wp--preset--duotone--grayscale: url('#wp-duotone-grayscale');--wp--preset--duotone--purple-yellow: url('#wp-duotone-purple-yellow');--wp--preset--duotone--blue-red: url('#wp-duotone-blue-red');--wp--preset--duotone--midnight: url('#wp-duotone-midnight');--wp--preset--duotone--magenta-yellow: url('#wp-duotone-magenta-yellow');--wp--preset--duotone--purple-green: url('#wp-duotone-purple-green');--wp--preset--duotone--blue-orange: url('#wp-duotone-blue-orange');--wp--preset--font-size--small: 13px;--wp--preset--font-size--medium: 20px;--wp--preset--font-size--large: 36px;--wp--preset--font-size--x-large: 42px;}.has-black-color{color: var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-color{color: var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-color{color: var(--wp--preset--color--white) !important;}.has-pale-pink-color{color: var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-color{color: var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-color{color: var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-color{color: var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-color{color: var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-color{color: var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-color{color: var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-color{color: var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-color{color: var(--wp--preset--color--vivid-purple) !important;}.has-black-background-color{background-color: var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-background-color{background-color: var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-background-color{background-color: var(--wp--preset--color--white) !important;}.has-pale-pink-background-color{background-color: var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-background-color{background-color: var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-background-color{background-color: var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-background-color{background-color: var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-background-color{background-color: var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-background-color{background-color: var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-background-color{background-color: var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-background-color{background-color: var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-background-color{background-color: var(--wp--preset--color--vivid-purple) !important;}.has-black-border-color{border-color: var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-border-color{border-color: var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-border-color{border-color: var(--wp--preset--color--white) !important;}.has-pale-pink-border-color{border-color: var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-border-color{border-color: var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-border-color{border-color: var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-border-color{border-color: var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-border-color{border-color: var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-border-color{border-color: var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-border-color{border-color: var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-border-color{border-color: var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-border-color{border-color: var(--wp--preset--color--vivid-purple) !important;}.has-vivid-cyan-blue-to-vivid-purple-gradient-background{background: var(--wp--preset--gradient--vivid-cyan-blue-to-vivid-purple) !important;}.has-light-green-cyan-to-vivid-green-cyan-gradient-background{background: var(--wp--preset--gradient--light-green-cyan-to-vivid-green-cyan) !important;}.has-luminous-vivid-amber-to-luminous-vivid-orange-gradient-background{background: var(--wp--preset--gradient--luminous-vivid-amber-to-luminous-vivid-orange) !important;}.has-luminous-vivid-orange-to-vivid-red-gradient-background{background: var(--wp--preset--gradient--luminous-vivid-orange-to-vivid-red) !important;}.has-very-light-gray-to-cyan-bluish-gray-gradient-background{background: var(--wp--preset--gradient--very-light-gray-to-cyan-bluish-gray) !important;}.has-cool-to-warm-spectrum-gradient-background{background: var(--wp--preset--gradient--cool-to-warm-spectrum) !important;}.has-blush-light-purple-gradient-background{background: var(--wp--preset--gradient--blush-light-purple) !important;}.has-blush-bordeaux-gradient-background{background: var(--wp--preset--gradient--blush-bordeaux) !important;}.has-luminous-dusk-gradient-background{background: var(--wp--preset--gradient--luminous-dusk) !important;}.has-pale-ocean-gradient-background{background: var(--wp--preset--gradient--pale-ocean) !important;}.has-electric-grass-gradient-background{background: var(--wp--preset--gradient--electric-grass) !important;}.has-midnight-gradient-background{background: var(--wp--preset--gradient--midnight) !important;}.has-small-font-size{font-size: var(--wp--preset--font-size--small) !important;}.has-medium-font-size{font-size: var(--wp--preset--font-size--medium) !important;}.has-large-font-size{font-size: var(--wp--preset--font-size--large) !important;}.has-x-large-font-size{font-size: var(--wp--preset--font-size--x-large) !important;}
+</style>
+<link rel='stylesheet' id='article_forum_connect_comments-css'  href='https://cdn.arstechnica.net/wp-content/plugins/article-forum-connect/public/css/comments.css?ver=1.2.2' type='text/css' media='all' />
+<link rel='stylesheet' id='article_forum_connect_paywall-css'  href='https://cdn.arstechnica.net/wp-content/plugins/article-forum-connect/public/css/paywall.css?ver=1.2.2' type='text/css' media='all' />
+<link rel="amphtml" href="https://arstechnica.com/science/2023/08/whats-going-on-with-the-reports-of-a-room-temperature-superconductor/3/amp/"><meta name="twitter:partner" content="tfwp" />
+<!--
+	generated 99 seconds ago
+	generated in 0.220 seconds
+	served from batcache in 0.001 seconds
+	expires in 201 seconds
+	billboard: forced 
+	view: grid 
+	theme: light 
+ -->
+</head>
+
+<body class="post-template-default single single-post postid-1958785 single-format-standard paged-3 single-paged-3 grid-view light blog-us">
+  <!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-NLXNPCQ" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) -->
+
+      	<aside class="ad ad_crown" aria-label="Top of page advertisement"></aside>
+  
+  <div class="site-wrapper">
+    <a class="screen-reader-text skip-link" href="#main" aria-label="Skip to main content">Skip to main content</a>
+    <header class="site-header">
+      <div class="header-left">
+        <a href="https://arstechnica.com" id="header-logo" title="Ars Technica Homepage">
+      <span class="icon icon-logo-ars-us"></span>
+  </a>
+      </div>
+
+      <div class="header-right">
+        <nav id="header-nav-primary">
+          <ul>
+            
+  <li><a class="nav-link section-information-technology " href="/information-technology/">Biz &amp; IT</a></li>
+  <li><a class="nav-link section-gadgets " href="/gadgets/">Tech</a></li>
+  <li><a class="nav-link section-science active" href="/science/">Science</a></li>
+  <li><a class="nav-link section-tech-policy " href="/tech-policy/">Policy</a></li>
+  <li><a class="nav-link section-cars " href="/cars/">Cars</a></li>
+  <li><a class="nav-link section-gaming " href="/gaming/">Gaming &amp; Culture</a></li>
+  <li><a class="nav-link store" href="/store/">Store</a></li>
+  <li><a class="nav-link forums" href="/civis/">Forums</a></li>
+          </ul>
+        </nav>
+
+                              <a href="/store/product/subscriptions/" class="header-highlight-link">Subscribe</a>
+                                  <div class="dropdown" id="header-search">
+          <a href="/search/" class="dropdown-toggle search-toggle" aria-label="Search" aria-expanded="false">
+            <span class="icon icon-search-mag-glass"></span>
+          </a>
+          <div class="dropdown-content">
+            <form action="/search/" method="GET" id="search_form">
+  <input type="hidden" name="ie" value="UTF-8">
+  <input type="text" name="q" id="hdr_search_input" value="" aria-label="Search..." placeholder="Search...">
+</form>
+<a class="nav-search-close">Close</a>
+          </div>
+        </div>
+        <div class="dropdown dropdown-mega" id="header-burger">
+          <a href="#site-menu" class="dropdown-toggle" aria-label="Menu" aria-expanded="false">
+            <span></span>
+          </a>
+          <div id="site-menu" class="dropdown-content">
+            <section class="burger-navigate">
+  <h3>
+    <span class="icon icon-half-target"></span>
+    Navigate
+  </h3>
+  <ul>
+          <li><a class="nav-link store" href="/store/">Store</a></li>
+      <li><a class="nav-link subscribe" href="/store/product/subscriptions/">Subscribe</a></li>
+        <li><a class="nav-link videos" href="http://video.arstechnica.com/">Videos</a></li>
+    <li><a class="nav-link section-features" href="/features/">Features</a></li>
+    <li><a class="nav-link section-reviews" href="/reviews/">Reviews</a></li>
+  </ul>
+
+  <ul>
+    <li><a class="nav-link page-rss-feeds" href="/rss-feeds/">RSS Feeds</a></li>
+    <li><a class="nav-link mobile" href="/?view=mobile">Mobile Site</a></li>
+  </ul>
+
+  <ul>
+    <li><a class="nav-link page-about-us" href="/about-us/">About Ars</a></li>
+    <li><a class="nav-link page-staff-directory" href="/staff-directory/">Staff Directory</a></li>
+    <li><a class="nav-link page-contact-us" href="/contact-us/">Contact Us</a></li>
+  </ul>
+
+  <ul>
+    <li><a class="nav-link page-advertise-with-us" href="https://www.condenast.com/brands/ars-technica">Advertise with Ars</a></li>
+    <li><a class="nav-link page-reprints" href="/reprints/">Reprints</a></li>
+  </ul>
+</section>
+
+<section class="burger-filter">
+  <h3>
+    <span class="icon icon-half-mag"></span>
+    Filter by topic
+  </h3>
+  <ul id="burger-nav-primary">
+    
+  <li><a class="nav-link section-information-technology " href="/information-technology/">Biz &amp; IT</a></li>
+  <li><a class="nav-link section-gadgets " href="/gadgets/">Tech</a></li>
+  <li><a class="nav-link section-science active" href="/science/">Science</a></li>
+  <li><a class="nav-link section-tech-policy " href="/tech-policy/">Policy</a></li>
+  <li><a class="nav-link section-cars " href="/cars/">Cars</a></li>
+  <li><a class="nav-link section-gaming " href="/gaming/">Gaming &amp; Culture</a></li>
+  <li><a class="nav-link store" href="/store/">Store</a></li>
+  <li><a class="nav-link forums" href="/civis/">Forums</a></li>
+  </ul>
+</section>
+
+<section class="burger-settings">
+  <h3>
+    <span class="icon icon-half-gear"></span>
+    Settings
+  </h3>
+  <div>
+    <div class="burger-layout">
+      
+<p>Front page layout</p>
+<div class="burger-layout-grid">
+  <a rel="nofollow" href="/science/2023/08/whats-going-on-with-the-reports-of-a-room-temperature-superconductor/3/?view=grid">
+    <span class="icon icon-grid"></span><br>
+    Grid
+    <div class="faux-radio active"></div>
+  </a>
+</div>
+
+<div class="burger-layout-list">
+  <a rel="nofollow" href="/science/2023/08/whats-going-on-with-the-reports-of-a-room-temperature-superconductor/3/?view=archive">
+    <span class="icon icon-list"></span><br>
+    List
+    <div class="faux-radio "></div>
+  </a>
+</div>
+
+    </div>
+    <div class="burger-theme">
+      <p>Site theme</p>
+  <div class="burger-theme-light">
+    <a rel="nofollow" href="/science/2023/08/whats-going-on-with-the-reports-of-a-room-temperature-superconductor/3/?theme=light">
+      <span><span>light</span></span>
+      <div class="faux-radio active"></div>
+    </a>
+  </div>
+  <div class="burger-theme-dark">
+    <a rel="nofollow" href="/science/2023/08/whats-going-on-with-the-reports-of-a-room-temperature-superconductor/3/?theme=dark">
+      <span><span>dark</span></span>
+      <div class="faux-radio "></div>
+    </a>
+  </div>
+    </div>
+  </div>
+</section>
+          </div>
+        </div>
+              <a class="navlink login-link" href="https://arstechnica.com/civis/login?_xfRedirect=%2Fscience%2F2023%2F08%2Fwhats-going-on-with-the-reports-of-a-room-temperature-superconductor%2F3%2F">
+      Sign in
+    </a>
+  
+        </div>
+    </header>
+
+              
+    <main id="main" class="content-wrapper">
+
+<script type="text/javascript">
+  ars.ARTICLE = {"url":"https:\/\/arstechnica.com\/science\/2023\/08\/whats-going-on-with-the-reports-of-a-room-temperature-superconductor\/","short_url":"https:\/\/arstechnica.com\/?p=1958785","title":"What\u2019s going on with the reports of a room-temperature superconductor?","author":52979,"authorName":"John Timmer","pubDate":"2023-08-04T14:07:48Z","id":1958785,"topic":1494994,"pages":3,"current_page":3,"superscroll":true,"promoted":[],"single_page":false,"comments":113,"fullwidth":false,"slug":"whats-going-on-with-the-reports-of-a-room-temperature-superconductor","arsStaff":{"104481":{"name":"Aaron Zimmerman","title":"Copy Chief","staff":true},"332715":{"name":"Andrew Cunningham","title":"Senior Technology Reporter","staff":true},"855306":{"name":"Ashley Belanger","title":"Senior Policy Reporter","staff":true},"1002":{"name":"Aurich Lawson","title":"Creative Director","staff":true},"857898":{"name":"Benj Edwards","title":"AI and Machine Learning Reporter","staff":true},"509873":{"name":"Beth Mole","title":"Senior Health Reporter","staff":true},"453791":{"name":"Cathleen O'Grady","title":"Contributing science reporter","staff":true},"102179":{"name":"Chris Lee","title":"Associate writer","staff":true},"821742":{"name":"Corey Gaskin","title":"Senior Commerce Writer","staff":true},"329388":{"name":"Dan Goodin","title":"Security Editor","staff":true},"254631":{"name":"Diana Gitig","title":"Associate Writer","staff":false},"25862":{"name":"Eric Bangeman","title":"Managing Editor","staff":true},"512413":{"name":"Eric Berger","title":"Senior Space Editor","staff":true},"46707":{"name":"Iljitsch van Beijnum","title":"Associate Writer","staff":false},"316010":{"name":"Jason Marlin","title":"Technical Director","staff":true},"746799":{"name":"Jennifer Ouellette","title":"Senior Writer","staff":true},"15365":{"name":"Jeremy Reimer","title":"Senior Niche Technology Historian","staff":false},"52979":{"name":"John Timmer","title":"Senior Science Editor","staff":true},"312082":{"name":"Jon Brodkin","title":"Senior IT Reporter","staff":true},"14317":{"name":"Jonathan M. Gitlin","title":"Automotive Editor","staff":true},"998":{"name":"Ken Fisher","title":"Editor in Chief","staff":true},"440179":{"name":"Kerry Staurseth","title":"Associate Copyeditor","staff":true},"856780":{"name":"Kevin Purdy","title":"Senior Technology Reporter","staff":true},"328283":{"name":"Kyle Orland","title":"Senior Gaming Editor","staff":true},"10243":{"name":"Lee Hutchinson","title":"Senior Technology Editor","staff":true},"173191":{"name":"Matthew Lasar","title":"Associate writer","staff":true},"182268":{"name":"Nate Anderson","title":"Deputy Editor","staff":true},"1991":{"name":"Ohrmazd","title":"","staff":false},"391727":{"name":"Ron Amadeo","title":"Reviews Editor","staff":true},"588289":{"name":"Samuel Axon","title":"Senior Editor","staff":true},"294205":{"name":"Scott K. Johnson","title":"Associate Writer","staff":true},"843451":{"name":"Steve Haske","title":"","staff":false},"173910":{"name":"Timothy B. Lee","title":"Senior tech policy reporter","staff":false}},"tags":["chemistry","electrons","physics","superconductivity"],"zen_mode":false};
+</script>
+
+<article itemscope itemtype="http://schema.org/NewsArticle" class="article-single standalone intro-standard " id="">
+      <div class="column-wrapper">
+    <div class="left-column">
+        <header class="article-header">
+            <h4 class="post-upperdek">
+      No answers yet    &mdash;
+</h4>
+            <h1 itemprop="headline">What’s going on with the reports of a room-temperature superconductor?</h1>
+            <h2 itemprop="description">Rumors are flying of confirmation, but the situation is still frustratingly vague.</h2>
+            <section class="post-meta">
+
+  
+<p class="byline" itemprop="author creator" itemscope itemtype="http://schema.org/Person">
+      <a itemprop="url" href="https://arstechnica.com/author/john-timmer/" rel="author"><span itemprop="name">John Timmer</span></a>
+    -  <time class="date" data-time="1691158068" datetime="2023-08-04T14:07:48+00:00">Aug 4, 2023 2:07 pm UTC</time>
+</p>
+
+
+  
+</section>        </header>
+        <section class="article-guts">
+            <div itemprop="articleBody" class="article-content post-page">
+                                    
+
+
+
+
+
+<h2>What about those other superconductors?</h2>
+<p>The news comes at a somewhat awkward time for the field. A similar claim was made about a high-pressure material a few years ago, but that paper <a href="https://arstechnica.com/science/2020/10/high-pressure-superconductors-reach-room-temperature/">ended up being retracted</a> because of problems with some of its data. The same research group came back with a <a href="https://arstechnica.com/science/2023/03/room-temperature-superconductor-works-at-lower-pressures/">different material</a> that was said to work at room temperature, but that work <a href="https://arstechnica.com/science/2023/05/high-temperature-superconductor-report-fails-to-replicate/">hasn't been replicated</a>, and the head of the lab has now been <a href="https://www.nytimes.com/2023/07/26/science/ranga-dias-retraction-physics.html">accused of scientific misconduct</a>.</p>
+<p>There is almost no overlap between that work and LK-99. None of the people involved are the same, so there's no reason to suspect problematic research practices. And the chemistry and physics involved are completely different. The earlier work used high pressure to create chemicals with lots of hydrogen and unusual orbital structures. LK-99 uses no hydrogen at all and gets its orbital structures via a conformational change in a crystal lattice that takes place at ambient pressures.</p>
+<p>Hydrogen was the focus of the earlier work because its low atomic weight influences the behavior of vibrations within the material in a way that promotes the formation of superconducting pairs of electrons. The mechanism behind LK-99 is less clear, but clearly not that.</p>
+<p>(The LK-99's creators suggest that the conformational change in the crystal creates a sort of standing wave of electrons called a "charge density wave," and superconductivity involves electrons tunneling between wave sites. The modeling paper, by contrast, suggests that giving electrons the opportunity to both superconduct and participate in additional processes like charge density wave formation increases the probability that they'll superconduct. In any case, neither idea involves phonons.)</p>                                            <aside class="ad_wrapper" aria-label="In Content advertisement">
+    <span class="ad_notice">Advertisement </span>    
+    <div class="ad ad_instream"></div>    
+</aside>
+                                                        
+<h2>So when will we actually know anything?</h2>
+<p>Hopefully soon. The researchers behind the original report are trying to get information out there. In addition to the drafts placed in the arXiv, they have already <a href="http://journal.kci.go.kr/jkcgct/archive/articleView?artiId=ART002955269">published a paper on LK-99</a>, albeit in their native Korean. And a group of South Korean scientists working in the field <a href="https://www.reuters.com/science/skorean-experts-seek-verify-room-temperature-superconductor-claim-2023-08-03/">have also announced</a> that they're going to obtain LK-99 samples and try to confirm its reported behavior.</p>
+<p>There's also lots of activity outside of South Korea. Producing LK-99 is within reach of a lot of labs, and testing it is much easier since it doesn't require low temperatures or high pressures. That will mean a lot of short-term confusion, but it's likely to enable a consensus to emerge sooner.</p>
+<p>Whether or not this chemical superconducts at ambient temperatures might not be the final question, though. Assuming it does, there will be many questions about how to develop it into a useful material, how much current it can carry, and how to use it most effectively in the huge range of applications it can be put to. But I'm sure we'll all be happy if we end up needing answers to those questions.</p>
+
+                                                </div>
+
+            
+                            <nav class="page-numbers">Page: <span class="numbers"><a href="https://arstechnica.com/science/2023/08/whats-going-on-with-the-reports-of-a-room-temperature-superconductor/1/">1</a> <a href="https://arstechnica.com/science/2023/08/whats-going-on-with-the-reports-of-a-room-temperature-superconductor/2/">2</a> 3 </span></nav>
+            
+        </section>
+    </div>
+    <div class="xrail">
+        <div class="xrail-content">
+            
+            
+            
+                            <div class="ars-interlude-container ad_xrail ad_xrail_top"></div>
+            
+            
+                            <aside class="ad ad_xrail ad_xrail_top ad_xrail_last" aria-label="Top sidebar advertisement"></aside>
+                    </div>
+    </div>
+</div>
+
+<div class="column-wrapper">
+    <div class="left-column">
+        <div id="social-footer">
+                  <a class="comment-count icon-comment-bubble-down" href="https://arstechnica.com/science/2023/08/whats-going-on-with-the-reports-of-a-room-temperature-superconductor/?comments=1">
+      <h4 class="comment-count-before">reader comments</h4>
+  
+  <span class="comment-count-number">113</span>
+  <span class="visually-hidden"> with </span>
+  </a>
+          </div>
+                    <!-- cache hit 193:single/author:edaec1ff064d5323d80a377d6771e515 -->  <section class="article-author">
+          <a style="background-image:url('https://cdn.arstechnica.net/wp-content/uploads/2016/05/j.timmer-5.jpg');" class="author-photo" href="/author/john-timmer" tabindex="-1" role="presentation" aria-hidden="true"></a>
+    
+    <div class="author-bio">
+      <section class="author-bio-top">
+        <a href="/author/john-timmer" class="author-name">John Timmer</a>
+        John is Ars Technica's science editor. He has a Bachelor of Arts in Biochemistry from Columbia University, and a Ph.D. in Molecular and Cell Biology from the University of California, Berkeley. When physically separated from his keyboard, he tends to seek out a bicycle, or a scenic location for communing with his hiking boots.
+      </section>
+    </div>
+
+  </section>
+            </div>
+    <div class="xrail"></div>
+</div>
+<div id="article-footer-wrap">
+            <aside class="ad_wrapper" aria-label="Full width advertisement">
+    <span class="ad_notice">Advertisement </span>        
+    <div class="ad ad_fullwidth fullwidth"></div>
+</aside>
+    
+            <section id="comments-area" class="comments-area column-wrapper">
+      <div class="row comments-row left-column">
+      <a name="comments-bar"></a>
+      
+<div class="wp-forum-connect-container">
+
+    
+
+    
+</div>
+
+    </div>
+          <div class="xrail xrail-comments">
+        <div class="xrail-content-wrapper">
+          <div class="xrail-content xrail-content-comments">
+            <aside class="ad ad_xrail ad_xrail_comments" aria-label="Comments sidebar advertisement"></aside>
+          </div>
+        </div>
+                  <div class="xrail-content-wrapper xrail-content-wrapper-bottom">
+            <div class="xrail-content xrail-content-comments">
+              <aside class="ad ad_xrail ad_xrail_comments" aria-label="Comments sidebar advertisement"></aside>
+            </div>
+          </div>
+              </div>
+      </section>
+                    <section class="inline-playlist">
+  <div class='ars-video-playlist'>
+    <h3 class="ars-video-playlist-module-header">Channel <span>Ars Technica</span></h3>
+    <div class='ars-video-playlist-module' data-playlist-id='arstechnica-channel-ars-science' data-video-options='[]'></div>
+  </div>
+</section>
+                <div class="prev-next-links">
+  <a href="https://arstechnica.com/science/2023/08/frackers-can-use-dangerous-chemicals-without-disclosure-due-to-haliburton-loophole/" rel="prev"><span class="arrow">&larr;</span> Previous story</a>  <a href="https://arstechnica.com/cars/2023/08/fisker-debuts-an-entire-range-of-new-evs-including-one-sub-30000/" rel="next">Next story <span class="arrow">&rarr;</span></a></div>
+        <footer id="article-footer">
+  <div class="recommendations-footer">
+    <div id="story-recommendations">
+  <div class="heading-column">
+    <h3>Related Stories</h3>
+  </div>
+  <ul id="story-recs" class="rec-wrap"></ul>
+</div>
+  </div>
+      <div id="taboola-below-article-thumbnails---at"></div>
+<script type="text/javascript">
+  window._taboola = window._taboola || [];
+  _taboola.push({
+    mode: 'thumbnails-a-6x1',
+    container: 'taboola-below-article-thumbnails---at',
+    placement: 'Below Article Thumbnails - AT',
+    target_type: 'mix'
+  });
+</script>
+    <div class="recommendations-footer">
+    <div id="latest-stories">
+  <div class="heading-column">
+    <h3>Today on Ars</h3>
+  </div>
+  <ul id="latest-recs" class="rec-wrap"></ul>
+</div>
+  </div>
+</footer>
+    </div>
+  </article>
+  </main>
+
+  <footer class="site-footer">
+    <nav class="nav-footer">
+
+  <section>
+    <ul>
+      <li><a href="/store/">Store</a></li>
+      <li><a href="/store/product/subscriptions/">Subscribe</a></li>
+      <li><a href="/about-us/">About Us</a></li>
+      <li><a href="/rss-feeds/">RSS Feeds</a></li>
+      <li><a rel="nofollow" href="/science/2023/08/whats-going-on-with-the-reports-of-a-room-temperature-superconductor/3/?view=mobile">View Mobile Site</a></li>
+    </ul>
+  </section>
+
+  <section>
+    <ul>
+      <li><a href="/contact-us/">Contact Us</a></li>
+      <li><a href="/staff-directory/">Staff</a></li>
+      <li><a href="https://www.condenast.com/brands/ars-technica">Advertise with us</a></li>
+      <li><a href="/reprints/">Reprints</a></li>
+    </ul>
+  </section>
+
+  <section class="footer-newsletter">
+    <div class="newsletter-wrapper">
+      <h3>
+        <a href="/newsletters/" class="footer-newsletter-sign-up">Newsletter Signup</a>
+      </h3>
+      <p>Join the Ars Orbital Transmission mailing list to get weekly updates delivered to your inbox. <a href="/newsletters/" class="footer-newsletter-sign-up">Sign me up &rarr;</a></p>
+
+      <div class="footer-social-links">
+        <a href="https://twitter.com/arstechnica" class="footer-social-twitter">
+          <svg style="height: 40px; width: 40px;" id="b" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 40 40">
+            <defs>
+              <clipPath id="e">
+                <rect width="40" height="40" fill="none" />
+              </clipPath>
+              <clipPath id="f">
+                <rect width="40" height="40" fill="none" />
+              </clipPath>
+            </defs>
+            <g id="c">
+              <g id="d">
+                <g clip-path="url(#e)">
+                  <g clip-path="url(#f)">
+                    <path d="M16.3,28.1c7.5,0,11.7-6.3,11.7-11.7s0-.4,0-.5c.8-.6,1.5-1.3,2-2.1-.7,.3-1.5,.5-2.4,.6,.9-.5,1.5-1.3,1.8-2.3-.8,.5-1.7,.8-2.6,1-.6-.7-1.4-1.1-2.3-1.2s-1.8,0-2.6,.4c-.8,.4-1.4,1.1-1.8,1.9-.4,.8-.5,1.7-.3,2.6-1.6,0-3.2-.5-4.7-1.2-1.5-.7-2.7-1.8-3.8-3-.5,.9-.7,2-.5,3,.2,1,.9,1.9,1.7,2.5-.7,0-1.3-.2-1.9-.5h0c0,1,.3,1.9,.9,2.7,.6,.7,1.4,1.2,2.4,1.4-.6,.2-1.2,.2-1.9,0,.3,.8,.8,1.5,1.5,2s1.5,.8,2.4,.8c-1.5,1.1-3.2,1.8-5.1,1.8-.3,0-.7,0-1,0,1.9,1.2,4.1,1.8,6.3,1.8" fill="currentColor" />
+                  </g>
+                </g>
+              </g>
+            </g>
+          </svg>
+        </a>
+        <a href="https://mastodon.social/@arstechnica" class="footer-social-mastodon">
+          <svg style="height: 40px; width: 40px;" id="b" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 40 40">
+            <defs>
+              <clipPath id="e">
+                <rect width="40" height="40" fill="none" />
+              </clipPath>
+              <clipPath id="f">
+                <rect width="40" height="40" fill="none" />
+              </clipPath>
+            </defs>
+            <g id="c">
+              <g id="d">
+                <g clip-path="url(#e)">
+                  <g clip-path="url(#f)">
+                    <path d="M29.3,16.6c0-4.3-2.8-5.6-2.8-5.6-1.4-.7-3.9-.9-6.5-1h0c-2.6,0-5,.3-6.4,1,0,0-2.8,1.3-2.8,5.6s0,2.2,0,3.4c.1,4.2,.8,8.4,4.7,9.5,1.8,.5,3.4,.6,4.6,.5,2.3-.1,3.5-.8,3.5-.8v-1.6c0,0-1.7,.5-3.5,.4-1.8,0-3.7-.2-4-2.4,0-.2,0-.4,0-.6,0,0,1.8,.4,4,.5,1.4,0,2.7,0,4-.2,2.5-.3,4.7-1.8,5-3.3,.4-2.2,.4-5.4,.4-5.4h0Zm-3.4,5.6h-2.1v-5.1c0-1.1-.5-1.6-1.4-1.6s-1.5,.6-1.5,1.9v2.8h-2.1v-2.8c0-1.3-.5-1.9-1.5-1.9s-1.4,.5-1.4,1.6v5.1h-2.1v-5.3c0-1.1,.3-1.9,.8-2.6,.6-.6,1.3-1,2.2-1s1.9,.4,2.4,1.2l.5,.9,.5-.9c.5-.8,1.3-1.2,2.4-1.2s1.7,.3,2.2,1c.6,.6,.8,1.5,.8,2.6v5.3Z" fill="currentColor" />
+                  </g>
+                </g>
+              </g>
+            </g>
+          </svg>
+        </a>
+        <a href="https://www.facebook.com/arstechnica" class="footer-social-facebook">
+          <svg style="height: 40px; width: 40px;" id="b" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 40 40">
+            <defs>
+              <clipPath id="e">
+                <rect width="40" height="40" fill="none" />
+              </clipPath>
+              <clipPath id="f">
+                <rect width="40" height="40" fill="none" />
+              </clipPath>
+            </defs>
+            <g id="c">
+              <g id="d">
+                <g clip-path="url(#e)">
+                  <g clip-path="url(#f)">
+                    <path d="M17.3,13.9v2.8h-2v3.4h2v10h4.2v-10h2.8s.3-1.6,.4-3.4h-3.2v-2.3c0-.3,.5-.8,.9-.8h2.3v-3.5h-3.1c-4.4,0-4.3,3.4-4.3,3.9" fill="currentColor" />
+                  </g>
+                </g>
+              </g>
+            </g>
+          </svg>
+        </a>
+        <a href="https://www.youtube.com/@arstechnica" class="footer-social-youtube">
+          <svg style="height: 40px; width: 40px;" id="b" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 40 40">
+            <defs>
+              <clipPath id="e">
+                <rect width="40" height="40" fill="none" />
+              </clipPath>
+              <clipPath id="f">
+                <rect width="40" height="40" fill="none" />
+              </clipPath>
+            </defs>
+            <g id="c">
+              <g id="d">
+                <g clip-path="url(#e)">
+                  <g clip-path="url(#f)">
+                    <path d="M29.6,15.2c-.1-.4-.3-.8-.6-1.1-.3-.3-.7-.5-1.1-.7-1.6-.4-7.8-.4-7.8-.4,0,0-6.3,0-7.8,.4-.4,.1-.8,.3-1.1,.7-.3,.3-.5,.7-.6,1.1-.4,1.6-.4,4.8-.4,4.8,0,0,0,3.3,.4,4.8,.1,.4,.3,.8,.6,1.1,.3,.3,.7,.5,1.1,.7,1.6,.4,7.8,.4,7.8,.4,0,0,6.3,0,7.8-.4,.4-.1,.8-.3,1.1-.7s.5-.7,.6-1.1c.4-1.6,.4-4.8,.4-4.8,0,0,0-3.3-.4-4.8m-11.6,7.8v-5.9l5.2,3-5.2,3Z" fill="currentColor" />
+                  </g>
+                </g>
+              </g>
+            </g>
+          </svg>
+        </a>
+        <a href="https://www.instagram.com/arstechnica/" class="footer-social-instagram">
+          <svg style="height: 40px; width: 40px;" id="b" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 40 40">
+            <defs>
+              <clipPath id="e">
+                <rect width="40" height="40" fill="none" />
+              </clipPath>
+              <clipPath id="f">
+                <rect width="40" height="40" fill="none" />
+              </clipPath>
+            </defs>
+            <g id="c">
+              <g id="d">
+                <g clip-path="url(#e)">
+                  <g clip-path="url(#f)">
+                    <path d="M20,10c2.7,0,3.1,0,4.1,0,1.1,0,1.8,.2,2.4,.5,.7,.3,1.2,.6,1.8,1.2,.6,.6,.9,1.1,1.2,1.8,.2,.6,.4,1.4,.5,2.4,0,1.1,0,1.4,0,4.1s0,3.1,0,4.1c0,1.1-.2,1.8-.5,2.4-.3,.7-.6,1.3-1.2,1.8-.6,.6-1.1,.9-1.8,1.2-.6,.2-1.4,.4-2.4,.5-1.1,0-1.4,0-4.1,0s-3.1,0-4.1,0c-1.1,0-1.8-.2-2.4-.5-.7-.3-1.3-.6-1.8-1.2-.5-.5-.9-1.1-1.2-1.8-.2-.6-.4-1.4-.5-2.4,0-1.1,0-1.4,0-4.1s0-3.1,0-4.1c0-1.1,.2-1.8,.5-2.4,.3-.7,.6-1.2,1.2-1.8,.6-.6,1.1-.9,1.8-1.2,.6-.2,1.4-.4,2.4-.5,1.1,0,1.4,0,4.1,0m0,2.5c-2.4,0-2.7,0-3.7,0-.9,0-1.4,.2-1.7,.3-.4,.1-.8,.4-1.1,.7-.3,.3-.5,.6-.7,1.1-.1,.3-.3,.8-.3,1.7,0,1,0,1.3,0,3.7s0,2.7,0,3.7c0,.9,.2,1.4,.3,1.7,.2,.4,.4,.7,.7,1.1,.3,.3,.6,.5,1.1,.7,.3,.1,.8,.3,1.7,.3,1,0,1.3,0,3.7,0s2.7,0,3.7,0c.9,0,1.4-.2,1.7-.3,.4-.2,.7-.4,1.1-.7,.3-.3,.5-.6,.7-1.1,.1-.3,.3-.8,.3-1.7,0-1,0-1.3,0-3.7s0-2.7,0-3.7c0-.9-.2-1.4-.3-1.7-.1-.4-.4-.8-.7-1.1-.3-.3-.7-.5-1.1-.7-.3-.1-.8-.3-1.7-.3-1,0-1.3,0-3.7,0m0,2.2c.7,0,1.4,.1,2,.4,.6,.3,1.2,.7,1.7,1.1,.5,.5,.9,1.1,1.1,1.7,.3,.6,.4,1.3,.4,2s-.1,1.4-.4,2c-.3,.6-.7,1.2-1.1,1.7-.5,.5-1.1,.9-1.7,1.1-.6,.3-1.3,.4-2,.4-1.4,0-2.7-.6-3.7-1.5-1-1-1.5-2.3-1.5-3.7s.6-2.7,1.5-3.7,2.3-1.5,3.7-1.5m0,8.3c.8,0,1.5-.3,2.1-.9,.6-.6,.9-1.3,.9-2.1s-.3-1.5-.9-2.1c-.6-.6-1.3-.9-2.1-.9s-1.5,.3-2.1,.9c-.6,.6-.9,1.3-.9,2.1s.3,1.5,.9,2.1c.6,.6,1.3,.9,2.1,.9m6.6-8.1c0,.4-.2,.7-.4,1s-.6,.4-1,.4-.7-.2-1-.4c-.3-.3-.4-.6-.4-1s.2-.7,.4-1c.3-.3,.6-.4,1-.4s.7,.2,1,.4c.3,.3,.4,.6,.4,1" fill="currentColor" />
+                  </g>
+                </g>
+              </g>
+            </g>
+          </svg>
+        </a>
+      </div>
+
+    </div>
+  </section>
+</nav>
+
+<section class="footer-terms-logo">
+  <div class="cn-logo">
+    <a href="http://condenast.com/" class="icon icon-logo-cn-us" title="Visit Condé Nast"></a>
+  </div>
+
+  <p id="copyright-terms">
+  CNMN Collection<br>
+  WIRED Media Group<br>
+  © 2023 Condé Nast. All rights reserved. Use of and/or registration on any portion of this site constitutes acceptance of our <a href="https://www.condenast.com/user-agreement/">User Agreement</a> (updated 1/1/20) and <a href="https://www.condenast.com/privacy-policy/">Privacy Policy and Cookie Statement</a> (updated 1/1/20) and <a href="/amendment-to-conde-nast-user-agreement-privacy-policy/">Ars Technica Addendum</a> (effective 8/21/2018). Ars may earn compensation on sales from links on this site. <a href="/affiliate-link-policy/">Read our affiliate link policy</a>.<br>
+  <span style="display: inline-flex; flex-flow: row nowrap; align-items: center; gap: 5px;"><a href="https://www.condenast.com/privacy-policy/#california">Your California Privacy Rights</a> | <img src="https://cdn.arstechnica.net/wp-content/themes/ars/assets/img/privacyoptions123x59-c5c9972158.png" style="height: 1em; width: auto;" /> <a id="ot-sdk-btn" class="ot-sdk-show-settings">Do Not Sell My Personal Information</a></span><br>
+  The material on this site may not be reproduced, distributed, transmitted, cached or otherwise used, except with the prior written permission of Condé Nast.<br>
+  <a href="https://www.condenast.com/online-behavioral-advertising-oba-and-how-to-opt-out-of-oba/#clickheretoreadmoreaboutonlinebehavioraladvertising(oba)">Ad Choices</a>
+</p>
+</section>
+  </footer>
+  </div>
+
+  <script type="text/javascript" src="https://cdn.arstechnica.net/wp-content/themes/ars/assets/js/main-f627adae4a.js"></script>
+
+
+<!-- cache hit 193:single/javascript-footer:d29d6446a030580dc69054ef5c06dab8 -->
+        
+
+
+    <!-- Taboola -->
+  <script type="text/javascript">
+    window._taboola = window._taboola || [];
+    _taboola.push({
+      flush: true
+    });
+  </script>
+
+  <!-- Parse.ly start -->
+<script type="text/plain" class="optanon-category-C0002" id="parsely-cfg" src="//fpa-cdn.arstechnica.com/keys/arstechnica.com/p.js"></script>
+<!-- Parse.ly end -->
+
+<!-- Memo start -->
+<script type="text/javascript">
+__memo_config = {
+	pid: ars.MEMO_PID,
+	url: ars.ARTICLE.url,
+	author: [ars.ARTICLE.authorName],
+	title: ars.ARTICLE.title,
+	date: ars.ARTICLE.pubDate,
+};
+(function(){
+	var s = document.createElement('script'); 
+	s.async = true; 
+	s.type = 'text/javascript'; 
+	s.src = document.location.protocol + '//cdn.memo.co/js/memo.js';
+	(document.getElementsByTagName('head')[0] || document.getElementsByTagName('body') [0]).appendChild(s); 
+})();
+</script>
+<!-- Memo end -->
+
+  
+  
+    
+<script>
+  (function() {
+    var w = window.innerWidth ||
+      document.documentElement.clientWidth ||
+      document.body.clientWidth;
+    var src = 'https://player.cnevids.com/interlude/arstechnica.js';
+    if (!ars.MOBILE && w >= 1000) {
+      src += '?isRightRail=true';
+    }
+    var s = document.createElement('script');
+    s.setAttribute('async', true);
+    s.setAttribute('src', src);
+    document.body.appendChild(s);
+  })();
+</script>
+
+<script id="conde-polar" src="https://cdn.mediavoice.com/nativeads/script/condenastcorporate/conde-asa-polar-master.js" async></script>
+<!-- Sparrow begin -->
+<script type="text/plain" class="optanon-category-C0002">
+  (function() {
+    function DQ() {
+      var queue = window.sparrowQueue;
+      this.push = fn => fn();
+      window.sparrowQueue = this;
+      while (queue.length) {
+        queue.shift()();
+      }
+    }
+
+    function e(t, e) {
+      var n, a, o;
+      a = !1, n = document.createElement("script"), n.type = "text/javascript", n.src = t, n.onload = n.onreadystatechange = function() {
+        a || this.readyState && "complete" != this.readyState || (a = !0, e ? e() : !0)
+      }, o = document.getElementsByTagName("script")[0], o.parentNode.insertBefore(n, o)
+    }
+    if (location.search.indexOf('no_sparrow') < 0) {
+      e("https://pixel.condenastdigital.com/config/v2/production/ars-technica.config.js", function() {
+        e("https://pixel.condenastdigital.com/sparrow.min.js", function() {
+          if (window.SparrowConfigV2) {
+            window.sparrow = new window.Sparrow(window.SparrowConfigV2);
+            new DQ();
+          }
+        })
+      })
+    }
+  })();
+</script>
+<!-- Sparrow end -->
+<script type="text/javascript" src="//s.skimresources.com/js/100098X1555750.skimlinks.js"></script>
+<script type='text/javascript' src='https://cdn.arstechnica.net/wp-content/plugins/article-forum-connect/public/js/iframeResizer.min.js?ver=1.2.2' id='article_forum_connect_iframe_resizer-js'></script>
+<script type='text/javascript' src='https://cdn.arstechnica.net/wp-content/plugins/article-forum-connect/public/js/iframe.js?ver=1.2.2' id='article_forum_connect_iframe-js'></script>
+  </body>
+
+  </html>


### PR DESCRIPTION
ArsTechnica occasionally does long form articles that span multiple pages. 

When handled in the default path, these get ignored. I have added some code to follow the links, and append it all to the same Document. 
