### PR TITLE
[Feat] Add Links to Search, and show "PROCESSING" Links in the Card/List Views. 

### DIFF
--- a/packages/web/components/elements/LoadingBar.tsx
+++ b/packages/web/components/elements/LoadingBar.tsx
@@ -1,0 +1,78 @@
+import { Box } from './../elements/LayoutPrimitives'
+import { Dispatch, SetStateAction, useEffect, useState } from "react"
+
+type LoadingBarProps = {
+  fillColor: string
+  backgroundColor: string
+  borderRadius: string
+  percentFill?: number
+}
+
+type AnimationStatus = {
+  position: number,
+  transition: string
+}
+export function LoadingBar(props: LoadingBarProps): JSX.Element {
+  // OK So, what we want to do is.
+  // We have two boxes.
+  const [leftOne, setLeftOne] = useState({ position: 0, transition: 'left 0.5s linear' })
+  const [leftTwo, setLeftTwo] = useState({ position: -100, transition: 'left 0.5s linear' })
+
+  const calculateNewValue = (currVal: AnimationStatus, setNextVal: Dispatch<SetStateAction<AnimationStatus>>) => {
+    const position = currVal.position >= 100 ? -100 : currVal.position + 25;
+    const transition = currVal.position >= 100 ? 'left 0s linear' : 'left 0.5s linear';
+    setNextVal({ position, transition })
+  }
+
+  useEffect(() => {
+    const interval = setTimeout(() => {
+      calculateNewValue(leftOne, setLeftOne)
+    }, 500);
+
+    return () => {
+      clearTimeout(interval)
+    }
+  }, [leftOne])
+
+  useEffect(() => {
+    const interval = setTimeout(() => {
+      calculateNewValue(leftTwo, setLeftTwo)
+    }, 500);
+
+    return () => {
+      clearTimeout(interval)
+    }
+  }, [leftTwo])
+
+  return (
+    <Box
+      css={{
+        height: '5px',
+        width: '100%',
+        overflow: 'hidden',
+        backgroundColor: props.backgroundColor,
+      }}
+    >
+      <Box
+        css={{
+          height: '100%',
+          position: 'absolute',
+          width: `${props.percentFill ?? 10}%`,
+          left: `${leftOne.position}%`,
+          transition: leftOne.transition,
+          backgroundColor: props.fillColor,
+        }}
+      />
+      <Box
+        css={{
+          height: '100%',
+          position: 'absolute',
+          width: `${props.percentFill ?? 10}%`,
+          left: `${leftTwo.position}%`,
+          transition: leftTwo.transition,
+          backgroundColor: props.fillColor,
+        }}
+      />
+    </Box>
+  )
+}

--- a/packages/web/components/elements/LoadingBar.tsx
+++ b/packages/web/components/elements/LoadingBar.tsx
@@ -12,9 +12,8 @@ type AnimationStatus = {
   position: number,
   transition: string
 }
+
 export function LoadingBar(props: LoadingBarProps): JSX.Element {
-  // OK So, what we want to do is.
-  // We have two boxes.
   const [leftOne, setLeftOne] = useState({ position: 0, transition: 'left 0.5s linear' })
   const [leftTwo, setLeftTwo] = useState({ position: -100, transition: 'left 0.5s linear' })
 

--- a/packages/web/components/patterns/LibraryCards/CardTypes.tsx
+++ b/packages/web/components/patterns/LibraryCards/CardTypes.tsx
@@ -30,4 +30,5 @@ export type LinkedItemCardProps = {
   multiSelectMode: MultiSelectMode
 
   isHovered?: boolean
+  isLoading?: boolean
 }

--- a/packages/web/components/patterns/LibraryCards/LibraryGridCard.tsx
+++ b/packages/web/components/patterns/LibraryCards/LibraryGridCard.tsx
@@ -5,7 +5,6 @@ import { CoverImage } from '../../elements/CoverImage'
 import dayjs from 'dayjs'
 import relativeTime from 'dayjs/plugin/relativeTime'
 import { useCallback, useState } from 'react'
-import Link from 'next/link'
 import {
   AuthorInfoStyle,
   CardCheckbox,
@@ -28,7 +27,7 @@ import {
 import { CardMenu } from '../CardMenu'
 import { DotsThree } from 'phosphor-react'
 import { isTouchScreenDevice } from '../../../lib/deviceType'
-import { ProgressBarOverlay } from './LibraryListCard'
+import { LoadingBarOverlay, ProgressBarOverlay } from "./LibraryListCard"
 import { FallbackImage } from './FallbackImage'
 import { useRouter } from 'next/router'
 
@@ -88,7 +87,6 @@ export function LibraryGridCard(props: LinkedItemCardProps): JSX.Element {
         setIsHovered(false)
       }}
       onClick={(event) => {
-        console.log('click event: ', event)
         if (event.metaKey || event.ctrlKey) {
           window.open(
             `/${props.viewer.profile.username}/${props.item.slug}`,
@@ -133,6 +131,7 @@ type GridImageProps = {
   src?: string
   title?: string
   readingProgress?: number
+  isLoading?: boolean
 }
 
 const GridImage = (props: GridImageProps): JSX.Element => {
@@ -140,7 +139,17 @@ const GridImage = (props: GridImageProps): JSX.Element => {
 
   return (
     <>
-      {(props.readingProgress ?? 0) > 0 && (
+      {
+        props.isLoading && (
+          <LoadingBarOverlay
+            width="100%"
+            top={95}
+            bottomRadius={'0px'}
+            fillColor={"rgba(60, 179, 113, 1)"}
+          />
+        )
+      }
+      {(props.readingProgress ?? 0) > 0 && !props.isLoading && (
         <ProgressBarOverlay
           width="100%"
           top={95}
@@ -189,6 +198,7 @@ const LibraryGridCardContent = (props: LinkedItemCardProps): JSX.Element => {
           src={props.item.image}
           title={props.item.title}
           readingProgress={item.readingProgressPercent}
+          isLoading={props.isLoading}
         />
         <SpanBox
           css={{

--- a/packages/web/components/patterns/LibraryCards/LibraryListCard.tsx
+++ b/packages/web/components/patterns/LibraryCards/LibraryListCard.tsx
@@ -217,7 +217,7 @@ const ListImage = (props: ListImageProps): JSX.Element => {
         />
       )
       }
-      {(props.readingProgress ?? 0) > 0 && (
+      {(props.readingProgress ?? 0) > 0 && !props.isLoading && (
         <ProgressBarOverlay
           width="55px"
           top={50}

--- a/packages/web/components/patterns/LibraryCards/LibraryListCard.tsx
+++ b/packages/web/components/patterns/LibraryCards/LibraryListCard.tsx
@@ -31,6 +31,7 @@ import { ProgressBar } from '../../elements/ProgressBar'
 import { theme } from '../../tokens/stitches.config'
 import { FallbackImage } from './FallbackImage'
 import { useRouter } from 'next/router'
+import { LoadingBar } from "../../elements/LoadingBar"
 
 export function LibraryListCard(props: LinkedItemCardProps): JSX.Element {
   const router = useRouter()
@@ -128,11 +129,45 @@ export function LibraryListCard(props: LinkedItemCardProps): JSX.Element {
   )
 }
 
+type LoadingBarOverlayProps = {
+  top: number
+  width: string
+  bottomRadius: string,
+  fillColor?: string,
+  percentFill?: number
+}
+
+
 type ProgressBarOverlayProps = {
   top: number
   width: string
   value: number
-  bottomRadius: string
+  bottomRadius: string,
+}
+
+export const LoadingBarOverlay = (
+  props: LoadingBarOverlayProps
+): JSX.Element => {
+  return (
+    <Box
+      css={{
+        position: 'absolute',
+        width: props.width,
+        top: props.top,
+        borderBottomLeftRadius: props.bottomRadius,
+        borderBottomRightRadius: props.bottomRadius,
+        overflow: 'clip',
+        zIndex: 2,
+      }}
+    >
+      <LoadingBar
+        fillColor={props.fillColor ?? theme.colors.thProgressFg.toString()}
+        backgroundColor="rgba(217, 217, 217, 0.65)"
+        borderRadius={'2px'}
+        percentFill={props.percentFill}
+      />
+    </Box>
+  )
 }
 
 export const ProgressBarOverlay = (
@@ -164,13 +199,24 @@ type ListImageProps = {
   src?: string
   title?: string
   readingProgress?: number
+  isLoading?: boolean
 }
 
 const ListImage = (props: ListImageProps): JSX.Element => {
   const [displayFallback, setDisplayFallback] = useState(props.src == undefined)
 
   return (
-    <>
+    <>{
+      props.isLoading && (
+        <LoadingBarOverlay
+          width="55px"
+          top={50}
+          bottomRadius="4px"
+          fillColor={"rgba(60, 179, 113, 1)"}
+          percentFill={30}
+        />
+      )
+      }
       {(props.readingProgress ?? 0) > 0 && (
         <ProgressBarOverlay
           width="55px"
@@ -241,6 +287,7 @@ export function LibraryListCardContent(
           src={props.item.image}
           title={props.item.title}
           readingProgress={item.readingProgressPercent}
+          isLoading={props.isLoading}
         />
       </Box>
       <VStack

--- a/packages/web/components/patterns/LibraryCards/LinkedItemCard.tsx
+++ b/packages/web/components/patterns/LibraryCards/LinkedItemCard.tsx
@@ -2,6 +2,8 @@ import type { LinkedItemCardProps } from './CardTypes'
 import { LibraryGridCard } from './LibraryGridCard'
 import { LibraryListCard } from './LibraryListCard'
 
+
+// TODO: Add something for the loading view if we are loading.
 export function LinkedItemCard(props: LinkedItemCardProps): JSX.Element {
   if (props.layout == 'LIST_LAYOUT') {
     return <LibraryListCard {...props} />

--- a/packages/web/components/patterns/LibraryCards/LinkedItemCard.tsx
+++ b/packages/web/components/patterns/LibraryCards/LinkedItemCard.tsx
@@ -2,8 +2,6 @@ import type { LinkedItemCardProps } from './CardTypes'
 import { LibraryGridCard } from './LibraryGridCard'
 import { LibraryListCard } from './LibraryListCard'
 
-
-// TODO: Add something for the loading view if we are loading.
 export function LinkedItemCard(props: LinkedItemCardProps): JSX.Element {
   if (props.layout == 'LIST_LAYOUT') {
     return <LibraryListCard {...props} />

--- a/packages/web/components/templates/homeFeed/AddLinkModal.tsx
+++ b/packages/web/components/templates/homeFeed/AddLinkModal.tsx
@@ -16,41 +16,11 @@ import {
 
 type AddLinkModalProps = {
   onOpenChange: (open: boolean) => void
+  handleLinkSubmission: (link: string, timezone: string, locale:string) => Promise<void>,
 }
 
 export function AddLinkModal(props: AddLinkModalProps): JSX.Element {
   const [link, setLink] = useState('')
-
-  const handleLinkSubmission = useCallback(
-    async (link: string, timezone: string, locale: string) => {
-      const result = await saveUrlMutation(link, timezone, locale)
-      if (result) {
-        toast(
-          () => (
-            <Box>
-              Link Saved
-              <span style={{ padding: '16px' }} />
-              <Button
-                style="ctaDarkYellow"
-                autoFocus
-                onClick={() => {
-                  window.location.href = `/article?url=${encodeURIComponent(
-                    link
-                  )}`
-                }}
-              >
-                Read Now
-              </Button>
-            </Box>
-          ),
-          { position: 'bottom-right' }
-        )
-      } else {
-        showErrorToast('Error saving link', { position: 'bottom-right' })
-      }
-    },
-    [link]
-  )
 
   const validateLink = useCallback(
     (link: string) => {
@@ -81,7 +51,7 @@ export function AddLinkModal(props: AddLinkModalProps): JSX.Element {
           <ModalTitleBar title="Add Link" onOpenChange={props.onOpenChange} />
           <Box css={{ width: '100%', py: '16px' }}>
             <form
-              onSubmit={(event) => {
+              onSubmit={async (event) => {
                 event.preventDefault()
 
                 let submitLink = link
@@ -96,7 +66,7 @@ export function AddLinkModal(props: AddLinkModalProps): JSX.Element {
                   setLink(newLink)
                   submitLink = newLink
                 }
-                handleLinkSubmission(submitLink, timeZone, locale)
+                await props.handleLinkSubmission(submitLink, timeZone, locale)
                 props.onOpenChange(false)
               }}
             >

--- a/packages/web/components/templates/homeFeed/HomeFeedContainer.tsx
+++ b/packages/web/components/templates/homeFeed/HomeFeedContainer.tsx
@@ -181,6 +181,7 @@ export function HomeFeedContainer(): JSX.Element {
 
   useEffect(() => {
     let startIdx = 1;
+    let timeout : NodeJS.Timeout | undefined;
     if (savedLink) {
       const seeIfUpdated = async() => {
         if (startIdx > 5) {
@@ -206,15 +207,18 @@ export function HomeFeedContainer(): JSX.Element {
             performActionOnItem('update-item', { ...item, isLoading: true });
           }
           console.log(`Trying to get the metadata of item ${item.node.slug}... Retry ${startIdx} of 5`);
-          setTimeout(seeIfUpdated, TIMEOUT_DELAYS[startIdx++])
+          timeout = setTimeout(seeIfUpdated, TIMEOUT_DELAYS[startIdx++])
         }
 
         // If the item was not found, this suggests that we are not in the right search view. So we can bail early.
       }
       setSavedLink(undefined);
-      setTimeout(seeIfUpdated, TIMEOUT_DELAYS[0]);
+      timeout = setTimeout(seeIfUpdated, TIMEOUT_DELAYS[0]);
     }
 
+    return () => {
+      clearTimeout(timeout);
+    }
   }, [itemsPages])
 
   const handleFetchMore = useCallback(() => {

--- a/packages/web/components/templates/homeFeed/LibraryHeader.tsx
+++ b/packages/web/components/templates/homeFeed/LibraryHeader.tsx
@@ -230,7 +230,6 @@ export function SearchBox(props: SearchBoxProps): JSX.Element {
   const [isAddAction, setIsAddAction] = useState(false);
   const IS_URL_REGEX = /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)/;
 
-
   useEffect(() => {
     setSearchTerm(props.searchTerm ?? '')
   }, [props.searchTerm])
@@ -311,8 +310,6 @@ export function SearchBox(props: SearchBoxProps): JSX.Element {
             } else {
                 await props.handleLinkSubmission(searchTerm, timeZone, locale)
                 setSearchTerm(props.searchTerm ?? "")
-                // This will technically (albeit kinda hackily) refresh and add the link
-                // I would prefer, though, for this to actually be handled better.
                 props.applySearchQuery(props.searchTerm ?? "")
             }
             inputRef.current?.blur()

--- a/packages/web/lib/networking/queries/useGetArticleQuery.tsx
+++ b/packages/web/lib/networking/queries/useGetArticleQuery.tsx
@@ -1,6 +1,6 @@
 import { gql } from 'graphql-request'
 import useSWRImmutable, { Cache } from 'swr'
-import { makeGqlFetcher, RequestContext, ssrFetcher } from '../networkHelpers'
+import { gqlFetcher, makeGqlFetcher, RequestContext, ssrFetcher } from "../networkHelpers"
 import {
   articleFragment,
   ContentReader,
@@ -135,15 +135,15 @@ export function useGetArticleQuery({
 }
 
 export async function articleQuery(
-  context: RequestContext,
   input: ArticleQueryInput
-): Promise<ArticleAttributes> {
-  const result = (await ssrFetcher(context, query, input)) as ArticleData
+): Promise<ArticleAttributes | undefined> {
+
+  const result = (await gqlFetcher(query, input)) as ArticleData
   if (result.article) {
     return result.article.article
   }
 
-  return Promise.reject()
+  return undefined
 }
 
 export const cacheArticle = (

--- a/packages/web/lib/networking/queries/useGetLibraryItemsQuery.tsx
+++ b/packages/web/lib/networking/queries/useGetLibraryItemsQuery.tsx
@@ -60,6 +60,7 @@ export type LibraryItems = {
 export type LibraryItem = {
   cursor: string
   node: LibraryItemNode
+  isLoading?: boolean | undefined
 }
 
 export type LibraryItemNode = {


### PR DESCRIPTION
Hey - I've been working on something. 

So when I'm on desktop I tend to add links manually - copy and paste the URL and add it that way - I know there's a chrome plugin, but I always forget to use it. And I'm using a new browser that I'm trying to get used to. I find myself copying and pasting links into the Search Bar and then going "Oh right..." 

I also find it really jarring that when you do hit enter the link isn't populated in your list of links. I always expect it to show up, and it makes it feel a little... undynamic. 

So I worked on two things:

-   **Contextual search bar;** when adding a URL to the search bar the action changes from search to add link. You can see in the video there's a + to indicate this. I am also going to have that be a drop down so you can turn it back to search if necessary.  Though I suspect few people will search with a full URL including the https:// 

-   **Loading Cards**: Then when a link is added, I added a card view for the article, which shows that it is currently processing the link. 

I'm uploading a couple of video to show this, one with a CardView, one with the ListView, and one Showing the flow from the "AddLink" modal.

Videos of features: 
https://discord.com/channels/844965259462311966/1084693944861982791/1137721672603021382