### PR TITLE
A couple small backend cleanups to reduce errors

### DIFF
--- a/android/Omnivore/app/src/main/java/app/omnivore/omnivore/ui/auth/LoginViewModel.kt
+++ b/android/Omnivore/app/src/main/java/app/omnivore/omnivore/ui/auth/LoginViewModel.kt
@@ -113,7 +113,7 @@ class LoginViewModel @Inject constructor(
     validateUsernameJob?.cancel()
 
     validateUsernameJob = viewModelScope.launch {
-      delay(500)
+      delay(2000)
 
       // Check the username requirements first
       if (potentialUsername.isEmpty()) {

--- a/apple/OmnivoreKit/Sources/App/Views/Registration/CreateProfileView.swift
+++ b/apple/OmnivoreKit/Sources/App/Views/Registration/CreateProfileView.swift
@@ -95,7 +95,7 @@ import Views
     potentialUsername = profile.username
 
     $potentialUsername
-      .debounce(for: .seconds(0.5), scheduler: DispatchQueue.main)
+      .debounce(for: .seconds(2.0), scheduler: DispatchQueue.main)
       .sink(receiveValue: { [weak self] username in
         self?.validateUsername(username: username, dataService: dataService)
       })

--- a/packages/api/src/apollo.ts
+++ b/packages/api/src/apollo.ts
@@ -109,6 +109,7 @@ export function makeApolloServer(): ApolloServer {
       return new Error('Unexpected server error')
     },
     introspection: env.dev.isLocal,
+    persistedQueries: false,
   })
 
   return apollo

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -107,14 +107,14 @@ export const createApp = (): {
   const apiLimiter = rateLimit({
     windowMs: 60 * 1000, // 1 minute
     max: async (req) => {
-      // 100 RPM for an authenticated request, 5 for a non-authenticated request
+      // 100 RPM for an authenticated request, 15 for a non-authenticated request
       const token = getTokenByRequest(req)
       try {
         const claims = await getClaimsByToken(token)
-        return claims ? 100 : 5
+        return claims ? 100 : 15
       } catch (e) {
         console.log('non-authenticated request')
-        return 5
+        return 15
       }
     },
     keyGenerator: (req) => {

--- a/packages/text-to-speech/src/index.ts
+++ b/packages/text-to-speech/src/index.ts
@@ -347,12 +347,12 @@ export const textToSpeechStreamingHandler = Sentry.GCPFunction.wrapHttpFunction(
       }
 
       const audioDataString = audioData.toString('hex')
-      // save audio data to cache for 24 hours for mainly the newsletters
+      // save audio data to cache for 72 hours for mainly the newsletters
       await redisClient.set(
         cacheKey,
         JSON.stringify({ audioDataString, speechMarks }),
         {
-          EX: 3600 * 24, // in seconds
+          EX: 3600 * 72, // in seconds
           NX: true,
         }
       )

--- a/packages/web/components/templates/ConfirmProfileModal.tsx
+++ b/packages/web/components/templates/ConfirmProfileModal.tsx
@@ -27,7 +27,7 @@ export function ConfirmProfileModal(): JSX.Element {
       setUsername(event.target.value)
       setTimeout(() => {
         setDebouncedUsername(event.target.value)
-      }, 400)
+      }, 2000)
     },
     []
   )

--- a/packages/web/components/templates/auth/EmailSignup.tsx
+++ b/packages/web/components/templates/auth/EmailSignup.tsx
@@ -18,9 +18,8 @@ export function EmailSignup(): JSX.Element {
   const [password, setPassword] = useState<string | undefined>()
   const [fullname, setFullname] = useState<string | undefined>()
   const [username, setUsername] = useState<string | undefined>()
-  const [debouncedUsername, setDebouncedUsername] = useState<
-    string | undefined
-  >()
+  const [debouncedUsername, setDebouncedUsername] =
+    useState<string | undefined>()
   const [errorMessage, setErrorMessage] = useState<string | undefined>()
 
   useEffect(() => {
@@ -41,7 +40,7 @@ export function EmailSignup(): JSX.Element {
       setUsername(event.target.value)
       setTimeout(() => {
         setDebouncedUsername(event.target.value)
-      }, 400)
+      }, 2000)
     },
     []
   )


### PR DESCRIPTION
- Increase unauthed rate limit
- Increase cache time for text to speech data
- Increase the debounce time on username validation
