### PR TITLE
Trim RSS URLs before validating them to remove whitespace

### DIFF
--- a/apple/OmnivoreKit/Sources/Views/Colors/ThemeColors.xcassets/_lightGray.colorset/Contents.json
+++ b/apple/OmnivoreKit/Sources/Views/Colors/ThemeColors.xcassets/_lightGray.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0x68",
-          "green" : "0x69",
-          "red" : "0x69"
+          "blue" : "0x89",
+          "green" : "0x89",
+          "red" : "0x89"
         }
       },
       "idiom" : "universal"
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0x68",
-          "green" : "0x69",
-          "red" : "0x69"
+          "blue" : "0x89",
+          "green" : "0x89",
+          "red" : "0x89"
         }
       },
       "idiom" : "universal"

--- a/packages/web/pages/settings/feeds/add.tsx
+++ b/packages/web/pages/settings/feeds/add.tsx
@@ -25,9 +25,8 @@ const Header = styled(Box, {
 
 export default function AddRssFeed(): JSX.Element {
   const router = useRouter()
-  const [errorMessage, setErrorMessage] = useState<string | undefined>(
-    undefined
-  )
+  const [errorMessage, setErrorMessage] =
+    useState<string | undefined>(undefined)
   const [feedUrl, setFeedUrl] = useState<string>('')
 
   const subscribe = useCallback(async () => {
@@ -39,7 +38,7 @@ export default function AddRssFeed(): JSX.Element {
     let normailizedUrl: string
     // normalize the url
     try {
-      normailizedUrl = new URL(feedUrl).toString()
+      normailizedUrl = new URL(feedUrl.trim()).toString()
     } catch (e) {
       setErrorMessage('Please enter a valid feed URL')
       return

--- a/packages/web/public/sw.js
+++ b/packages/web/public/sw.js
@@ -138,7 +138,7 @@
       const requestUrl = new URL(request.url)
       if (requestUrl.pathname === '/share-target') {
         const shareRequest = handleShareTarget(request)
-        ev.respondWith(shareRequest)
+        return shareRequest
       }
     }
 


### PR DESCRIPTION
- Early return from share-target
- Trim RSS URLs before validating
