### PR TITLE
Dont use the service worker cache as it interferes with the content security policy

### DIFF
--- a/packages/web/public/sw.js
+++ b/packages/web/public/sw.js
@@ -129,23 +129,6 @@
       })
   }
 
-  function handleFetchRequest(ev) {
-    const request = ev.request
-    if (request.method === 'POST') {
-      const requestUrl = new URL(request.url)
-      if (requestUrl.pathname === '/share-target') {
-        const shareRequest = handleShareTarget(request)
-        return shareRequest
-      }
-    }
-
-    if (naviApi.onLine) {
-      return globalApi.fetch(request)
-    }
-
-    return fetchWithCacheBackup(request)
-  }
-
   function handleOutdatedCache() {
     return globalApi.caches.keys().then((cacheNames) => {
       return Promise.all(
@@ -181,8 +164,16 @@
     if (ev.request.destination === 'script') {
       return
     }
+    if (ev.request.destination === 'image') {
+      return
+    }
 
-    const handler = handleFetchRequest(ev)
-    ev.respondWith(handler)
+    if (ev.request.method === 'POST') {
+      const requestUrl = new URL(request.url)
+      if (requestUrl.pathname === '/share-target') {
+        const shareRequest = handleShareTarget(request)
+        return shareRequest
+      }
+    }
   })
 })()

--- a/packages/web/public/sw.js
+++ b/packages/web/public/sw.js
@@ -169,9 +169,9 @@
     }
 
     if (ev.request.method === 'POST') {
-      const requestUrl = new URL(request.url)
+      const requestUrl = new URL(ev.request.url)
       if (requestUrl.pathname === '/share-target') {
-        const shareRequest = handleShareTarget(request)
+        const shareRequest = handleShareTarget(ev.request)
         return shareRequest
       }
     }


### PR DESCRIPTION
If we use this, then the CSP can't set security policies as
granularly, as almost everything will go through connect-src,
like every time we get a fallback image it would go through
fetch and connect-src would have to allow all https.
