### PR TITLE
fix labels and highlights were deleted when deleting items

### DIFF
--- a/packages/api/src/resolvers/article/index.ts
+++ b/packages/api/src/resolvers/article/index.ts
@@ -672,10 +672,6 @@ export const setBookmarkArticleResolver = authorized<
         page.id,
         {
           state: ArticleSavingRequestStatus.Deleted,
-          labels: [],
-          highlights: [],
-          readingProgressAnchorIndex: 0,
-          readingProgressPercent: 0,
         },
         pageContext
       )

--- a/packages/api/test/resolvers/article.test.ts
+++ b/packages/api/test/resolvers/article.test.ts
@@ -765,7 +765,6 @@ describe('Article API', () => {
         await graphqlRequest(query, authToken).expect(200)
         const page = await getPageById(articleId)
         expect(page?.state).to.eql(ArticleSavingRequestStatus.Deleted)
-        expect(page?.highlights).to.eql([])
       })
     })
   })


### PR DESCRIPTION
@jacksonh we used to remove existing labels and highlights from the deleted items but we need to retain them since we allow undoing the deletion.

Fix #2852 