### PR TITLE
Android: Add Highlight color palette for web reader

### DIFF
--- a/android/Omnivore/app/src/main/java/app/omnivore/omnivore/dataService/HighlightActionHandlers.kt
+++ b/android/Omnivore/app/src/main/java/app/omnivore/omnivore/dataService/HighlightActionHandlers.kt
@@ -12,7 +12,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.util.*
 
-suspend fun DataService.createWebHighlight(jsonString: String) {
+suspend fun DataService.createWebHighlight(jsonString: String, colorName: String?) {
   val createHighlightInput = Gson().fromJson(jsonString, CreateHighlightParams::class.java).asCreateHighlightInput()
 
   withContext(Dispatchers.IO) {
@@ -28,7 +28,7 @@ suspend fun DataService.createWebHighlight(jsonString: String) {
       createdAt = null,
       updatedAt = null,
       createdByMe = false,
-      color = null,
+      color = colorName ?: createHighlightInput.color.getOrNull(),
     )
 
     highlight.serverSyncStatus = ServerSyncStatus.NEEDS_CREATION.rawValue
@@ -80,13 +80,13 @@ suspend fun DataService.createNoteHighlight(savedItemId: String, note: String): 
     db.savedItemAndHighlightCrossRefDao().insertAll(listOf(crossRef))
 
     val newHighlight = networker.createHighlight(input = CreateHighlightParams(
-       type = HighlightType.NOTE,
-       articleId = savedItemId,
-       id = createHighlightId,
-       shortId = shortId,
-       quote = null,
-       patch = null,
-       annotation = note,
+      type = HighlightType.NOTE,
+      articleId = savedItemId,
+      id = createHighlightId,
+      shortId = shortId,
+      quote = null,
+      patch = null,
+      annotation = note,
     ).asCreateHighlightInput())
 
     newHighlight?.let {

--- a/android/Omnivore/app/src/main/java/app/omnivore/omnivore/ui/components/HighlightColor.kt
+++ b/android/Omnivore/app/src/main/java/app/omnivore/omnivore/ui/components/HighlightColor.kt
@@ -1,0 +1,8 @@
+package app.omnivore.omnivore.ui.components
+
+import androidx.compose.ui.graphics.Color
+
+data class HighlightColor(
+    val name: String = "yellow",
+    val color: Color = Color(0xFFFFD234),
+)

--- a/android/Omnivore/app/src/main/java/app/omnivore/omnivore/ui/components/HighlightColorPalette.kt
+++ b/android/Omnivore/app/src/main/java/app/omnivore/omnivore/ui/components/HighlightColorPalette.kt
@@ -1,0 +1,48 @@
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import app.omnivore.omnivore.ui.components.HighlightColor
+import app.omnivore.omnivore.ui.components.HighlightColorPaletteMode
+
+@Composable
+fun HighlightColorPalette(
+    mode: HighlightColorPaletteMode = HighlightColorPaletteMode.Light,
+    selectedColorName: String,
+    onColorSelected: (color: HighlightColor) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Surface(
+        modifier = modifier,
+        shape = RoundedCornerShape(8.dp),
+        color = mode.backgroundColor,
+        shadowElevation = 9.dp
+    ) {
+        Row(modifier = Modifier.padding(8.dp, 2.dp, 8.dp, 2.dp)) {
+            HighlightColorPaletteItem(
+                color = HighlightColor(name = "yellow", Color(0xFFFFD234)),
+                isSelected = "yellow" == selectedColorName,
+                onClick = onColorSelected
+            )
+            HighlightColorPaletteItem(
+                color = HighlightColor(name = "red", Color(0xFFFB9A9A)),
+                isSelected = "red" == selectedColorName,
+                onClick = onColorSelected
+            )
+            HighlightColorPaletteItem(
+                color = HighlightColor(name = "green", Color(0xFF55C689)),
+                isSelected = "green" == selectedColorName,
+                onClick = onColorSelected
+            )
+            HighlightColorPaletteItem(
+                color = HighlightColor(name = "blue", Color(0xFF6AB1FF)),
+                isSelected = "blue" == selectedColorName,
+                onClick = onColorSelected
+            )
+        }
+    }
+}

--- a/android/Omnivore/app/src/main/java/app/omnivore/omnivore/ui/components/HighlightColorPaletteItem.kt
+++ b/android/Omnivore/app/src/main/java/app/omnivore/omnivore/ui/components/HighlightColorPaletteItem.kt
@@ -1,0 +1,47 @@
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Check
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import app.omnivore.omnivore.ui.components.HighlightColor
+
+@Composable
+fun HighlightColorPaletteItem(
+    color: HighlightColor,
+    isSelected: Boolean,
+    onClick: (color: HighlightColor) -> Unit,
+    modifier: Modifier = Modifier.padding(6.dp)
+) {
+    Column (
+        modifier = modifier,
+    ) {
+        Box(
+            modifier = Modifier
+                .size(40.dp)
+                .clip(CircleShape)
+                .background(color.color)
+                .clickable { onClick(color) }
+        )
+        {
+            if (isSelected) {
+                Icon(
+                    Icons.Rounded.Check,
+                    contentDescription = "checkIcon",
+                    tint = Color.DarkGray,
+                    modifier = Modifier.align(Alignment.Center)
+                )
+            }
+        }
+    }
+}

--- a/android/Omnivore/app/src/main/java/app/omnivore/omnivore/ui/components/HighlightColorPaletteMode.kt
+++ b/android/Omnivore/app/src/main/java/app/omnivore/omnivore/ui/components/HighlightColorPaletteMode.kt
@@ -1,0 +1,7 @@
+package app.omnivore.omnivore.ui.components
+
+import androidx.compose.ui.graphics.Color
+enum class HighlightColorPaletteMode(val backgroundColor: Color) {
+    Light(Color.White),
+    Dark(Color.Black),
+}

--- a/android/Omnivore/app/src/main/java/app/omnivore/omnivore/ui/reader/WebReaderViewModel.kt
+++ b/android/Omnivore/app/src/main/java/app/omnivore/omnivore/ui/reader/WebReaderViewModel.kt
@@ -20,6 +20,7 @@ import app.omnivore.omnivore.networking.*
 import app.omnivore.omnivore.persistence.entities.SavedItem
 import app.omnivore.omnivore.persistence.entities.SavedItemAndSavedItemLabelCrossRef
 import app.omnivore.omnivore.persistence.entities.SavedItemLabel
+import app.omnivore.omnivore.ui.components.HighlightColor
 import app.omnivore.omnivore.ui.library.SavedItemAction
 import com.apollographql.apollo3.api.Optional
 import com.apollographql.apollo3.api.Optional.Companion.presentIfNotNull
@@ -76,7 +77,10 @@ class WebReaderViewModel @Inject constructor(
   var lastTapCoordinates: TapCoordinates? = null
   private var isLoading = false
   private var slug: String? = null
-  
+
+  val showHighlightColorPalette = MutableLiveData(false)
+  val highlightColor = MutableLiveData(HighlightColor())
+
   fun loadItem(slug: String?, requestID: String?) {
     this.slug = slug
     if (isLoading || webReaderParamsLiveData.value != null) { return }
@@ -290,11 +294,30 @@ class WebReaderViewModel @Inject constructor(
     }
   }
 
+
+  fun showHighlightColorPalette() {
+    CoroutineScope(Dispatchers.Main).launch {
+      showHighlightColorPalette.postValue(true)
+    }
+  }
+
+  fun hideHighlightColorPalette() {
+    CoroutineScope(Dispatchers.Main).launch {
+      showHighlightColorPalette.postValue(false)
+    }
+  }
+
+  fun setHighlightColor(color: HighlightColor) {
+    CoroutineScope(Dispatchers.Main).launch {
+      highlightColor.postValue(color)
+    }
+  }
+
   fun handleIncomingWebMessage(actionID: String, jsonString: String) {
     when (actionID) {
       "createHighlight" -> {
         viewModelScope.launch {
-          dataService.createWebHighlight(jsonString)
+          dataService.createWebHighlight(jsonString, highlightColor.value?.name)
         }
       }
       "deleteHighlight" -> {


### PR DESCRIPTION
Hey 👋 

This goes toward #2820 

## Note(s)
- The colours match what's in the web version.
- Only added to the web reader for now.
- The default colour is yellow.
- The selected colour is bound to the article read (i.e., not persisted).
- Happy to discuss implementation/ui/ux details, I literally just went with the flow 😃 
- It only partially works (see below)

## Important
I am facing an issue where the highlight is first created with the default colour, but if leaving the article and opening it back again, then it appears with the colour manually selected (see attached screen record below.)

My guess is that the highlight is "pre-created" but I couldn't pinpoint where? There is something that escapes me in the flow 🤔 

Any pointers would be much appreciated!

https://github.com/omnivore-app/omnivore/assets/4558395/5eb5ad48-4773-4d38-a484-678d0318c46b


