### PR TITLE
Sort subscriptions by name for now (should allow options in the future)

### DIFF
--- a/packages/web/components/templates/homeFeed/LibraryFilterMenu.tsx
+++ b/packages/web/components/templates/homeFeed/LibraryFilterMenu.tsx
@@ -204,9 +204,7 @@ function Subscriptions(
     if (!props.subscriptions) {
       return []
     }
-    return props.subscriptions.sort((a, b) =>
-      b.updatedAt.localeCompare(a.updatedAt)
-    )
+    return props.subscriptions.sort((a, b) => a.name.localeCompare(b.name))
   }, [props.subscriptions])
 
   useRegisterActions(

--- a/packages/web/pages/settings/feeds/index.tsx
+++ b/packages/web/pages/settings/feeds/index.tsx
@@ -199,8 +199,8 @@ export default function Rss(): JSX.Element {
                 )
                 setOnPauseId(subscription.id)
               }}
-              deleteTitle="Delete"
-              editTitle={subscription.status === 'ACTIVE' ? 'Pause' : 'Resume'}
+              deleteTitle="Unsubscribe"
+              // editTitle={subscription.status === 'ACTIVE' ? 'Pause' : 'Resume'}
               sublineElement={
                 <SpanBox
                   css={{

--- a/packages/web/pages/settings/feeds/index.tsx
+++ b/packages/web/pages/settings/feeds/index.tsx
@@ -39,7 +39,7 @@ export default function Rss(): JSX.Element {
     }
     return subscriptions
       .filter((s) => s.status == 'ACTIVE')
-      .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt))
+      .sort((a, b) => a.name.localeCompare(b.name))
   }, [subscriptions])
 
   async function updateSubscription(): Promise<void> {

--- a/packages/web/pages/settings/subscriptions.tsx
+++ b/packages/web/pages/settings/subscriptions.tsx
@@ -40,7 +40,7 @@ export default function SubscriptionsPage(): JSX.Element {
     }
     return subscriptions
       .filter((s) => s.status == 'ACTIVE')
-      .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt))
+      .sort((a, b) => a.name.localeCompare(b.name))
   }, [subscriptions])
 
   return (


### PR DESCRIPTION
A few things here:

- sort subscriptions by name
- Get rid of the paused state for subscriptions
- only display active subscriptions in UI