### PR TITLE
delete rss subscription row from db when unsubscribe

### DIFF
--- a/packages/api/src/services/subscriptions.ts
+++ b/packages/api/src/services/subscriptions.ts
@@ -147,13 +147,15 @@ export const unsubscribe = async (subscription: Subscription) => {
     }
     // TODO: find a good way to unsubscribe by url if email fails or not provided
     // because it often requires clicking a button on the page to unsubscribe
+    return authTrx((tx) =>
+      tx.getRepository(Subscription).update(subscription.id, {
+        status: SubscriptionStatus.Unsubscribed,
+      })
+    )
   }
 
-  return authTrx((tx) =>
-    tx.getRepository(Subscription).update(subscription.id, {
-      status: SubscriptionStatus.Unsubscribed,
-    })
-  )
+  // unsubscribe from rss feed
+  return authTrx((tx) => tx.getRepository(Subscription).delete(subscription.id))
 }
 
 export const unsubscribeAll = async (


### PR DESCRIPTION
@jacksonh I think this is a regression when a newsletter subscription is deleted, we mark it as unsub but for rss subscriptions, we should just delete it from the database.
