### PR TITLE
[Android] Add padding on LabelChip on LabelsSelectionSheet

### DIFF
--- a/android/Omnivore/app/src/main/java/app/omnivore/omnivore/ui/components/LabelsSelectionSheet.kt
+++ b/android/Omnivore/app/src/main/java/app/omnivore/omnivore/ui/components/LabelsSelectionSheet.kt
@@ -373,6 +373,7 @@ fun LabelsSelectionSheetContent(
               name = label.name,
               colors = chipColors,
               modifier = Modifier
+                .padding(end = 10.dp, bottom = 10.dp)
                 .clickable {
                   state.addChip(LabelChipView(label))
                   filterTextValue = TextFieldValue()


### PR DESCRIPTION
Hi 👋 

Every time, I click the wrong label 😅 so I thought that some padding would have been nice! I used the same value of the screen's horizontal padding to keep consistency.

| Before | After | 
| ----------- | ----------- | 
| <img width="363" src="https://github.com/omnivore-app/omnivore/assets/9467705/2bf60f2b-6958-46ac-a6eb-b5e6b6daaf4b"> | <img width="363" src="https://github.com/omnivore-app/omnivore/assets/9467705/f78251b4-2378-4754-a694-385a96840c74"> | 