### PR TITLE
iOS: Add length indicator to new label textfield

### DIFF
--- a/apple/OmnivoreKit/Sources/App/Views/Labels/LabelsView.swift
+++ b/apple/OmnivoreKit/Sources/App/Views/Labels/LabelsView.swift
@@ -116,8 +116,16 @@ struct CreateLabelView: View {
       }
       .padding(.bottom, 8)
 
-      TextField("Label Name", text: $newLabelName)
+      TextField(LocalText.labelNamePlaceholder, text: $newLabelName)
         .textFieldStyle(StandardTextFieldStyle())
+        .onChange(of: newLabelName) { inputLabelName in
+          newLabelName = String(inputLabelName.prefix(viewModel.labelNameMaxLength))
+        }
+
+      Text("\(newLabelName.count)/\(viewModel.labelNameMaxLength)")
+        .font(.caption)
+        .frame(maxWidth: .infinity, alignment: .trailing)
+        .foregroundColor(newLabelName.count < viewModel.labelNameMaxLength ? .gray : .red)
 
       ScrollView(.horizontal, showsIndicators: false) {
         LazyHGrid(rows: rows, alignment: .top, spacing: 20) {

--- a/apple/OmnivoreKit/Sources/App/Views/Labels/LabelsViewModel.swift
+++ b/apple/OmnivoreKit/Sources/App/Views/Labels/LabelsViewModel.swift
@@ -5,6 +5,8 @@ import SwiftUI
 import Views
 
 @MainActor final class LabelsViewModel: ObservableObject {
+  let labelNameMaxLength = 64
+
   @Published var isLoading = false
   @Published var selectedLabels = Set<LinkedItemLabel>()
   @Published var unselectedLabels = Set<LinkedItemLabel>()

--- a/apple/OmnivoreKit/Sources/Views/LocalText.swift
+++ b/apple/OmnivoreKit/Sources/Views/LocalText.swift
@@ -26,6 +26,7 @@ public enum LocalText {
   public static let labelsViewAssignNameColor = localText(key: "labelsViewAssignNameColor")
   public static let createLabelMessage = localText(key: "createLabelMessage")
   public static let labelsPurposeDescription = localText(key: "labelsPurposeDescription")
+  public static let labelNamePlaceholder = localText(key: "labelNamePlaceholder")
 
   // Manage Account View
   public static let manageAccountDelete = localText(key: "manageAccountDelete")

--- a/apple/OmnivoreKit/Sources/Views/Resources/en.lproj/Localizable.strings
+++ b/apple/OmnivoreKit/Sources/Views/Resources/en.lproj/Localizable.strings
@@ -19,6 +19,7 @@
 "labelsViewAssignNameColor" = "Assign a name and color.";
 "createLabelMessage" = "Create a new Label";
 "labelsPurposeDescription" = "Use labels to create curated collections of links.";
+"labelNamePlaceholder" = "Label Name";
 
 // Manage Account View
 "manageAccountDelete" = "Delete Account";

--- a/apple/OmnivoreKit/Sources/Views/Resources/es.lproj/Localizable.strings
+++ b/apple/OmnivoreKit/Sources/Views/Resources/es.lproj/Localizable.strings
@@ -19,6 +19,7 @@
 "labelsViewAssignNameColor" = "Asigna un nombre y un color.";
 "createLabelMessage" = "Crea una nueva Etiqueta";
 "labelsPurposeDescription" = "Usa Etiquetas para coleccione de enlaces organizadas.";
+"labelNamePlaceholder" = "Nombre de la etiqueta";
 
 // Manage Account View
 "manageAccountDelete" = "Borrar Cuenta";

--- a/apple/OmnivoreKit/Sources/Views/Resources/zh-Hans.lproj/Localizable.strings
+++ b/apple/OmnivoreKit/Sources/Views/Resources/zh-Hans.lproj/Localizable.strings
@@ -20,6 +20,7 @@
 "labelsViewAssignNameColor" = "指定名称和颜色。";
 "createLabelMessage" = "创建新标签";
 "labelsPurposeDescription" = "使用标签创建精选的链接集合。";
+"labelNamePlaceholder" = "标签名称";
 
 // Manage Account View
 "manageAccountDelete" = "删除帐户";


### PR DESCRIPTION
## Summary
* Started working on this after seeing #1481 (although it refers to label description.)
* Adding a length indicator under the TextField for label creation.
* Adding guard rails to prevent users from even trying to create label names that are [too long](https://github.com/omnivore-app/omnivore/blob/29c878605709b7039f72cdbc7770dbc268395e3c/packages/api/src/schema.ts#L1455).

## Additional Note
I am aware that there are two schools of thought; some think validation should only be performed in one place, and others might not agree. In this case, I believe this makes for a better user experience (currently, creating a new label that is too long is a very strange experience; it looks like it works at first, but actually doesn't.)

Anyway, let me know what you think. If you think that's valuable, I am happy to add that to Android as well.

## Screen Record
https://github.com/omnivore-app/omnivore/assets/4558395/cf417026-86cf-49f0-ae89-96566aa18117

