### PR TITLE
fix/slow db query

### DIFF
--- a/packages/api/src/resolvers/article/index.ts
+++ b/packages/api/src/resolvers/article/index.ts
@@ -707,9 +707,9 @@ export const typeaheadSearchResolver = authorized<
   TypeaheadSearchSuccess,
   TypeaheadSearchError,
   QueryTypeaheadSearchArgs
->(async (_obj, { query, first }, { log }) => {
+>(async (_obj, { query, first }, { log, uid }) => {
   try {
-    const items = await findLibraryItemsByPrefix(query, first || undefined)
+    const items = await findLibraryItemsByPrefix(query, uid, first || undefined)
 
     return {
       items: items.map((item) => ({

--- a/packages/api/src/routers/svc/content.ts
+++ b/packages/api/src/routers/svc/content.ts
@@ -71,7 +71,8 @@ export function contentServiceRouter() {
           .withRepository(libraryItemRepository)
           .createQueryBuilder('item')
           .innerJoinAndSelect('item.uploadFile', 'file')
-          .where('file.id = :fileId', { fileId })
+          .where('item.user = :userId', { userId: uploadFile.user.id })
+          .andWhere('file.id = :fileId', { fileId })
           .getOne(),
       undefined,
       uploadFile.user.id

--- a/packages/api/src/services/highlights.ts
+++ b/packages/api/src/services/highlights.ts
@@ -136,8 +136,11 @@ export const updateHighlight = async (
 export const deleteHighlightById = async (highlightId: string) => {
   return authTrx(async (tx) => {
     const highlightRepo = tx.withRepository(highlightRepository)
-    const highlight = await highlightRepo.findOneByOrFail({
-      id: highlightId,
+    const highlight = await highlightRepo.findOneOrFail({
+      where: { id: highlightId },
+      relations: {
+        user: true,
+      },
     })
 
     await highlightRepo.delete(highlightId)

--- a/packages/rss-handler/src/index.ts
+++ b/packages/rss-handler/src/index.ts
@@ -70,7 +70,7 @@ const sendUpdateSubscriptionMutation = async (
     )
 
     /* eslint-disable @typescript-eslint/no-unsafe-member-access */
-    return !!response.data.data.savePage
+    return !!response.data.data.updateSubscription.subscription
   } catch (error) {
     if (axios.isAxiosError(error)) {
       console.error('update subscription mutation error', error.message)


### PR DESCRIPTION
- fix updated subscription always show failed in the rss handler logs
- fix: after successfully deleted highlights, still return error codes
- add user_id to the sql query to reduce query latency
