### PR TITLE
Android: Show URL in OpenLinkView

### DIFF
--- a/android/Omnivore/app/src/main/java/app/omnivore/omnivore/ui/reader/OpenLinkView.kt
+++ b/android/Omnivore/app/src/main/java/app/omnivore/omnivore/ui/reader/OpenLinkView.kt
@@ -1,0 +1,59 @@
+package app.omnivore.omnivore.ui.reader
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import app.omnivore.omnivore.R
+
+@Composable
+fun OpenLinkView(webReaderViewModel: WebReaderViewModel) {
+    val context = LocalContext.current
+
+    Column(modifier = Modifier
+        .padding(top = 25.dp)
+        .padding(horizontal = 50.dp), verticalArrangement = Arrangement.spacedBy(20.dp)) {
+        Row {
+            Text(webReaderViewModel.currentLink.toString(),
+                fontWeight = FontWeight.Light,
+                color = Color.DarkGray,
+                fontSize = 12.sp,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+                )
+        }
+        Row(modifier = Modifier.padding(top = 25.dp)) {
+            Button(onClick = { webReaderViewModel.openCurrentLink(context) }, modifier = Modifier.fillMaxWidth()) {
+                Text(text = stringResource(R.string.open_link_view_action_open_in_browser))
+            }
+        }
+        Row {
+            Button(onClick = { webReaderViewModel.saveCurrentLink(context) }, modifier = Modifier.fillMaxWidth()) {
+                Text(text = stringResource(R.string.open_link_view_action_save_to_omnivore))
+
+            }
+        }
+        Row {
+            Button(onClick = {webReaderViewModel.copyCurrentLink(context) }, modifier = Modifier.fillMaxWidth()) {
+                Text(text = stringResource(R.string.open_link_view_action_copy_link))
+            }
+        }
+        Row {
+            Button(onClick = {webReaderViewModel.resetBottomSheet() }, modifier = Modifier.fillMaxWidth()) {
+                Text(text = stringResource(R.string.open_link_view_action_cancel))
+            }
+        }
+    }
+}

--- a/android/Omnivore/app/src/main/java/app/omnivore/omnivore/ui/reader/WebReaderLoadingContainer.kt
+++ b/android/Omnivore/app/src/main/java/app/omnivore/omnivore/ui/reader/WebReaderLoadingContainer.kt
@@ -42,7 +42,6 @@ import com.google.accompanist.systemuicontroller.rememberSystemUiController
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 import kotlin.math.roundToInt
-import androidx.compose.material3.Button
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import app.omnivore.omnivore.ui.components.LabelsViewModel
@@ -446,41 +445,6 @@ fun BottomSheetUI(title: String?, content: @Composable () -> Unit) {
     ) { paddingValues ->
       Box(modifier = Modifier.fillMaxSize()) {
         content()
-      }
-    }
-  }
-}
-
-@OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterialApi::class)
-@Composable
-fun OpenLinkView(webReaderViewModel: WebReaderViewModel) {
-  val context = LocalContext.current
-
-  Column(modifier = Modifier
-    .padding(top = 50.dp)
-    .padding(horizontal = 50.dp), verticalArrangement = Arrangement.spacedBy(20.dp)) {
-    Row {
-      Button(onClick = { webReaderViewModel.openCurrentLink(context) }, modifier = Modifier.fillMaxWidth()) {
-        Text(text = stringResource(R.string.open_link_view_action_open_in_browser))
-
-      }
-    }
-    Row() {
-      Button(onClick = { webReaderViewModel.saveCurrentLink(context) }, modifier = Modifier.fillMaxWidth()) {
-        Text(text = stringResource(R.string.open_link_view_action_save_to_omnivore))
-
-      }
-    }
-    Row() {
-      Button(onClick = {webReaderViewModel.copyCurrentLink(context) }, modifier = Modifier.fillMaxWidth()) {
-        Text(text = stringResource(R.string.open_link_view_action_copy_link))
-
-      }
-    }
-    Row {
-      Button(onClick = {webReaderViewModel.resetBottomSheet() }, modifier = Modifier.fillMaxWidth()) {
-        Text(text = stringResource(R.string.open_link_view_action_cancel))
-
       }
     }
   }


### PR DESCRIPTION
## Summary
- Showing the URL in the sheet when tapping a link in an article.
- Moving `OpenLinkView` in its own file.

Towards #2362 

## Screenshots
| Normal        | w/ Text overflow           |
| ------------- |:-------------:|
| ![Screenshot_20231016-090217](https://github.com/omnivore-app/omnivore/assets/4558395/8d777fb6-92aa-43cb-8b9e-3271beb3aea1)     | ![Screenshot_20231016-090237](https://github.com/omnivore-app/omnivore/assets/4558395/7a8d37bf-dcf7-4ae0-9a74-1c8fe6b18afd) |

