### PR TITLE
docs: fix typos in packages/content-fetch/README.md

### DIFF
--- a/packages/content-fetch/README.md
+++ b/packages/content-fetch/README.md
@@ -1,6 +1,6 @@
 # Puppeteer parsing function handler
 
-This workspace is used to provide the GCF for the app to hande requests for the article parsing via Puppeteer.
+This workspace is used to provide the GCF for the app to handle requests for the article parsing via Puppeteer.
      
 ## Using locally
 
@@ -8,7 +8,7 @@ Copy .env.example file to .env file: `cp .env.example .env`
 
 Run `yarn start` to start the Google Cloud Function locally (Works without hot reloading).
 
-After this, you should be able to access the functon on [http://localhost:8080/puppeteer](http://localhost:8080/puppeteer)
+After this, you should be able to access the function on [http://localhost:8080/puppeteer](http://localhost:8080/puppeteer)
 
 ## Deployment
 


### PR DESCRIPTION
1. hande -> handle
2. functon -> function