### PR TITLE
Downgrade API container python to 3.10 from 3.11 to fix a node-gyp build error

### DIFF
--- a/packages/api/Dockerfile
+++ b/packages/api/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18.16-alpine as builder
+FROM node:18.16-alpine3.17 as builder
 
 WORKDIR /app
 
@@ -32,7 +32,7 @@ RUN rm -rf /app/packages/api/node_modules
 RUN rm -rf /app/node_modules
 RUN yarn install --pure-lockfile --production
 
-FROM node:18.16-alpine as runner
+FROM node:18.16-alpine3.17 as runner
 
 WORKDIR /app
 

--- a/packages/api/Dockerfile-test
+++ b/packages/api/Dockerfile-test
@@ -1,4 +1,4 @@
-FROM node:18.16-alpine
+FROM node:18.16-alpine3.17
 
 WORKDIR /app
 

--- a/packages/content-fetch/Dockerfile
+++ b/packages/content-fetch/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18.16-alpine
+FROM node:18.16-alpine3.17
 
 # Installs latest Chromium (92) package.
 RUN apk add --no-cache \

--- a/packages/content-fetch/Dockerfile-gcf
+++ b/packages/content-fetch/Dockerfile-gcf
@@ -1,4 +1,4 @@
-FROM node:18.16-alpine
+FROM node:18.16-alpine3.17
 
 # Installs latest Chromium (92) package.
 RUN apk add --no-cache \

--- a/packages/db/Dockerfile
+++ b/packages/db/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18.16-alpine
+FROM node:18.16-alpine3.17
 
 WORKDIR /app
 

--- a/packages/import-handler/Dockerfile
+++ b/packages/import-handler/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18.16-alpine
+FROM node:18.16-alpine3.17
 
 WORKDIR /app
 

--- a/packages/import-handler/Dockerfile-collector
+++ b/packages/import-handler/Dockerfile-collector
@@ -1,4 +1,4 @@
-FROM node:18.16-alpine
+FROM node:18.16-alpine3.17
 
 WORKDIR /app
 

--- a/packages/inbound-email-handler/Dockerfile
+++ b/packages/inbound-email-handler/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18.16-alpine
+FROM node:18.16-alpine3.17
 
 # Run everything after as non-privileged user.
 WORKDIR /app

--- a/packages/pdf-handler/Dockerfile
+++ b/packages/pdf-handler/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18.16-alpine
+FROM node:18.16-alpine3.17
 
 # Run everything after as non-privileged user.
 WORKDIR /app

--- a/packages/rule-handler/Dockerfile
+++ b/packages/rule-handler/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18.16-alpine
+FROM node:18.16-alpine3.17
 
 # Run everything after as non-privileged user.
 WORKDIR /app

--- a/packages/text-to-speech/Dockerfile
+++ b/packages/text-to-speech/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18.16-alpine
+FROM node:18.16-alpine3.17
 
 # Run everything after as non-privileged user.
 WORKDIR /app

--- a/packages/thumbnail-handler/Dockerfile
+++ b/packages/thumbnail-handler/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18.16-alpine
+FROM node:18.16-alpine3.17
 
 # Run everything after as non-privileged user.
 WORKDIR /app


### PR DESCRIPTION
I get the following error when building the API container on ARM:

```
395.0 Traceback (most recent call last):
395.0   File "/app/node_modules/@npmcli/run-script/node_modules/node-gyp/gyp/gyp_main.py", line 51, in <module>
395.0     sys.exit(gyp.script_main())
395.0              ^^^^^^^^^^^^^^^^^
395.0   File "/app/node_modules/@npmcli/run-script/node_modules/node-gyp/gyp/pylib/gyp/__init__.py", line 670, in script_main
395.0     return main(sys.argv[1:])
395.0            ^^^^^^^^^^^^^^^^^^
395.0   File "/app/node_modules/@npmcli/run-script/node_modules/node-gyp/gyp/pylib/gyp/__init__.py", line 662, in main
395.0     return gyp_main(args)
395.0            ^^^^^^^^^^^^^^
395.0   File "/app/node_modules/@npmcli/run-script/node_modules/node-gyp/gyp/pylib/gyp/__init__.py", line 629, in gyp_main
395.0     [generator, flat_list, targets, data] = Load(
395.0                                             ^^^^^
395.0   File "/app/node_modules/@npmcli/run-script/node_modules/node-gyp/gyp/pylib/gyp/__init__.py", line 150, in Load
395.0     result = gyp.input.Load(
395.0              ^^^^^^^^^^^^^^^
395.0   File "/app/node_modules/@npmcli/run-script/node_modules/node-gyp/gyp/pylib/gyp/input.py", line 3021, in Load
395.0     LoadTargetBuildFile(
395.0   File "/app/node_modules/@npmcli/run-script/node_modules/node-gyp/gyp/pylib/gyp/input.py", line 411, in LoadTargetBuildFile
395.0     build_file_data = LoadOneBuildFile(
395.0                       ^^^^^^^^^^^^^^^^^
395.0   File "/app/node_modules/@npmcli/run-script/node_modules/node-gyp/gyp/pylib/gyp/input.py", line 239, in LoadOneBuildFile
395.0     build_file_contents = open(build_file_path, "rU").read()
395.0                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
395.0 ValueError: invalid mode: 'rU' while trying to load binding.gyp
395.0 gyp ERR! configure error
395.0 gyp ERR! stack Error: `gyp` failed with exit code: 1
395.0 gyp ERR! stack     at ChildProcess.onCpExit (/app/node_modules/@npmcli/run-script/node_modules/node-gyp/lib/configure.js:351:16)
395.0 gyp ERR! stack     at ChildProcess.emit (node:events:513:28)
395.0 gyp ERR! stack     at ChildProcess._handle.onexit (node:internal/child_process:291:12)
395.0 gyp ERR! System Linux 6.4.16-linuxkit
395.0 gyp ERR! command "/usr/local/bin/node" "/app/node_modules/.bin/node-gyp" "rebuild"
395.0 gyp ERR! cwd /app/node_modules/microtime
395.0 gyp ERR! node -v v18.16.1
395.0 gyp ERR! node-gyp -v v7.1.2
395.0 gyp ERR! not ok
```

An investigation led me to https://github.com/nodejs/node-gyp/issues/2219, which indicates this is a bug introduced in Python 3.11. Setting the Alpine version to 3.17 effectively downgrades Python from 3.11 to 3.10 (there's only one Python version bundled in each Alpine release).

It seems like this might only affect ARM64, [since CI is currently using 3.11](https://github.com/omnivore-app/omnivore/actions/runs/6575606292/job/17863141470#step:3:90) without encountering this issue. 