### PR TITLE
On web always set PDF position to the last viewed page

### DIFF
--- a/packages/web/components/templates/article/PdfArticleContainer.tsx
+++ b/packages/web/components/templates/article/PdfArticleContainer.tsx
@@ -413,6 +413,7 @@ export default function PdfArticleContainer(
           }
           await articleReadingProgressMutation({
             id: props.article.id,
+            force: true,
             readingProgressPercent: percent,
             readingProgressAnchorIndex: pageIndex,
           })

--- a/packages/web/components/templates/article/PdfArticleContainer.tsx
+++ b/packages/web/components/templates/article/PdfArticleContainer.tsx
@@ -408,9 +408,6 @@ export default function PdfArticleContainer(
             100,
             Math.max(0, ((pageIndex + 1) / instance.totalPageCount) * 100)
           )
-          if (percent <= props.article.readingProgressPercent) {
-            return
-          }
           await articleReadingProgressMutation({
             id: props.article.id,
             force: true,

--- a/packages/web/lib/networking/mutations/articleReadingProgressMutation.ts
+++ b/packages/web/lib/networking/mutations/articleReadingProgressMutation.ts
@@ -3,6 +3,7 @@ import { gqlFetcher } from '../networkHelpers'
 
 export type ArticleReadingProgressMutationInput = {
   id: string
+  force?: boolean
   readingProgressPercent?: number
   readingProgressTopPercent?: number
   readingProgressAnchorIndex?: number


### PR DESCRIPTION
- When saving PDF read position always set it to the current page
- Remove soptimization
