### PR TITLE
Fix hover behavior of library list hover actions

### DIFF
--- a/packages/web/components/patterns/LibraryCards/LibraryListCard.tsx
+++ b/packages/web/components/patterns/LibraryCards/LibraryListCard.tsx
@@ -36,8 +36,6 @@ import { LoadingBar } from '../../elements/LoadingBar'
 
 export function LibraryListCard(props: LinkedItemCardProps): JSX.Element {
   const router = useRouter()
-  const [isHovered, setIsHovered] = useState(false)
-
   const [isOpen, setIsOpen] = useState(false)
 
   const { refs, floatingStyles, context } = useFloating({
@@ -93,12 +91,6 @@ export function LibraryListCard(props: LinkedItemCardProps): JSX.Element {
       }}
       alignment="start"
       distribution="start"
-      onMouseEnter={() => {
-        setIsHovered(true)
-      }}
-      onMouseLeave={() => {
-        setIsHovered(false)
-      }}
       onClick={(event) => {
         if (event.metaKey || event.ctrlKey) {
           window.open(
@@ -120,11 +112,11 @@ export function LibraryListCard(props: LinkedItemCardProps): JSX.Element {
             item={props.item}
             viewer={props.viewer}
             handleAction={props.handleAction}
-            isHovered={isHovered ?? false}
+            isHovered={isOpen ?? false}
           />
         </Box>
       )}
-      <LibraryListCardContent {...props} isHovered={isHovered} />
+      <LibraryListCardContent {...props} isHovered={isOpen} />
     </VStack>
   )
 }


### PR DESCRIPTION
In the library list view, there is a toolbar of actions that appears over each entry when you hover over it. This change fixes the hover behavior of this toolbar so that you do not need to move the mouse cursor out and back into the library list item after archiving/deleting a previous item in order to re-activate the toolbar.

This video shows the previous behavior:

https://github.com/omnivore-app/omnivore/assets/6109875/5f09674c-fd43-4b15-9f76-f6d82f070bf2

And this video shows the behavior after this patch is applied:

https://github.com/omnivore-app/omnivore/assets/6109875/010e11a0-39ee-4a44-acbb-200f4cd96521