### PR TITLE
Fixes #3050 - URLs sensitive to trailing slash

### DIFF
--- a/packages/api/src/utils/helpers.ts
+++ b/packages/api/src/utils/helpers.ts
@@ -385,5 +385,6 @@ export const cleanUrl = (url: string) => {
     stripHash: true,
     stripWWW: false,
     removeQueryParameters: trackingParams,
+    removeTrailingSlash: false,
   })
 }


### PR DESCRIPTION
By passing false to `removeTrailingSlash` for normalize-url call, the URLs sensitive to trailing slash will be parsed correctly