### PR TITLE
iOS: Show URL in OpenLink Confirmation Dialog

### DIFF
--- a/apple/OmnivoreKit/Sources/App/Views/WebReader/WebReaderContainer.swift
+++ b/apple/OmnivoreKit/Sources/App/Views/WebReader/WebReaderContainer.swift
@@ -438,7 +438,8 @@ struct WebReaderContainerView: View {
             await audioController.preload(itemIDs: [item.unwrappedID])
           }
         }
-        .confirmationDialog(linkToOpen?.absoluteString ?? "", isPresented: $displayLinkSheet) {
+        .confirmationDialog(linkToOpen?.absoluteString ?? "", isPresented: $displayLinkSheet,
+                            titleVisibility: .visible) {
           Button(action: {
             if let linkToOpen = linkToOpen {
               safariWebLink = SafariWebLink(id: UUID(), url: linkToOpen)


### PR DESCRIPTION
Showing the URL in the sheet when tapping a link in an article.

Note that the code to set the title was already in place, but one argument was missing when creating the confirmation dialog.

Towards #2362 (implementation for Android was done in #2939)

## Screenshots
| Before        | After           |
| ------------- |:-------------:|
| ![Simulator Screenshot - iPhone 15 Pro - 2023-11-03 at 16 35 30](https://github.com/omnivore-app/omnivore/assets/4558395/82cc48a7-b11a-427f-8782-02016b729602)  | ![Simulator Screenshot - iPhone 15 Pro - 2023-11-03 at 16 34 34](https://github.com/omnivore-app/omnivore/assets/4558395/b43fbb7e-8a7f-4978-a02f-ae56ad1368f1) |



