### PR TITLE
fix pocket importer stops running when there is no unarchived items in the batch

### DIFF
--- a/packages/integration-handler/src/index.ts
+++ b/packages/integration-handler/src/index.ts
@@ -231,14 +231,15 @@ export const importer = Sentry.GCPFunction.wrapHttpFunction(
 
         // paginate api calls to the integration
         do {
-          // filter out items that are deleted or archived if the stateToImport is unarchived
           // write the list of urls, state and labels to the stream
           retrievedData
             .filter((row) => {
+              // filter out items that are deleted
               if (row.state === State.DELETED) {
                 return false
               }
 
+              // filter out items that archived if the stateToImport is unarchived
               return (
                 stateToImport !== State.UNARCHIVED ||
                 row.state !== State.ARCHIVED

--- a/packages/integration-handler/src/integrations/index.ts
+++ b/packages/integration-handler/src/integrations/index.ts
@@ -57,7 +57,7 @@ export const updateIntegration = async (
         token: integrationToken,
         enabled: true,
         type,
-        taskName,
+        // taskName, // TODO: remove this
       },
     },
   })

--- a/packages/integration-handler/src/integrations/integration.ts
+++ b/packages/integration-handler/src/integrations/integration.ts
@@ -1,16 +1,18 @@
 import { Item } from '../item'
 
 export enum State {
+  SUCCEEDED = 'SUCCEEDED',
   ARCHIVED = 'ARCHIVED',
   UNREAD = 'UNREAD',
   UNARCHIVED = 'UNARCHIVED',
+  DELETED = 'DELETED',
   ALL = 'ALL',
 }
 
 export interface RetrievedData {
   url: string
   labels?: string[]
-  state?: string
+  state?: State
 }
 export interface RetrievedResult {
   data: RetrievedData[]

--- a/packages/integration-handler/src/integrations/pocket.ts
+++ b/packages/integration-handler/src/integrations/pocket.ts
@@ -122,26 +122,18 @@ export class PocketClient extends IntegrationClient {
     }
 
     const pocketItems = Object.values(pocketData.list)
-    const statusToState: Record<string, string> = {
-      '0': 'SUCCEEDED',
-      '1': 'ARCHIVED',
-      '2': 'DELETED',
+    const statusToState: Record<string, State> = {
+      '0': State.SUCCEEDED,
+      '1': State.ARCHIVED,
+      '2': State.DELETED,
     }
-    const data = pocketItems
-      .map((item) => ({
-        url: item.given_url,
-        labels: item.tags
-          ? Object.values(item.tags).map((tag) => tag.tag)
-          : undefined,
-        state: statusToState[item.status],
-      }))
-      .filter((item) => {
-        if (item.state === 'DELETED') {
-          return false
-        }
-
-        return state !== State.UNARCHIVED || item.state !== 'ARCHIVED'
-      })
+    const data = pocketItems.map((item) => ({
+      url: item.given_url,
+      labels: item.tags
+        ? Object.values(item.tags).map((tag) => tag.tag)
+        : undefined,
+      state: statusToState[item.status],
+    }))
 
     if (pocketData.error) {
       throw new Error(`Error retrieving pocket data: ${pocketData.error}`)


### PR DESCRIPTION
Filter the items by state but do not mutate the retrieved items from API