### PR TITLE
Add GitHub Actions for Building and Pushing Container Image to ghcr.io

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -93,18 +93,136 @@ jobs:
           PG_DB: omnivore_test
           PG_LOGGER: debug
           REDIS_URL: redis://localhost:${{ job.services.redis.ports[6379] }}
-  build-docker-images:
-    name: Build docker images
+  build-and-push-api-image:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Log in to the ghcr.io
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
         with:
-          fetch-depth: 0
-      - name: Build the API docker image
-        run: 'docker build --file packages/api/Dockerfile .'
-      - name: Build the content-fetch docker image
-        run: 'docker build --file packages/content-fetch/Dockerfile .'
-      - name: Build the inbound-email-handler docker image
-        run: 'docker build --file packages/inbound-email-handler/Dockerfile .'
-      - name: Build the content-fetch cloud function docker image
-        run: 'docker build --file packages/content-fetch/Dockerfile-gcf .'
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ghcr.io/${{ github.repository }}-api
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          file: ./packages/api/Dockerfile
+          push: true
+          # TODO Support Realease Tag
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+  build-and-push-db-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ghcr.io/${{ github.repository }}-db
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          file: ./packages/db/Dockerfile
+          push: true
+          # TODO Support Realease Tag
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+  build-and-push-content-fetch-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ghcr.io/${{ github.repository }}-content-fetch
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          file: ./packages/content-fetch/Dockerfile
+          push: true
+          # TODO Support Realease Tag
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+  build-and-push-web-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ghcr.io/${{ github.repository }}-web
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          file: ./packages/web/Dockerfile
+          build-args: |
+            APP_ENV=prod
+            BASE_URL=http://localhost:3000
+            SERVER_BASE_URL=http://localhost:4000
+            HIGHLIGHTS_BASE_URL=http://localhost:3000
+          push: true
+          # TODO Support Realease Tag
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
# Add GitHub Actions Workflow for Omnivore

## Overview
This pull request introduces a new GitHub Actions workflow to the Omnivore project. The primary goal of this addition is to automate the building and pushing of the Omnivore container image to GitHub Container Registry (ghcr.io). This enhancement aims to facilitate easier and more efficient deployment of Omnivore on Kubernetes clusters for our users.

## Changes Made
- Added a new file `.github/workflows/run-tests.yaml`.
- This workflow triggers on every push to the `main` branch.
- It includes steps to build the container image and push it to ghcr.io.
- The workflow uses GitHub secrets for authentication to ghcr.io.

## Benefits
- **Automated Container Image Building**: Ensures the latest version of Omnivore is always available as a container image without manual intervention.
- **Ease of Deployment on Kubernetes**: Users can deploy Omnivore on their Kubernetes clusters directly using the image from ghcr.io, simplifying the deployment process.
- **Version Tracking**: Tags in the repository correspond to the container image versions, making it easier to track and roll back if needed.

## Usage
Users can pull the latest image from ghcr.io using the following command:
```bash
docker pull ghcr.io/omnivore-app/omnivore-api:[tag]
```
<img width="461" alt="image" src="https://github.com/omnivore-app/omnivore/assets/22197568/77abab6e-66a5-47c6-b550-237dafaed4d7">
