### PR TITLE
improve advanced search

### DIFF
--- a/packages/api/src/services/library_item.ts
+++ b/packages/api/src/services/library_item.ts
@@ -317,18 +317,18 @@ export const buildQuery = (
           )
         }
         case 'sort': {
-          const [sort, sortOrder] = value.split('-')
-          if (sort.toLowerCase() === 'score') {
-            // score is not a column and is handled separately
+          const [sort, sortOrder] = value.toLowerCase().split('-')
+          const matchingSortBy = Object.values(SortBy).find(
+            (sortBy) => sortBy === sort
+          )
+          if (!matchingSortBy) {
             return null
           }
+          const column = getColumnName(matchingSortBy)
 
           const order =
-            sortOrder?.toLowerCase() === 'asc'
-              ? SortOrder.ASCENDING
-              : SortOrder.DESCENDING
+            sortOrder === 'asc' ? SortOrder.ASCENDING : SortOrder.DESCENDING
 
-          const column = getColumnName(sort)
           orders.push({ by: `library_item.${column}`, order })
           return null
         }

--- a/packages/api/src/services/library_item.ts
+++ b/packages/api/src/services/library_item.ts
@@ -148,8 +148,13 @@ const getColumnName = (field: string) => {
     case 'updated':
     case 'published':
       return `${lowerCaseField}_at`
-    default:
+    case 'author':
+    case 'title':
+    case 'description':
+    case 'note':
       return lowerCaseField
+    default:
+      throw new Error(`Unexpected field: ${field}`)
   }
 }
 


### PR DESCRIPTION
- allow plural and singular form for has/no filter, e.g. highlight/highlights
- not throw error if sort keyword not found, e.g. `sort:inbox-asc`
