### PR TITLE
do not throw ambiguous error if all the parsed results are the same

### DIFF
--- a/packages/liqe/src/parse.ts
+++ b/packages/liqe/src/parse.ts
@@ -56,7 +56,14 @@ export const parse = (query: string): LiqeQuery => {
   }
 
   if (results.length > 1) {
-    throw new Error('Ambiguous results.');
+    // check if all results are the same
+    const firstResult = JSON.stringify(results[0]);
+
+    for (const result of results) {
+      if (JSON.stringify(result) !== firstResult) {
+        throw new Error('Ambiguous results.');
+      }
+    }
   }
 
   const hydratedAst = hydrateAst(results[0]);


### PR DESCRIPTION
the liqe library tries to match all possible parsed results and some results could be the same so we do not throw error if all the parsed results are the same to avoid ambiguous error