### PR TITLE
Update app/build.gradle to allow debug builds w/o a keystore

### DIFF
--- a/android/Omnivore/app/build.gradle
+++ b/android/Omnivore/app/build.gradle
@@ -8,7 +8,9 @@ plugins {
 
 def keystorePropertiesFile = rootProject.file("app/external/keystore.properties");
 def keystoreProperties = new Properties()
-keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
+if (keystorePropertiesFile.exists()) {
+    keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
+}
 
 android {
     compileSdk 33
@@ -26,24 +28,28 @@ android {
         }
     }
 
-    signingConfigs{
-        release{
+    signingConfigs {
+        release {
             keyAlias 'key0'
             storeFile file('external/omnivore-prod.keystore')
             storePassword keystoreProperties['prodStorePassword']
             keyPassword keystoreProperties['prodKeyPassword']
         }
-        debug{
-            keyAlias 'androiddebugkey'
-            storeFile file('external/omnivore-demo.keystore')
-            storePassword keystoreProperties['demoStorePassword']
-            keyPassword keystoreProperties['demoKeyPassword']
+        debug {
+            if (keystoreProperties['demoStorePassword'] && keystoreProperties['demoKeyPassword']) {
+                keyAlias 'androiddebugkey'
+                storeFile file('external/omnivore-demo.keystore')
+                storePassword keystoreProperties['demoStorePassword']
+                keyPassword keystoreProperties['demoKeyPassword']
+            }
         }
     }
 
     buildTypes {
-        debug{
-            signingConfig signingConfigs.debug
+        debug {
+            if (signingConfigs.debug.storeFile) {
+                signingConfig signingConfigs.debug
+            }
             buildConfigField("String", "OMNIVORE_API_URL", "\"https://api-demo.omnivore.app\"")
             buildConfigField("String", "OMNIVORE_WEB_URL", "\"https://demo.omnivore.app\"")
             buildConfigField("String", "OMNIVORE_GAUTH_SERVER_CLIENT_ID", "\"267918240109-eu2ar09unac3lqqigluknhk7t0021b54.apps.googleusercontent.com\"")

--- a/android/Omnivore/app/build.gradle
+++ b/android/Omnivore/app/build.gradle
@@ -47,9 +47,7 @@ android {
 
     buildTypes {
         debug {
-            if (signingConfigs.debug.storeFile) {
-                signingConfig signingConfigs.debug
-            }
+            signingConfig signingConfigs.debug
             buildConfigField("String", "OMNIVORE_API_URL", "\"https://api-demo.omnivore.app\"")
             buildConfigField("String", "OMNIVORE_WEB_URL", "\"https://demo.omnivore.app\"")
             buildConfigField("String", "OMNIVORE_GAUTH_SERVER_CLIENT_ID", "\"267918240109-eu2ar09unac3lqqigluknhk7t0021b54.apps.googleusercontent.com\"")


### PR DESCRIPTION
# Context

When you first import and try to build the `android` project. You are met with the following error:

```
A problem occurred evaluating project ':app'.
omnivore\android\Omnivore\app\external\keystore.properties (The system cannot find the file specified)
```

This will only occur for new  (or potential new) contributors as they won't have a `keystore.properties` setup. Since Android studio will automatically sign debug builds with the [default keystore](https://developer.android.com/studio/publish/app-signing#debug-mode) . Requiring a custom one for debug seems like a extra unnecessary step to start building

# Fix

This change checks to verify that `external/keystore.properties` exists before loading it and checks to see if `demoKeyPassword` and `demoStorePassword` exist before creating a debug signing config.