### PR TITLE
Run SwiftFormat manually using plugin system

### DIFF
--- a/apple/BuildTools/Package.swift
+++ b/apple/BuildTools/Package.swift
@@ -5,7 +5,6 @@ let package = Package(
   name: "BuildTools",
   platforms: [.macOS(.v10_11)],
   dependencies: [
-    .package(url: "https://github.com/nicklockwood/SwiftFormat", from: "0.48.11"),
     .package(url: "https://github.com/realm/SwiftLint", from: "0.44.0"),
     .package(url: "https://github.com/maticzav/swift-graphql", from: "2.2.1")
   ],

--- a/apple/Omnivore.xcodeproj/project.pbxproj
+++ b/apple/Omnivore.xcodeproj/project.pbxproj
@@ -830,6 +830,7 @@
 			packageReferences = (
 				0418837C2742E99F003E0001 /* XCRemoteSwiftPackageReference "intercom-ios" */,
 				048F592A2790EAF800E0B494 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
+				04B616992B5C296700128513 /* XCRemoteSwiftPackageReference "SwiftFormat" */,
 			);
 			productRefGroup = E601FA26367162479B614F0F /* Products */;
 			projectDirPath = "";
@@ -2051,6 +2052,14 @@
 			requirement = {
 				kind = upToNextMajorVersion;
 				minimumVersion = 8.0.0;
+			};
+		};
+		04B616992B5C296700128513 /* XCRemoteSwiftPackageReference "SwiftFormat" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/nicklockwood/SwiftFormat";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.53.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/apple/Omnivore.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/apple/Omnivore.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -248,8 +248,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/nicklockwood/SwiftFormat",
       "state" : {
-        "revision" : "872e7034f54aeee3f20acf790ecc13e1383f7360",
-        "version" : "0.48.4"
+        "revision" : "fef156a6135e584985ed26713dd2e9ee41f952cb",
+        "version" : "0.53.0"
       }
     },
     {

--- a/apple/scripts/format_and_lint.sh
+++ b/apple/scripts/format_and_lint.sh
@@ -1,5 +1,4 @@
 cd BuildTools
 SDKROOT=(xcrun --sdk macosx --show-sdk-path)
 # swift package update #Uncomment this line temporarily to update the version used to the latest matching your BuildTools/Package.swift file
-swift run -c release swiftformat "$SRCROOT"
 swift run swiftlint --path "$SRCROOT"


### PR DESCRIPTION
This updates where SwiftFormat is run from. Instead of using the BuildTools command line package this pulls in the SwiftFormat package using the projects main Package.swift file. Doing this gives the option to run SwiftFormat manually by right clicking on the Omnivore workspace in the file viewer. 

This means it will be run manually now instead of using a build phase and running on every build. Maybe that's preferred. Or not! 

SwiftLint also has a plugin that can be triggered from a Build Phase but I was running into package resolution issues when trying to add it to the main package. Something conflicts with the swift markdown package. If we can get that working then we only need BuildTools for GraphQL generation and most users won't have to bother with BuildTools (there was a user a few months back running into issues with BuildTools because of their macOS version). 

<img width="500" alt="Screenshot 2024-01-20 at 8 20 58 AM" src="https://github.com/omnivore-app/omnivore/assets/836745/7bc46a76-96d3-4da6-8e5a-668b7979d0ba">
