### PR TITLE
improve contrast on active table row background color

### DIFF
--- a/packages/web/components/tokens/stitches.config.ts
+++ b/packages/web/components/tokens/stitches.config.ts
@@ -169,7 +169,7 @@ export const { styled, css, theme, getCssText, globalCss, keyframes, config } =
         thBackground3: '#FFFFFF',
         thBackground4: '#EBEBEB',
         thBackground5: '#F5F5F5',
-        thBackgroundActive: '#F9F9F9',
+        thBackgroundActive: 'rgb(255, 234, 159)',
         thBackgroundContrast: '#FFFFFF',
         thLeftMenuBackground: '#FCFCFC',
         thLibraryBackground: '#F3F3F3',


### PR DESCRIPTION
A friend is unable to see any change when a table row is set to active due to the very low degree of color contrast shift. This subs in Omnivore yellow color as is used elsewhere in the app for similar purposes.

Open to other solutions but this seemed like a quick one :) 