### PR TITLE
Dont pass library item id to backend when updating highlights

### DIFF
--- a/packages/web/lib/networking/mutations/updateHighlightMutation.ts
+++ b/packages/web/lib/networking/mutations/updateHighlightMutation.ts
@@ -41,7 +41,13 @@ export async function updateHighlightMutation(
   `
 
   try {
-    const data = await gqlFetcher(mutation, { input })
+    const data = await gqlFetcher(mutation, {
+      input: {
+        highlightId: input.highlightId,
+        annotation: input.annotation,
+        color: input.color,
+      },
+    })
     const output = data as UpdateHighlightOutput | undefined
     return output?.updateHighlight.highlight.id
   } catch {


### PR DESCRIPTION
The native (iOS and Android) code needs this param but we
cant send it to the web.
