### PR TITLE
fix/subscription

### DIFF
--- a/packages/api/src/entity/subscription.ts
+++ b/packages/api/src/entity/subscription.ts
@@ -86,6 +86,9 @@ export class Subscription {
   @Column('timestamp', { nullable: true })
   refreshedAt?: Date | null
 
+  @Column('timestamp', { nullable: true })
+  failedAt?: Date | null
+
   @Column('boolean')
   isPrivate?: boolean | null
 

--- a/packages/api/src/entity/subscription.ts
+++ b/packages/api/src/entity/subscription.ts
@@ -16,7 +16,6 @@ export enum SubscriptionStatus {
   Active = 'ACTIVE',
   Deleted = 'DELETED',
   Unsubscribed = 'UNSUBSCRIBED',
-  RefreshError = 'REFRESH_ERROR',
 }
 
 export enum SubscriptionType {

--- a/packages/api/src/entity/subscription.ts
+++ b/packages/api/src/entity/subscription.ts
@@ -7,11 +7,22 @@ import {
   PrimaryGeneratedColumn,
   UpdateDateColumn,
 } from 'typeorm'
-import { SubscriptionStatus, SubscriptionType } from '../generated/graphql'
 import { NewsletterEmail } from './newsletter_email'
 import { User } from './user'
 
 export const DEFAULT_SUBSCRIPTION_FOLDER = 'following'
+
+export enum SubscriptionStatus {
+  Active = 'ACTIVE',
+  Deleted = 'DELETED',
+  Unsubscribed = 'UNSUBSCRIBED',
+  RefreshError = 'REFRESH_ERROR',
+}
+
+export enum SubscriptionType {
+  Newsletter = 'NEWSLETTER',
+  Rss = 'RSS',
+}
 
 @Entity({ name: 'subscriptions' })
 export class Subscription {
@@ -59,7 +70,7 @@ export class Subscription {
   count!: number
 
   @Column('timestamp', { nullable: true })
-  lastFetchedAt?: Date | null
+  mostRecentItemDate?: Date | null
 
   @Column('text', { nullable: true })
   lastFetchedChecksum?: string | null
@@ -72,6 +83,9 @@ export class Subscription {
 
   @Column('timestamp', { nullable: true })
   scheduledAt?: Date | null
+
+  @Column('timestamp', { nullable: true })
+  refreshedAt?: Date | null
 
   @Column('boolean')
   isPrivate?: boolean | null

--- a/packages/api/src/generated/graphql.ts
+++ b/packages/api/src/generated/graphql.ts
@@ -2833,6 +2833,7 @@ export type Subscription = {
   count: Scalars['Int'];
   createdAt: Scalars['Date'];
   description?: Maybe<Scalars['String']>;
+  failedAt?: Maybe<Scalars['Date']>;
   fetchContent: Scalars['Boolean'];
   folder: Scalars['String'];
   icon?: Maybe<Scalars['String']>;
@@ -2854,7 +2855,6 @@ export type Subscription = {
 export enum SubscriptionStatus {
   Active = 'ACTIVE',
   Deleted = 'DELETED',
-  RefreshError = 'REFRESH_ERROR',
   Unsubscribed = 'UNSUBSCRIBED'
 }
 
@@ -3208,6 +3208,7 @@ export enum UpdateSubscriptionErrorCode {
 export type UpdateSubscriptionInput = {
   autoAddToLibrary?: InputMaybe<Scalars['Boolean']>;
   description?: InputMaybe<Scalars['String']>;
+  failedAt?: InputMaybe<Scalars['Date']>;
   fetchContent?: InputMaybe<Scalars['Boolean']>;
   folder?: InputMaybe<Scalars['String']>;
   id: Scalars['ID'];
@@ -6190,6 +6191,7 @@ export type SubscriptionResolvers<ContextType = ResolverContext, ParentType exte
   count?: SubscriptionResolver<ResolversTypes['Int'], "count", ParentType, ContextType>;
   createdAt?: SubscriptionResolver<ResolversTypes['Date'], "createdAt", ParentType, ContextType>;
   description?: SubscriptionResolver<Maybe<ResolversTypes['String']>, "description", ParentType, ContextType>;
+  failedAt?: SubscriptionResolver<Maybe<ResolversTypes['Date']>, "failedAt", ParentType, ContextType>;
   fetchContent?: SubscriptionResolver<ResolversTypes['Boolean'], "fetchContent", ParentType, ContextType>;
   folder?: SubscriptionResolver<ResolversTypes['String'], "folder", ParentType, ContextType>;
   icon?: SubscriptionResolver<Maybe<ResolversTypes['String']>, "icon", ParentType, ContextType>;

--- a/packages/api/src/generated/graphql.ts
+++ b/packages/api/src/generated/graphql.ts
@@ -2852,6 +2852,7 @@ export type Subscription = {
 export enum SubscriptionStatus {
   Active = 'ACTIVE',
   Deleted = 'DELETED',
+  RefreshError = 'REFRESH_ERROR',
   Unsubscribed = 'UNSUBSCRIBED'
 }
 

--- a/packages/api/src/generated/graphql.ts
+++ b/packages/api/src/generated/graphql.ts
@@ -2839,8 +2839,10 @@ export type Subscription = {
   id: Scalars['ID'];
   isPrivate?: Maybe<Scalars['Boolean']>;
   lastFetchedAt?: Maybe<Scalars['Date']>;
+  mostRecentItemDate?: Maybe<Scalars['Date']>;
   name: Scalars['String'];
   newsletterEmail?: Maybe<Scalars['String']>;
+  refreshedAt?: Maybe<Scalars['Date']>;
   status: SubscriptionStatus;
   type: SubscriptionType;
   unsubscribeHttpUrl?: Maybe<Scalars['String']>;
@@ -3210,9 +3212,10 @@ export type UpdateSubscriptionInput = {
   folder?: InputMaybe<Scalars['String']>;
   id: Scalars['ID'];
   isPrivate?: InputMaybe<Scalars['Boolean']>;
-  lastFetchedAt?: InputMaybe<Scalars['Date']>;
   lastFetchedChecksum?: InputMaybe<Scalars['String']>;
+  mostRecentItemDate?: InputMaybe<Scalars['Date']>;
   name?: InputMaybe<Scalars['String']>;
+  refreshedAt?: InputMaybe<Scalars['Date']>;
   scheduledAt?: InputMaybe<Scalars['Date']>;
   status?: InputMaybe<SubscriptionStatus>;
 };
@@ -6193,8 +6196,10 @@ export type SubscriptionResolvers<ContextType = ResolverContext, ParentType exte
   id?: SubscriptionResolver<ResolversTypes['ID'], "id", ParentType, ContextType>;
   isPrivate?: SubscriptionResolver<Maybe<ResolversTypes['Boolean']>, "isPrivate", ParentType, ContextType>;
   lastFetchedAt?: SubscriptionResolver<Maybe<ResolversTypes['Date']>, "lastFetchedAt", ParentType, ContextType>;
+  mostRecentItemDate?: SubscriptionResolver<Maybe<ResolversTypes['Date']>, "mostRecentItemDate", ParentType, ContextType>;
   name?: SubscriptionResolver<ResolversTypes['String'], "name", ParentType, ContextType>;
   newsletterEmail?: SubscriptionResolver<Maybe<ResolversTypes['String']>, "newsletterEmail", ParentType, ContextType>;
+  refreshedAt?: SubscriptionResolver<Maybe<ResolversTypes['Date']>, "refreshedAt", ParentType, ContextType>;
   status?: SubscriptionResolver<ResolversTypes['SubscriptionStatus'], "status", ParentType, ContextType>;
   type?: SubscriptionResolver<ResolversTypes['SubscriptionType'], "type", ParentType, ContextType>;
   unsubscribeHttpUrl?: SubscriptionResolver<Maybe<ResolversTypes['String']>, "unsubscribeHttpUrl", ParentType, ContextType>;

--- a/packages/api/src/generated/schema.graphql
+++ b/packages/api/src/generated/schema.graphql
@@ -2235,8 +2235,10 @@ type Subscription {
   id: ID!
   isPrivate: Boolean
   lastFetchedAt: Date
+  mostRecentItemDate: Date
   name: String!
   newsletterEmail: String
+  refreshedAt: Date
   status: SubscriptionStatus!
   type: SubscriptionType!
   unsubscribeHttpUrl: String
@@ -2577,9 +2579,10 @@ input UpdateSubscriptionInput {
   folder: String
   id: ID!
   isPrivate: Boolean
-  lastFetchedAt: Date
   lastFetchedChecksum: String
+  mostRecentItemDate: Date
   name: String
+  refreshedAt: Date
   scheduledAt: Date
   status: SubscriptionStatus
 }

--- a/packages/api/src/generated/schema.graphql
+++ b/packages/api/src/generated/schema.graphql
@@ -2229,6 +2229,7 @@ type Subscription {
   count: Int!
   createdAt: Date!
   description: String
+  failedAt: Date
   fetchContent: Boolean!
   folder: String!
   icon: String
@@ -2250,7 +2251,6 @@ type Subscription {
 enum SubscriptionStatus {
   ACTIVE
   DELETED
-  REFRESH_ERROR
   UNSUBSCRIBED
 }
 
@@ -2575,6 +2575,7 @@ enum UpdateSubscriptionErrorCode {
 input UpdateSubscriptionInput {
   autoAddToLibrary: Boolean
   description: String
+  failedAt: Date
   fetchContent: Boolean
   folder: String
   id: ID!

--- a/packages/api/src/generated/schema.graphql
+++ b/packages/api/src/generated/schema.graphql
@@ -2248,6 +2248,7 @@ type Subscription {
 enum SubscriptionStatus {
   ACTIVE
   DELETED
+  REFRESH_ERROR
   UNSUBSCRIBED
 }
 

--- a/packages/api/src/jobs/rss/refreshAllFeeds.ts
+++ b/packages/api/src/jobs/rss/refreshAllFeeds.ts
@@ -1,11 +1,10 @@
-import { Job, Queue } from 'bullmq'
+import { Job } from 'bullmq'
 import { DataSource } from 'typeorm'
-import { QUEUE_NAME, getBackendQueue } from '../../queue-processor'
-import { redisDataSource } from '../../redis_data_source'
+import { v4 as uuid } from 'uuid'
+import { getBackendQueue } from '../../queue-processor'
+import { validateUrl } from '../../services/create_page_save_request'
 import { RssSubscriptionGroup } from '../../utils/createTask'
 import { stringToHash } from '../../utils/helpers'
-import { validateUrl } from '../../services/create_page_save_request'
-import { v4 as uuid } from 'uuid'
 
 export type RSSRefreshContext = {
   type: 'all' | 'user-added'
@@ -90,7 +89,7 @@ const updateSubscriptionGroup = async (
     refreshContext,
     subscriptionIds: group.subscriptionIds,
     feedUrl: group.url,
-    lastFetchedTimestamps: group.fetchedDates.map(
+    lastFetchedTimestamps: group.mostRecentItemDates.map(
       (timestamp) => timestamp?.getTime() || 0
     ), // unix timestamp in milliseconds
     lastFetchedChecksums: group.checksums,

--- a/packages/api/src/jobs/rss/refreshFeed.ts
+++ b/packages/api/src/jobs/rss/refreshFeed.ts
@@ -1,12 +1,14 @@
 import axios from 'axios'
 import crypto from 'crypto'
-import * as jwt from 'jsonwebtoken'
 import { parseHTML } from 'linkedom'
 import Parser, { Item } from 'rss-parser'
-import { promisify } from 'util'
+import { SubscriptionStatus } from '../../entity/subscription'
 import { env } from '../../env'
 import { redisDataSource } from '../../redis_data_source'
-import { updateSubscription } from '../../services/update_subscription'
+import {
+  updateSubscription,
+  updateSubscriptions,
+} from '../../services/update_subscription'
 import createHttpTaskWithToken from '../../utils/createTask'
 import { RSSRefreshContext } from './refreshAllFeeds'
 
@@ -333,7 +335,6 @@ const createItemWithPreviewContent = async (
   }
 }
 
-const signToken = promisify(jwt.sign)
 const parser = new Parser({
   customFields: {
     item: [
@@ -441,7 +442,8 @@ const processSubscription = async (
   const updatedLastFetchedChecksum = fetchResult.checksum
 
   // fetch feed
-  let itemCount = 0
+  let itemCount = 0,
+    errorCount = 0
 
   const feedLastBuildDate = feed.lastBuildDate
   console.log('Feed last build date', feedLastBuildDate)
@@ -455,69 +457,71 @@ const processSubscription = async (
 
   // save each item in the feed
   for (const item of feed.items) {
-    // use published or updated if isoDate is not available for atom feeds
-    const isoDate =
-      item.isoDate || item.published || item.updated || item.created
-    console.log('Processing feed item', item.links, item.isoDate, feedUrl)
+    try {
+      // use published or updated if isoDate is not available for atom feeds
+      const isoDate =
+        item.isoDate || item.published || item.updated || item.created
+      console.log('Processing feed item', item.links, item.isoDate, feedUrl)
 
-    if (!item.links || item.links.length === 0) {
-      console.log('Invalid feed item', item)
-      continue
+      if (!item.links || item.links.length === 0) {
+        throw new Error('Invalid feed item')
+      }
+
+      const link = getLink(item.links)
+      if (!link) {
+        throw new Error('Invalid feed item link')
+      }
+
+      const feedItem = {
+        ...item,
+        isoDate,
+        link,
+      }
+
+      const publishedAt = feedItem.isoDate
+        ? new Date(feedItem.isoDate)
+        : new Date()
+      // remember the last valid item
+      if (
+        !lastValidItem ||
+        (lastValidItem.isoDate && publishedAt > new Date(lastValidItem.isoDate))
+      ) {
+        lastValidItem = feedItem
+      }
+
+      // Max limit per-feed update
+      if (itemCount > 99) {
+        continue
+      }
+
+      // skip old items
+      if (isOldItem(feedItem, mostRecentItemDate)) {
+        console.log('Skipping old feed item', feedItem.link)
+        continue
+      }
+
+      const created = await createTask(
+        fetchContentTasks,
+        userId,
+        feedUrl,
+        feedItem,
+        fetchContent,
+        folder
+      )
+      if (!created) {
+        throw new Error('Failed to create task for feed item')
+      }
+
+      // remember the last item fetched at
+      if (!lastItemFetchedAt || publishedAt > lastItemFetchedAt) {
+        lastItemFetchedAt = publishedAt
+      }
+
+      itemCount = itemCount + 1
+    } catch (error) {
+      console.error('Error while saving RSS feed item', error, item)
+      errorCount = errorCount + 1
     }
-
-    const link = getLink(item.links)
-    if (!link) {
-      console.log('Invalid feed item links', item.links)
-      continue
-    }
-
-    const feedItem = {
-      ...item,
-      isoDate,
-      link,
-    }
-
-    const publishedAt = feedItem.isoDate
-      ? new Date(feedItem.isoDate)
-      : new Date()
-    // remember the last valid item
-    if (
-      !lastValidItem ||
-      (lastValidItem.isoDate && publishedAt > new Date(lastValidItem.isoDate))
-    ) {
-      lastValidItem = feedItem
-    }
-
-    // Max limit per-feed update
-    if (itemCount > 99) {
-      continue
-    }
-
-    // skip old items
-    if (isOldItem(feedItem, mostRecentItemDate)) {
-      console.log('Skipping old feed item', feedItem.link)
-      continue
-    }
-
-    const created = await createTask(
-      fetchContentTasks,
-      userId,
-      feedUrl,
-      feedItem,
-      fetchContent,
-      folder
-    )
-    if (!created) {
-      console.error('Failed to create task for feed item', feedItem.link)
-      continue
-    }
-
-    // remember the last item fetched at
-    if (!lastItemFetchedAt || publishedAt > lastItemFetchedAt) {
-      lastItemFetchedAt = publishedAt
-    }
-
-    itemCount = itemCount + 1
   }
 
   // no items saved
@@ -539,17 +543,18 @@ const processSubscription = async (
     )
     if (!created) {
       console.error('Failed to create task for feed item', lastValidItem.link)
-      throw new Error('Failed to create task for feed item')
+      errorCount = errorCount + 1
     }
 
     lastItemFetchedAt = lastValidItem.isoDate
       ? new Date(lastValidItem.isoDate)
-      : new Date()
+      : refreshedAt
   }
 
   const updateFrequency = getUpdateFrequency(feed)
   const updatePeriodInMs = getUpdatePeriodInHours(feed) * 60 * 60 * 1000
   const nextScheduledAt = scheduledAt + updatePeriodInMs * updateFrequency
+  const status = errorCount > 0 ? SubscriptionStatus.RefreshError : undefined
 
   // update subscription mostRecentItemDate and refreshedAt
   const updatedSubscription = await updateSubscription(userId, subscriptionId, {
@@ -557,6 +562,7 @@ const processSubscription = async (
     lastFetchedChecksum: updatedLastFetchedChecksum,
     scheduledAt: new Date(nextScheduledAt),
     refreshedAt,
+    status,
   })
   console.log('Updated subscription', updatedSubscription)
 }
@@ -570,38 +576,39 @@ export const refreshFeed = async (request: any) => {
 }
 
 export const _refreshFeed = async (request: RefreshFeedRequest) => {
-  try {
-    const {
-      feedUrl,
-      subscriptionIds,
-      mostRecentItemDates,
-      scheduledTimestamps,
-      userIds,
-      lastFetchedChecksums,
-      fetchContents,
-      folders,
-      refreshContext,
-    } = request
-    console.log('Processing feed', feedUrl, { refreshContext: refreshContext })
+  const {
+    feedUrl,
+    subscriptionIds,
+    mostRecentItemDates,
+    scheduledTimestamps,
+    userIds,
+    lastFetchedChecksums,
+    fetchContents,
+    folders,
+    refreshContext,
+  } = request
 
+  console.log('Processing feed', feedUrl, { refreshContext: refreshContext })
+
+  try {
     const isBlocked = await isFeedBlocked(feedUrl)
     if (isBlocked) {
       console.log('feed is blocked: ', feedUrl)
-      return
+      throw new Error('feed is blocked')
     }
 
     const fetchResult = await fetchAndChecksum(feedUrl)
     if (!fetchResult) {
       console.error('Failed to fetch RSS feed', feedUrl)
       await incrementFeedFailure(feedUrl)
-      return
+      throw new Error('Failed to fetch RSS feed')
     }
 
     const feed = await parseFeed(feedUrl, fetchResult.content)
     if (!feed) {
       console.error('Failed to parse RSS feed', feedUrl)
       await incrementFeedFailure(feedUrl)
-      return
+      throw new Error('Failed to parse RSS feed')
     }
 
     let allowFetchContent = true
@@ -615,19 +622,23 @@ export const _refreshFeed = async (request: RefreshFeedRequest) => {
     const fetchContentTasks = new Map<string, FetchContentTask>() // url -> FetchContentTask
     // process each subscription sequentially
     for (let i = 0; i < subscriptionIds.length; i++) {
-      await processSubscription(
-        fetchContentTasks,
-        subscriptionIds[i],
-        userIds[i],
-        feedUrl,
-        fetchResult,
-        mostRecentItemDates[i],
-        scheduledTimestamps[i],
-        lastFetchedChecksums[i],
-        fetchContents[i] && allowFetchContent,
-        folders[i],
-        feed
-      )
+      try {
+        await processSubscription(
+          fetchContentTasks,
+          subscriptionIds[i],
+          userIds[i],
+          feedUrl,
+          fetchResult,
+          mostRecentItemDates[i],
+          scheduledTimestamps[i],
+          lastFetchedChecksums[i],
+          fetchContents[i] && allowFetchContent,
+          folders[i],
+          feed
+        )
+      } catch (error) {
+        console.error('Error while processing subscription', error)
+      }
     }
 
     // create fetch content tasks
@@ -638,7 +649,17 @@ export const _refreshFeed = async (request: RefreshFeedRequest) => {
         task.item
       )
     }
+
+    return true
   } catch (e) {
     console.error('Error while saving RSS feeds', e)
+
+    // mark subscriptions as error if we failed to get the feed
+    await updateSubscriptions(subscriptionIds, {
+      status: SubscriptionStatus.RefreshError,
+      refreshedAt: new Date(),
+    })
+
+    return false
   }
 }

--- a/packages/api/src/jobs/rss/refreshFeed.ts
+++ b/packages/api/src/jobs/rss/refreshFeed.ts
@@ -15,7 +15,7 @@ type FolderType = 'following' | 'inbox'
 interface RefreshFeedRequest {
   subscriptionIds: string[]
   feedUrl: string
-  lastFetchedTimestamps: number[] // unix timestamp in milliseconds
+  mostRecentItemDates: number[] // unix timestamp in milliseconds
   scheduledTimestamps: number[] // unix timestamp in milliseconds
   lastFetchedChecksums: string[]
   userIds: string[]
@@ -28,7 +28,7 @@ export const isRefreshFeedRequest = (data: any): data is RefreshFeedRequest => {
   return (
     'subscriptionIds' in data &&
     'feedUrl' in data &&
-    'lastFetchedTimestamps' in data &&
+    'mostRecentItemDates' in data &&
     'scheduledTimestamps' in data &&
     'userIds' in data &&
     'lastFetchedChecksums' in data &&
@@ -422,7 +422,7 @@ const processSubscription = async (
   userId: string,
   feedUrl: string,
   fetchResult: { content: string; checksum: string },
-  lastFetchedAt: number,
+  mostRecentItemDate: number,
   scheduledAt: number,
   lastFetchedChecksum: string,
   fetchContent: boolean,
@@ -445,7 +445,7 @@ const processSubscription = async (
   console.log('Feed last build date', feedLastBuildDate)
   if (
     feedLastBuildDate &&
-    new Date(feedLastBuildDate) <= new Date(lastFetchedAt)
+    new Date(feedLastBuildDate) <= new Date(mostRecentItemDate)
   ) {
     console.log('Skipping old feed', feedLastBuildDate)
     return
@@ -492,7 +492,7 @@ const processSubscription = async (
     }
 
     // skip old items
-    if (isOldItem(feedItem, lastFetchedAt)) {
+    if (isOldItem(feedItem, mostRecentItemDate)) {
       console.log('Skipping old feed item', feedItem.link)
       continue
     }
@@ -521,7 +521,7 @@ const processSubscription = async (
   // no items saved
   if (!lastItemFetchedAt) {
     // the feed has been fetched before, no new valid items found
-    if (lastFetchedAt || !lastValidItem) {
+    if (mostRecentItemDate || !lastValidItem) {
       console.log('No new valid items found')
       return
     }
@@ -571,7 +571,7 @@ export const _refreshFeed = async (request: RefreshFeedRequest) => {
     const {
       feedUrl,
       subscriptionIds,
-      lastFetchedTimestamps,
+      mostRecentItemDates,
       scheduledTimestamps,
       userIds,
       lastFetchedChecksums,
@@ -618,7 +618,7 @@ export const _refreshFeed = async (request: RefreshFeedRequest) => {
         userIds[i],
         feedUrl,
         fetchResult,
-        lastFetchedTimestamps[i],
+        mostRecentItemDates[i],
         scheduledTimestamps[i],
         lastFetchedChecksums[i],
         fetchContents[i] && allowFetchContent,

--- a/packages/api/src/jobs/rss/refreshFeed.ts
+++ b/packages/api/src/jobs/rss/refreshFeed.ts
@@ -74,11 +74,14 @@ interface FetchContentTask {
   item: RssFeedItem
 }
 
-export const isOldItem = (item: RssFeedItem, lastFetchedAt: number) => {
+export const isOldItem = (
+  item: RssFeedItem,
+  mostRecentItemTimestamp: number
+) => {
   // existing items and items that were published before 24h
   const publishedAt = item.isoDate ? new Date(item.isoDate) : new Date()
   return (
-    publishedAt <= new Date(lastFetchedAt) ||
+    publishedAt <= new Date(mostRecentItemTimestamp) ||
     publishedAt < new Date(Date.now() - 24 * 60 * 60 * 1000)
   )
 }

--- a/packages/api/src/jobs/rss/refreshFeed.ts
+++ b/packages/api/src/jobs/rss/refreshFeed.ts
@@ -637,10 +637,12 @@ export const _refreshFeed = async (request: RefreshFeedRequest) => {
     const fetchContentTasks = new Map<string, FetchContentTask>() // url -> FetchContentTask
     // process each subscription sequentially
     for (let i = 0; i < subscriptionIds.length; i++) {
+      const subscriptionId = subscriptionIds[i]
+
       try {
         await processSubscription(
           fetchContentTasks,
-          subscriptionIds[i],
+          subscriptionId,
           userIds[i],
           feedUrl,
           fetchResult,
@@ -652,7 +654,10 @@ export const _refreshFeed = async (request: RefreshFeedRequest) => {
           feed
         )
       } catch (error) {
-        console.error('Error while processing subscription', error)
+        console.error('Error while processing subscription', {
+          error,
+          subscriptionId,
+        })
       }
     }
 
@@ -666,8 +671,12 @@ export const _refreshFeed = async (request: RefreshFeedRequest) => {
     }
 
     return true
-  } catch (e) {
-    console.error('Error while saving RSS feeds', e)
+  } catch (error) {
+    console.error('Error while saving RSS feeds', {
+      feedUrl,
+      subscriptionIds,
+      error,
+    })
 
     // mark subscriptions as error if we failed to get the feed
     await updateSubscriptions(subscriptionIds, {

--- a/packages/api/src/jobs/rss/refreshFeed.ts
+++ b/packages/api/src/jobs/rss/refreshFeed.ts
@@ -2,7 +2,6 @@ import axios from 'axios'
 import crypto from 'crypto'
 import { parseHTML } from 'linkedom'
 import Parser, { Item } from 'rss-parser'
-import { SubscriptionStatus } from '../../entity/subscription'
 import { env } from '../../env'
 import { redisDataSource } from '../../redis_data_source'
 import { validateUrl } from '../../services/create_page_save_request'
@@ -537,13 +536,13 @@ const processSubscription = async (
 
       itemCount = itemCount + 1
     } catch (error) {
-      console.error('Error while saving RSS feed item', error, item)
+      console.error('Error while saving RSS feed item', { error, item })
       failedAt = new Date()
     }
   }
 
   // no items saved
-  if (!lastItemFetchedAt) {
+  if (!lastItemFetchedAt && !failedAt) {
     // the feed has been fetched before, no new valid items found
     if (mostRecentItemDate || !lastValidItem) {
       console.log('No new valid items found')

--- a/packages/api/src/jobs/save_page.ts
+++ b/packages/api/src/jobs/save_page.ts
@@ -339,7 +339,8 @@ export const savePageJob = async (data: Data, attemptsMade: number) => {
         userId,
         url,
       })
-      throw new Error('Unable to save job, user can not be found.')
+      // if the user is not found, we do not retry
+      return false
     }
 
     // for non-pdf content, we need to save the page

--- a/packages/api/src/resolvers/function_resolvers.ts
+++ b/packages/api/src/resolvers/function_resolvers.ts
@@ -477,6 +477,10 @@ export const functionResolvers = {
         DEFAULT_SUBSCRIPTION_FOLDER
       )
     },
+    // for campability with old clients
+    lastFetchedAt(subscription: Subscription) {
+      return subscription.mostRecentItemDate
+    },
   },
   NewsletterEmail: {
     subscriptionCount(newsletterEmail: NewsletterEmail) {

--- a/packages/api/src/resolvers/function_resolvers.ts
+++ b/packages/api/src/resolvers/function_resolvers.ts
@@ -479,7 +479,7 @@ export const functionResolvers = {
     },
     // for campability with old clients
     lastFetchedAt(subscription: Subscription) {
-      return subscription.mostRecentItemDate
+      return subscription.refreshedAt
     },
   },
   NewsletterEmail: {

--- a/packages/api/src/resolvers/subscriptions/index.ts
+++ b/packages/api/src/resolvers/subscriptions/index.ts
@@ -217,10 +217,7 @@ export const subscribeResolver = authorized<
       type: SubscriptionType.Rss,
     })
     if (existingSubscription) {
-      if (
-        existingSubscription.status === SubscriptionStatus.Active ||
-        existingSubscription.status === SubscriptionStatus.RefreshError
-      ) {
+      if (existingSubscription.status === SubscriptionStatus.Active) {
         return {
           errorCodes: [SubscribeErrorCode.AlreadySubscribed],
         }

--- a/packages/api/src/schema.ts
+++ b/packages/api/src/schema.ts
@@ -1686,12 +1686,15 @@ const schema = gql`
     autoAddToLibrary: Boolean
     fetchContent: Boolean!
     folder: String!
+    mostRecentItemDate: Date
+    refreshedAt: Date
   }
 
   enum SubscriptionStatus {
     ACTIVE
     UNSUBSCRIBED
     DELETED
+    REFRESH_ERROR
   }
 
   type SubscriptionsError {

--- a/packages/api/src/schema.ts
+++ b/packages/api/src/schema.ts
@@ -2600,7 +2600,6 @@ const schema = gql`
     id: ID!
     name: String
     description: String
-    lastFetchedAt: Date
     lastFetchedChecksum: String
     status: SubscriptionStatus
     scheduledAt: Date
@@ -2608,6 +2607,8 @@ const schema = gql`
     autoAddToLibrary: Boolean
     fetchContent: Boolean
     folder: String
+    refreshedAt: Date
+    mostRecentItemDate: Date
   }
 
   union UpdateSubscriptionResult =

--- a/packages/api/src/schema.ts
+++ b/packages/api/src/schema.ts
@@ -1688,13 +1688,13 @@ const schema = gql`
     folder: String!
     mostRecentItemDate: Date
     refreshedAt: Date
+    failedAt: Date
   }
 
   enum SubscriptionStatus {
     ACTIVE
     UNSUBSCRIBED
     DELETED
-    REFRESH_ERROR
   }
 
   type SubscriptionsError {
@@ -2609,6 +2609,7 @@ const schema = gql`
     folder: String
     refreshedAt: Date
     mostRecentItemDate: Date
+    failedAt: Date
   }
 
   union UpdateSubscriptionResult =

--- a/packages/api/src/services/subscriptions.ts
+++ b/packages/api/src/services/subscriptions.ts
@@ -103,7 +103,7 @@ export const saveSubscription = async ({
     unsubscribeHttpUrl,
     unsubscribeMailTo,
     icon,
-    lastFetchedAt: new Date(),
+    refreshedAt: new Date(),
   }
 
   const existingSubscription = await getSubscriptionByName(name, userId)
@@ -199,7 +199,7 @@ export const createSubscription = async (
     newsletterEmail,
     status,
     unsubscribeMailTo,
-    lastFetchedAt: new Date(),
+    refreshedAt: new Date(),
     type: subscriptionType,
     url,
   })

--- a/packages/api/src/services/update_subscription.ts
+++ b/packages/api/src/services/update_subscription.ts
@@ -25,6 +25,7 @@ type UpdateSubscriptionData = {
   scheduledAt?: Date | null
   status?: SubscriptionStatus | null
   refreshedAt?: Date | null
+  failedAt?: Date | null
 }
 
 export const updateSubscription = async (
@@ -44,13 +45,14 @@ export const updateSubscription = async (
     lastFetchedChecksum: newData.lastFetchedChecksum || undefined,
     status: newData.status || undefined,
     scheduledAt: newData.scheduledAt || undefined,
+    failedAt: newData.failedAt || undefined,
     autoAddToLibrary: newData.autoAddToLibrary ?? undefined,
     isPrivate: newData.isPrivate ?? undefined,
     fetchContent: newData.fetchContent ?? undefined,
     folder: newData.folder ?? undefined,
   })
 
-  return await getRepository(Subscription).findOneByOrFail({
+  return await repo.findOneByOrFail({
     id: subscriptionId,
     user: { id: userId },
   })
@@ -70,6 +72,7 @@ export const updateSubscriptions = async (
       lastFetchedChecksum: newData.lastFetchedChecksum || undefined,
       status: newData.status || undefined,
       scheduledAt: newData.scheduledAt || undefined,
+      failedAt: newData.failedAt || undefined,
       autoAddToLibrary: newData.autoAddToLibrary ?? undefined,
       isPrivate: newData.isPrivate ?? undefined,
       fetchContent: newData.fetchContent ?? undefined,

--- a/packages/api/src/services/update_subscription.ts
+++ b/packages/api/src/services/update_subscription.ts
@@ -1,8 +1,4 @@
-import { Subscription } from '../entity/subscription'
-import {
-  SubscriptionStatus,
-  UpdateSubscriptionInput,
-} from '../generated/graphql'
+import { Subscription, SubscriptionStatus } from '../entity/subscription'
 import { getRepository } from '../repository'
 
 const ensureOwns = async (userId: string, subscriptionId: string) => {
@@ -23,11 +19,12 @@ type UpdateSubscriptionData = {
   fetchContent?: boolean | null
   folder?: string | null
   isPrivate?: boolean | null
-  lastFetchedAt?: Date | null
+  mostRecentItemDate?: Date | null
   lastFetchedChecksum?: string | null
   name?: string | null
   scheduledAt?: Date | null
   status?: SubscriptionStatus | null
+  refreshedAt?: Date | null
 }
 
 export const updateSubscription = async (
@@ -42,9 +39,8 @@ export const updateSubscription = async (
     id: subscriptionId,
     name: newData.name || undefined,
     description: newData.description || undefined,
-    lastFetchedAt: newData.lastFetchedAt
-      ? new Date(newData.lastFetchedAt)
-      : undefined,
+    mostRecentItemDate: newData.mostRecentItemDate || undefined,
+    refreshedAt: newData.refreshedAt || undefined,
     lastFetchedChecksum: newData.lastFetchedChecksum || undefined,
     status: newData.status || undefined,
     scheduledAt: newData.scheduledAt

--- a/packages/api/src/services/update_subscription.ts
+++ b/packages/api/src/services/update_subscription.ts
@@ -43,9 +43,7 @@ export const updateSubscription = async (
     refreshedAt: newData.refreshedAt || undefined,
     lastFetchedChecksum: newData.lastFetchedChecksum || undefined,
     status: newData.status || undefined,
-    scheduledAt: newData.scheduledAt
-      ? new Date(newData.scheduledAt)
-      : undefined,
+    scheduledAt: newData.scheduledAt || undefined,
     autoAddToLibrary: newData.autoAddToLibrary ?? undefined,
     isPrivate: newData.isPrivate ?? undefined,
     fetchContent: newData.fetchContent ?? undefined,
@@ -56,4 +54,26 @@ export const updateSubscription = async (
     id: subscriptionId,
     user: { id: userId },
   })
+}
+
+export const updateSubscriptions = async (
+  subscriptionIds: string[],
+  newData: UpdateSubscriptionData
+) => {
+  return getRepository(Subscription).save(
+    subscriptionIds.map((id) => ({
+      id,
+      name: newData.name || undefined,
+      description: newData.description || undefined,
+      mostRecentItemDate: newData.mostRecentItemDate || undefined,
+      refreshedAt: newData.refreshedAt || undefined,
+      lastFetchedChecksum: newData.lastFetchedChecksum || undefined,
+      status: newData.status || undefined,
+      scheduledAt: newData.scheduledAt || undefined,
+      autoAddToLibrary: newData.autoAddToLibrary ?? undefined,
+      isPrivate: newData.isPrivate ?? undefined,
+      fetchContent: newData.fetchContent ?? undefined,
+      folder: newData.folder ?? undefined,
+    }))
+  )
 }

--- a/packages/db/migrations/0159.do.alter_subscriptions.sql
+++ b/packages/db/migrations/0159.do.alter_subscriptions.sql
@@ -1,0 +1,19 @@
+-- Type: DO
+-- Name: alter_subscriptions
+-- Description: Alter omnivore.subscriptions table to add a new state and date column
+
+BEGIN;
+
+ALTER TYPE subscription_status_type
+    ADD VALUE IF NOT EXISTS 'REFRESH_ERROR';
+
+ALTER TABLE omnivore.subscriptions
+    ADD COLUMN refreshed_at timestamptz;
+UPDATE omnivore.subscriptions
+    SET refreshed_at = last_fetched_at
+    WHERE last_fetched_at IS NOT NULL;
+
+ALTER TABLE omnivore.subscriptions
+    RENAME COLUMN last_fetched_at TO most_recent_item_date;
+
+COMMIT;

--- a/packages/db/migrations/0159.do.alter_subscriptions.sql
+++ b/packages/db/migrations/0159.do.alter_subscriptions.sql
@@ -4,10 +4,8 @@
 
 BEGIN;
 
-ALTER TYPE subscription_status_type
-    ADD VALUE IF NOT EXISTS 'REFRESH_ERROR';
-
 ALTER TABLE omnivore.subscriptions
+    ADD COLUMN failed_at timestamptz,
     ADD COLUMN refreshed_at timestamptz;
 UPDATE omnivore.subscriptions
     SET refreshed_at = last_fetched_at

--- a/packages/db/migrations/0159.undo.alter_subscriptions.sql
+++ b/packages/db/migrations/0159.undo.alter_subscriptions.sql
@@ -8,6 +8,7 @@ ALTER TABLE omnivore.subscriptions
     RENAME COLUMN most_recent_item_date TO last_fetched_at;
 
 ALTER TABLE omnivore.subscriptions
+    DROP COLUMN failed_at,
     DROP COLUMN refreshed_at;
 
 COMMIT;

--- a/packages/db/migrations/0159.undo.alter_subscriptions.sql
+++ b/packages/db/migrations/0159.undo.alter_subscriptions.sql
@@ -1,0 +1,13 @@
+-- Type: UNDO
+-- Name: alter_subscriptions
+-- Description: Alter omnivore.subscriptions table to add a new state and date column
+
+BEGIN;
+
+ALTER TABLE omnivore.subscriptions
+    RENAME COLUMN most_recent_item_date TO last_fetched_at;
+
+ALTER TABLE omnivore.subscriptions
+    DROP COLUMN refreshed_at;
+
+COMMIT;

--- a/packages/rss-handler/test/index.test.ts
+++ b/packages/rss-handler/test/index.test.ts
@@ -7,17 +7,17 @@ describe('isOldItem', () => {
     const item = {
       pubDate: '2020-01-01',
     } as RssFeedItem
-    const lastFetchedAt = Date.now()
+    const mostRecentItemTimestamp = Date.now()
 
-    expect(isOldItem(item, lastFetchedAt)).to.be.true
+    expect(isOldItem(item, mostRecentItemTimestamp)).to.be.true
   })
 
   it('returns true if item was published at the last fetched time', () => {
-    const lastFetchedAt = Date.now()
+    const mostRecentItemTimestamp = Date.now()
     const item = {
-      pubDate: new Date(lastFetchedAt).toISOString(),
+      pubDate: new Date(mostRecentItemTimestamp).toISOString(),
     } as RssFeedItem
 
-    expect(isOldItem(item, lastFetchedAt)).to.be.true
+    expect(isOldItem(item, mostRecentItemTimestamp)).to.be.true
   })
 })


### PR DESCRIPTION
- add REFRESH_ERROR to the status of subscriptions and add a new column refreshed_at
- add refreshedAt to the gql schema
- update refreshed_at when feed is processed
- mark subscription as error if item was failed
- validate feed item url and convert relative url to absolute url
- get active user subscriptions only
