### PR TITLE
Fix Main Thread Violation - Google Sign In

### DIFF
--- a/apple/OmnivoreKit/Sources/App/Views/Registration/RegistrationView.swift
+++ b/apple/OmnivoreKit/Sources/App/Views/Registration/RegistrationView.swift
@@ -59,7 +59,8 @@ import Views
   }
 
   func handleGoogleAuth(authenticator: Authenticator) async {
-    let googleAuthResponse = await authenticator.handleGoogleAuth()
+    let presentingVC = presentingViewController()
+    let googleAuthResponse = await authenticator.handleGoogleAuth(presentingVC: presentingVC)
 
     switch googleAuthResponse {
     case let .loginError(error):
@@ -70,4 +71,16 @@ import Views
       break
     }
   }
+}
+
+@MainActor private func presentingViewController() -> PlatformViewController? {
+  #if os(iOS)
+    let scene = UIApplication.shared.connectedScenes.first as? UIWindowScene
+    return scene?.windows
+      .filter(\.isKeyWindow)
+      .first?
+      .rootViewController
+  #elseif os(macOS)
+    return NSApplication.shared.windows.first
+  #endif
 }

--- a/apple/OmnivoreKit/Sources/Services/Authentication/GoogleAuth.swift
+++ b/apple/OmnivoreKit/Sources/Services/Authentication/GoogleAuth.swift
@@ -10,9 +10,9 @@ public enum GoogleAuthResponse {
 }
 
 extension Authenticator {
-  public func handleGoogleAuth() async -> GoogleAuthResponse {
+  public func handleGoogleAuth(presentingVC: PlatformViewController?) async -> GoogleAuthResponse {
     let idToken = await withCheckedContinuation { continuation in
-      googleSignIn { continuation.resume(returning: $0) }
+      googleSignIn(presenting: presentingVC) { continuation.resume(returning: $0) }
     }
 
     guard let idToken = idToken else { return .loginError(error: .unauthorized) }
@@ -50,13 +50,7 @@ extension Authenticator {
     }
   }
 
-  func googleSignIn(completion: @escaping (String?) -> Void) {
-    #if os(iOS)
-      let presenting = presentingViewController()
-    #else
-      let presenting = NSApplication.shared.windows.first
-    #endif
-
+  func googleSignIn(presenting: PlatformViewController?, completion: @escaping (String?) -> Void) {
     guard let presenting = presenting else {
       completion(nil)
       return
@@ -81,16 +75,4 @@ extension Authenticator {
       }
     }
   }
-}
-
-private func presentingViewController() -> PlatformViewController? {
-  #if os(iOS)
-    let scene = UIApplication.shared.connectedScenes.first as? UIWindowScene
-    return scene?.windows
-      .filter(\.isKeyWindow)
-      .first?
-      .rootViewController
-  #elseif os(macOS)
-    return nil
-  #endif
 }


### PR DESCRIPTION
Today in PR's nobody asked for: fixing a threading violation I added years ago 😬 

I kept crashing while trying to sign in to an iPad simulator. Turns out we're introspecting on views from a background thread. This fixes it (sort of) by passing in the vc reference. 

Still getting a warning from the main thread checker but it's coming from Google's SDK. Two warnings now instead of seven so hopefully less likely to crash.