### PR TITLE
Prevent add label if press enter in composition session

### DIFF
--- a/pkg/extension/src/scripts/content/toast.js
+++ b/pkg/extension/src/scripts/content/toast.js
@@ -575,7 +575,7 @@
       }
       case 'enter': {
         if (event.target.id == 'omnivore-edit-label-input') {
-          if (event.target.value) {
+          if (event.target.value && !event.isComposing) {
             const labelList = event.target.form.querySelector('#label-list')
             addLabel(labelList, event.target, event.target.value)
           }


### PR DESCRIPTION
Thank you for this fantastic app!

As a user from Japan, I came across an issue where a label was erroneously being created upon pressing the 'Enter' key to confirm Japanese Kanji conversion during the label addition process. I have resolved this problem.

ref: https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/isComposing

![CleanShot 2024-01-31 at 13 43 43](https://github.com/omnivore-app/omnivore/assets/11070996/fd8acb24-2a72-4dc3-807d-a02e4605ea05)


