### PR TITLE
fix: update-label job uses too much cpu

### DIFF
--- a/packages/api/src/jobs/update_db.ts
+++ b/packages/api/src/jobs/update_db.ts
@@ -17,16 +17,15 @@ export const updateLabels = async (data: UpdateLabelsData) => {
   return authTrx(
     async (tx) =>
       tx.query(
-        `WITH labels_agg AS (
-          SELECT array_agg(DISTINCT l.name) AS names_agg
-          FROM omnivore.labels l
-          INNER JOIN omnivore.entity_labels el ON el.label_id = l.id 
-          LEFT JOIN omnivore.highlight h ON h.id = el.highlight_id 
-          WHERE el.library_item_id = $1 OR h.library_item_id = $1
-        )
-        UPDATE omnivore.library_item li
-        SET label_names = COALESCE((SELECT names_agg FROM labels_agg), ARRAY[]::TEXT[])
-        WHERE li.id = $1`,
+        `UPDATE omnivore.library_item
+          SET label_names = COALESCE((
+            SELECT array_agg(DISTINCT l.name)
+            FROM omnivore.labels l
+            INNER JOIN omnivore.entity_labels el
+              ON el.label_id = l.id
+              AND el.library_item_id = $1
+          ), ARRAY[]::TEXT[])
+          WHERE id = $1`,
         [data.libraryItemId]
       ),
     undefined,
@@ -38,14 +37,13 @@ export const updateHighlight = async (data: UpdateHighlightData) => {
   return authTrx(
     async (tx) =>
       tx.query(
-        `WITH highlight_agg AS (
-          SELECT array_agg(COALESCE(annotation, '')) AS annotation_agg
-          FROM omnivore.highlight
-          WHERE library_item_id = $1
-        )
-        UPDATE omnivore.library_item
-        SET highlight_annotations = COALESCE((SELECT annotation_agg FROM highlight_agg), ARRAY[]::TEXT[])
-        WHERE id = $1`,
+        `UPDATE omnivore.library_item
+          SET highlight_annotations = COALESCE((
+            SELECT array_agg(COALESCE(annotation, ''))
+            FROM omnivore.highlight
+            WHERE library_item_id = $1
+          ), ARRAY[]::TEXT[])
+          WHERE id = $1`,
         [data.libraryItemId]
       ),
     undefined,

--- a/packages/api/src/utils/createTask.ts
+++ b/packages/api/src/utils/createTask.ts
@@ -680,7 +680,7 @@ export const bulkEnqueueUpdateLabels = async (data: UpdateLabelsData[]) => {
     data: d,
     opts: {
       attempts: 3,
-      priority: 5,
+      priority: 1,
       backoff: {
         type: 'exponential',
         delay: 1000,
@@ -705,7 +705,7 @@ export const enqueueUpdateHighlight = async (data: UpdateHighlightData) => {
   try {
     return queue.add(UPDATE_HIGHLIGHT_JOB, data, {
       attempts: 3,
-      priority: 5,
+      priority: 1,
       backoff: {
         type: 'exponential',
         delay: 1000,

--- a/packages/api/src/utils/createTask.ts
+++ b/packages/api/src/utils/createTask.ts
@@ -679,7 +679,12 @@ export const bulkEnqueueUpdateLabels = async (data: UpdateLabelsData[]) => {
     name: UPDATE_LABELS_JOB,
     data: d,
     opts: {
-      priority: 1,
+      attempts: 3,
+      priority: 5,
+      backoff: {
+        type: 'exponential',
+        delay: 1000,
+      },
     },
   }))
 
@@ -699,7 +704,12 @@ export const enqueueUpdateHighlight = async (data: UpdateHighlightData) => {
 
   try {
     return queue.add(UPDATE_HIGHLIGHT_JOB, data, {
-      priority: 1,
+      attempts: 3,
+      priority: 5,
+      backoff: {
+        type: 'exponential',
+        delay: 1000,
+      },
     })
   } catch (error) {
     logger.error('error enqueuing update highlight job', error)


### PR DESCRIPTION
- remove the inner join with highlights table in the sql of update-label job
- change the update-db job priority to 5 and use exponential backoff strategy for retrying
