### PR TITLE
Only sync reading times if they are more than a minute old

### DIFF
--- a/packages/api/src/data_source.ts
+++ b/packages/api/src/data_source.ts
@@ -18,4 +18,7 @@ export const appDataSource = new DataSource({
   logger: new CustomTypeOrmLogger(['query', 'info']),
   connectTimeoutMS: 40000, // 40 seconds
   maxQueryExecutionTime: 10000, // 10 seconds
+  extra: {
+    options: process.env.PG_EXTRA_OPTIONS,
+  },
 })

--- a/packages/api/src/jobs/sync_read_positions.ts
+++ b/packages/api/src/jobs/sync_read_positions.ts
@@ -25,6 +25,14 @@ async function* getSyncUpdatesIterator(redis: Redis) {
   return
 }
 
+const isMoreThan60SecondsOld = (iso8601String: string): boolean => {
+  const currentTime = new Date()
+  const parsedDate = new Date(iso8601String)
+  const timeDifferenceInSeconds =
+    (currentTime.getTime() - parsedDate.getTime()) / 1000
+  return timeDifferenceInSeconds > 60
+}
+
 const syncReadPosition = async (cacheKey: string) => {
   const components = componentsForCachedReadingPositionKey(cacheKey)
   const positions = components
@@ -37,7 +45,9 @@ const syncReadPosition = async (cacheKey: string) => {
     components &&
     positions &&
     positions.positionItems &&
-    positions.positionItems.length > 0
+    positions.positionItems.length > 0 &&
+    positions.positionItems[0].updatedAt &&
+    isMoreThan60SecondsOld(positions.positionItems[0].updatedAt)
   ) {
     const position = reduceCachedReadingPositionMembers(
       components.uid,


### PR DESCRIPTION
this should hopefully reduce contention with other rules running
