### PR TITLE
Remove Elasticsearch dependency for self-hosted instances

### DIFF
--- a/self-hosting/helm/README.md
+++ b/self-hosting/helm/README.md
@@ -4,9 +4,9 @@ Helm chart to self-host Omnivore.
 
 ## Notes and General Information
 
-This helm chart uses docker images from [`sejaeger/omnivore-*`](https://hub.docker.com/u/sejaeger). If you want to use the Web-UI or build your own images, checkout `../.build-and-push-images.sh`. You will find some hard-coded environment variables (e.g., `PG_DB` or `PG_USER`), please don't change them! Those are also hard-coded in the code base and changing them will likely cause problems. Please have a look at [the values file](values.yaml) and [change it accordingly](https://github.com/bjw-s/helm-charts/blob/main/charts/library/common/values.yaml) to your setup, especially: postgres hostname, elasticsearch URL, omnivore URL.
+This helm chart uses docker images from [`sejaeger/omnivore-*`](https://hub.docker.com/u/sejaeger). If you want to use the Web-UI or build your own images, checkout `../.build-and-push-images.sh`. You will find some hard-coded environment variables (e.g., `PG_DB` or `PG_USER`), please don't change them! Those are also hard-coded in the code base and changing them will likely cause problems. Please have a look at [the values file](values.yaml) and [change it accordingly](https://github.com/bjw-s/helm-charts/blob/main/charts/library/common/values.yaml) to your setup, especially: postgres hostname, omnivore URL.
 
-Omnivore requires Postgres (+vector extension!) and Elasticsearch to store its information. Please make sure to have them up and running. Using the bitnami Helm charts works perfectly fine. However, for Postgres you need to use a custom built image that contains the vector extension: [See this descriptions](https://github.com/pgvector/pgvector/issues/126#issuecomment-1589203644) for more information or simply use `sejaeger/postgres-vector` from docker hub.
+Omnivore requires Postgres (+vector extension!) to store its information. Please make sure to have it up and running. Using the bitnami Helm charts works perfectly fine but you need to use a custom built image that contains the vector extension: [See this descriptions](https://github.com/pgvector/pgvector/issues/126#issuecomment-1589203644) for more information or simply use `sejaeger/postgres-vector` from docker hub.
 
 This setup uses a couple of secrets to safely store passwords, tokens and private information. It's your responsibility to generate them and create the following secretes accordingly. 
 
@@ -21,8 +21,6 @@ This setup uses a couple of secrets to safely store passwords, tokens and privat
 * postgres-admin-user-and-password
     * PGPASSWORD
     * POSTGRES_USER
-* elasticsearch-auth-secret
-    * ES_PASSWORD
 * omnivore-content-fetch-verification-token
     * VERIFICATION_TOKEN
 

--- a/self-hosting/helm/values.yaml
+++ b/self-hosting/helm/values.yaml
@@ -9,7 +9,7 @@ controllers:
       api:
         image:
           repository: sejaeger/omnivore-api
-          tag: e44616b01
+          tag: 150444efb
           pullPolicy: IfNotPresent
         env:
           API_ENV: local
@@ -20,8 +20,6 @@ controllers:
           PG_POOL_MAX: 20
           CLIENT_URL: https://omnivore.example.com # URL any client can use to reach the server
           GATEWAY_URL: http://omnivore-api:8080/api
-          ES_URL: http://elasticsearch.elasticsearch.svc.cluster.local:9200
-          ES_USERNAME: elastic
           CONTENT_FETCH_URL: http://omnivore-content-fetch:8080/?token=$(VERIFICATION_TOKEN)
         envFrom:
           - secretRef:
@@ -33,14 +31,12 @@ controllers:
           - secretRef:
               name: omnivore-pg-password
           - secretRef:
-              name: elasticsearch-auth-secret
-          - secretRef:
               name: omnivore-content-fetch-verification-token
     initContainers:
       migrate:
         image:
           repository: sejaeger/omnivore-migrate
-          tag: e44616b01
+          tag: 150444efb
           pullPolicy: IfNotPresent
         command: ["/bin/sh", "-c", "--"]
         args: ["./packages/db/setup.sh"]
@@ -66,7 +62,7 @@ controllers:
       web:
         image:
           repository: sejaeger/omnivore-web
-          tag: e44616b01
+          tag: 150444efb
           pullPolicy: IfNotPresent
 
   content-fetch:

--- a/self-hosting/helm/values.yaml
+++ b/self-hosting/helm/values.yaml
@@ -4,7 +4,7 @@ controllers:
   api:
     enabled: true
     type: deployment
-    strategy: Recreate
+    strategy: RollingUpdate
     containers:
       api:
         image:
@@ -57,7 +57,7 @@ controllers:
   web:
     enabled: true
     type: deployment
-    strategy: Recreate
+    strategy: RollingUpdate
     containers:
       web:
         image:
@@ -68,7 +68,7 @@ controllers:
   content-fetch:
     enabled: true
     type: deployment
-    strategy: Recreate
+    strategy: RollingUpdate
     containers:
       content-fetch:
         image:


### PR DESCRIPTION
Accordingly to [this comment](https://github.com/omnivore-app/omnivore/issues/25#issuecomment-1943402621), this PR updates the Kubernetes pods and removes the elasticsearch dependency.

Additionally, we now use the `RollingUpdate` strategy instead of `Recreate`.