### PR TITLE
Allow overflow on grid cards, clear pointer events from dropdowns after triggered

### DIFF
--- a/packages/web/components/templates/homeFeed/HomeFeedContainer.tsx
+++ b/packages/web/components/templates/homeFeed/HomeFeedContainer.tsx
@@ -1265,7 +1265,7 @@ function LibraryItems(props: LibraryItemsProps): JSX.Element {
         marginBottom: '0px',
         paddingTop: '0',
         paddingBottom: '0px',
-        overflow: 'hidden',
+        overflow: 'visible',
         '@media (max-width: 930px)': {
           gridGap: props.layout == 'LIST_LAYOUT' ? '0px' : '20px',
         },
@@ -1345,6 +1345,7 @@ function LibraryItems(props: LibraryItemsProps): JSX.Element {
                 } else {
                   props.actionHandler(action, linkedItem)
                 }
+                document.body.style.removeProperty('pointer-events')
               }}
             />
           )}

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -51,7 +51,6 @@
     "pspdfkit": "^2023.4.6",
     "react": "^18.2.0",
     "react-color": "^2.19.3",
-    "react-colorful": "^5.5.1",
     "react-dom": "^18.2.0",
     "react-dropzone": "^14.2.3",
     "react-hot-toast": "^2.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -25914,7 +25914,7 @@ react-color@^2.19.3:
     reactcss "^1.2.0"
     tinycolor2 "^1.4.1"
 
-react-colorful@^5.1.2, react-colorful@^5.5.1:
+react-colorful@^5.1.2:
   version "5.5.1"
   resolved "https://registry.yarnpkg.com/react-colorful/-/react-colorful-5.5.1.tgz#29d9c4e496f2ca784dd2bb5053a3a4340cfaf784"
   integrity sha512-M1TJH2X3RXEt12sWkpa6hLc/bbYS0H6F4rIqjQZ+RxNBstpY67d9TrFXtqdZwhpmBXcCwEi7stKqFue3ZRkiOg==


### PR DESCRIPTION
The pointer events from radix are not cleared if a modal is opened
from a dropdown, so we manually clear them here.
