### PR TITLE
Remove ad_id permission on Android

### DIFF
--- a/android/Omnivore/app/src/main/AndroidManifest.xml
+++ b/android/Omnivore/app/src/main/AndroidManifest.xml
@@ -4,7 +4,6 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
-    <uses-permission android:name="com.google.android.gms.permission.AD_ID"/>
     <uses-permission android:name="android.permission.WAKE_LOCK" />
 
     <application


### PR DESCRIPTION
Need to do a bit more testing to see if this breaks anything,
but I don't see any packages we include that need it.
