### PR TITLE
Fix iOS Build: add prefixes & arg apparently dropped in #3812

### DIFF
--- a/apple/OmnivoreKit/Sources/App/Views/AI/FullScreenDigestView.swift
+++ b/apple/OmnivoreKit/Sources/App/Views/AI/FullScreenDigestView.swift
@@ -39,7 +39,7 @@ struct DigestAudioItem: AudioItemProperties {
 @available(iOS 17.0, *)
 @MainActor
 struct FullScreenDigestView: View {
-  let viewModel: DigestViewModel = DigestViewModel()
+  let viewModel: FullScreenDigestViewModel = FullScreenDigestViewModel()
   let dataService: DataService
   let audioController: AudioController
 

--- a/apple/OmnivoreKit/Sources/App/Views/LibraryTabView.swift
+++ b/apple/OmnivoreKit/Sources/App/Views/LibraryTabView.swift
@@ -135,7 +135,7 @@ struct LibraryTabView: View {
 
         if showDigest, #available(iOS 17.0, *) {
           NavigationView {
-            DigestView(dataService: dataService)
+            FullScreenDigestView(dataService: dataService, audioController: audioController)
               .navigationBarTitleDisplayMode(.inline)
               .navigationViewStyle(.stack)
           }.tag("digest")


### PR DESCRIPTION
It builds now; can't speak to correctness

--- 

https://github.com/omnivore-app/omnivore/pull/3812#issuecomment-2067772397 :

> ![CleanShot 2024-04-20 at 14 14 38@2x](https://github.com/omnivore-app/omnivore/assets/43136/1a18b50d-ab79-4d68-8cf9-aaad202fc985)
> 
> It seems like some files have gone missing? (unless they are supposed to autogen somehow in which case config is missing?)
> 
> At least:
> - `DigestViewModel`
> - `DigestView`
> 
> (and when I backed up before 47150c29913ecece27a755509815eecc8642bd17, `ExplainView` but it seems like that got factored out?
> 
> Built okay at e30fa13a2e5ef4581827e0bb0623f75d1c8b81a0 )