### PR TITLE
Android: add reader preference for using volume rocker to scroll

### DIFF
--- a/android/Omnivore/app/src/main/java/app/omnivore/omnivore/feature/reader/ReaderPreferencesView.kt
+++ b/android/Omnivore/app/src/main/java/app/omnivore/omnivore/feature/reader/ReaderPreferencesView.kt
@@ -43,6 +43,8 @@ fun ReaderPreferencesView(webReaderViewModel: WebReaderViewModel) {
 
   val themeState = remember { mutableStateOf(currentWebPreferences.storedThemePreference) }
 
+  val volumeForScrollState = remember { mutableStateOf(currentWebPreferences.shouldUseVolumeRockerForScroll) }
+
   OmnivoreTheme {
   Column(
     modifier = Modifier
@@ -239,6 +241,24 @@ fun ReaderPreferencesView(webReaderViewModel: WebReaderViewModel) {
         }
       )
     }
+
+    Row(verticalAlignment = Alignment.CenterVertically) {
+      Text(
+        stringResource(R.string.reader_preferences_view_volume_scroll),
+        style = TextStyle(
+          fontSize = 15.sp,
+          fontWeight = FontWeight.Normal,
+          color = Color(red = 137, green = 137, blue = 137))
+      )
+      Spacer(modifier = Modifier.weight(1.0F))
+      Switch (
+          checked = volumeForScrollState.value,
+          onCheckedChange = {
+            volumeForScrollState.value = it
+            webReaderViewModel.updateVolumeRockerForScroll(it)
+          }
+      )
+    }
   }
 }
 }
@@ -285,5 +305,6 @@ data class WebPreferences(
   val storedThemePreference: String,
   val fontFamily: WebFont,
   val prefersHighContrastText: Boolean,
-  val prefersJustifyText: Boolean
+  val prefersJustifyText: Boolean,
+  var shouldUseVolumeRockerForScroll: Boolean
 )

--- a/android/Omnivore/app/src/main/java/app/omnivore/omnivore/feature/reader/WebReader.kt
+++ b/android/Omnivore/app/src/main/java/app/omnivore/omnivore/feature/reader/WebReader.kt
@@ -170,11 +170,17 @@ fun WebReader(
                     if (event.action == KeyEvent.ACTION_DOWN) {
                         when (keyCode) {
                             KeyEvent.KEYCODE_VOLUME_UP -> {
+                                if (!webReaderViewModel.shouldUseVolumeRockerForScroll) {
+                                    return@setOnKeyListener false
+                                }
                                 scrollVertically(OmnivoreWebView.Direction.UP)
                                 return@setOnKeyListener true
                             }
 
                             KeyEvent.KEYCODE_VOLUME_DOWN -> {
+                                if (!webReaderViewModel.shouldUseVolumeRockerForScroll) {
+                                    return@setOnKeyListener false
+                                }
                                 scrollVertically(OmnivoreWebView.Direction.DOWN)
                                 return@setOnKeyListener true
                             }

--- a/android/Omnivore/app/src/main/java/app/omnivore/omnivore/feature/reader/WebReaderViewModel.kt
+++ b/android/Omnivore/app/src/main/java/app/omnivore/omnivore/feature/reader/WebReaderViewModel.kt
@@ -106,6 +106,8 @@ class WebReaderViewModel @Inject constructor(
     private val showHighlightColorPalette = MutableLiveData(false)
     val highlightColor = MutableLiveData(HighlightColor())
 
+    var shouldUseVolumeRockerForScroll = true
+
     fun loadItem(slug: String?, requestID: String?) {
         this.slug = slug
         if (isLoading || webReaderParamsLiveData.value != null) {
@@ -470,6 +472,7 @@ class WebReaderViewModel @Inject constructor(
         val prefersHighContrastFont =
             datastoreRepo.getString(DatastoreKeys.prefersWebHighContrastText) == "true"
         val prefersJustifyText = datastoreRepo.getString(DatastoreKeys.prefersJustifyText) == "true"
+        val shouldUseVolumeRockerForScroll = datastoreRepo.getString(DatastoreKeys.volumeForScroll) != "false"
 
         WebPreferences(
             textFontSize = storedFontSize ?: 12,
@@ -479,7 +482,8 @@ class WebReaderViewModel @Inject constructor(
             storedThemePreference = storedThemePreference,
             fontFamily = storedWebFont,
             prefersHighContrastText = prefersHighContrastFont,
-            prefersJustifyText = prefersJustifyText
+            prefersJustifyText = prefersJustifyText,
+            shouldUseVolumeRockerForScroll = shouldUseVolumeRockerForScroll
         )
     }
 
@@ -553,6 +557,13 @@ class WebReaderViewModel @Inject constructor(
         val script =
             "var event = new Event('updateJustifyText');event.justifyText = $justifyText;document.dispatchEvent(event);"
         enqueueScript(script)
+    }
+
+    fun updateVolumeRockerForScroll(shouldUseVolumeRockerForScroll: Boolean) {
+        runBlocking {
+            datastoreRepo.putString(DatastoreKeys.volumeForScroll, shouldUseVolumeRockerForScroll.toString())
+        }
+        this.shouldUseVolumeRockerForScroll = shouldUseVolumeRockerForScroll
     }
 
     fun applyWebFont(font: WebFont) {

--- a/android/Omnivore/app/src/main/java/app/omnivore/omnivore/utils/Constants.kt
+++ b/android/Omnivore/app/src/main/java/app/omnivore/omnivore/utils/Constants.kt
@@ -23,6 +23,7 @@ object DatastoreKeys {
   const val lastUsedSavedItemFilter = "lastUsedSavedItemFilter"
   const val lastUsedSavedItemSortFilter = "lastUsedSavedItemSortFilter"
   const val preferredTheme = "preferredTheme"
+  const val volumeForScroll = "volumeForScroll"
 }
 
 object AppleConstants {

--- a/android/Omnivore/app/src/main/res/values-de/strings.xml
+++ b/android/Omnivore/app/src/main/res/values-de/strings.xml
@@ -148,6 +148,7 @@
     <string name="reader_preferences_view_justify_text">Text ausrichten</string>
 
     <!-- WebReaderLoadingContainer -->
+    <string name="reader_preferences_view_volume_scroll">Verwenden Sie die Lautstärketasten zum Scrollen</string>
     <string name="web_reader_loading_container_error_msg">Wir konnten deinen Inhalt nicht abrufen.</string>
     <string name="web_reader_loading_container_bottom_sheet_reader_preferences">Lese-Einstellungen</string>
     <string name="web_reader_loading_container_bottom_sheet_notebook">Notizbuch</string>

--- a/android/Omnivore/app/src/main/res/values-zh-rCN/strings.xml
+++ b/android/Omnivore/app/src/main/res/values-zh-rCN/strings.xml
@@ -149,6 +149,7 @@
     <string name="reader_preferences_view_justify_text">对齐文字</string>
 
     <!-- WebReaderLoadingContainer -->
+    <string name="reader_preferences_view_volume_scroll">使用音量按钮滚动</string>
     <string name="web_reader_loading_container_error_msg">我们无法取得您的内容。</string>
     <string name="web_reader_loading_container_bottom_sheet_reader_preferences">阅读器偏好设定</string>
     <string name="web_reader_loading_container_bottom_sheet_notebook">笔记</string>

--- a/android/Omnivore/app/src/main/res/values-zh-rTW/strings.xml
+++ b/android/Omnivore/app/src/main/res/values-zh-rTW/strings.xml
@@ -148,6 +148,7 @@
     <string name="reader_preferences_view_justify_text">對齊文字</string>
 
     <!-- WebReaderLoadingContainer -->
+    <string name="reader_preferences_view_volume_scroll">使用音量按鈕捲動</string>
     <string name="web_reader_loading_container_error_msg">我們無法取得您的內容。</string>
     <string name="web_reader_loading_container_bottom_sheet_reader_preferences">閱讀器偏好設定</string>
     <string name="web_reader_loading_container_bottom_sheet_notebook">筆記本</string>

--- a/android/Omnivore/app/src/main/res/values/strings.xml
+++ b/android/Omnivore/app/src/main/res/values/strings.xml
@@ -148,6 +148,7 @@
     <string name="reader_preferences_view_auto">Auto</string>
     <string name="reader_preferences_view_high_constrast_text">High Contrast Text</string>
     <string name="reader_preferences_view_justify_text">Justify Text</string>
+    <string name="reader_preferences_view_volume_scroll">Use Volume Rocker to scroll</string>
 
     <!-- WebReaderLoadingContainer -->
     <string name="web_reader_loading_container_error_msg">We were unable to fetch your content.</string>


### PR DESCRIPTION
Currently, using the volume rocker while having the reader open will scroll either up or down instead of adjusting volume. 
Added an option to disable this behaviour in the reader preferences sheet.


https://github.com/omnivore-app/omnivore/assets/9449875/44341ffd-0f03-45dc-a241-a949cc9fd26e

