### PR TITLE
fix/digest

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -22,6 +22,7 @@
     "@google-cloud/storage": "^7.0.1",
     "@google-cloud/tasks": "^4.0.0",
     "@graphql-tools/utils": "^9.1.1",
+    "@langchain/anthropic": "^0.1.16",
     "@langchain/openai": "^0.0.14",
     "@notionhq/client": "^2.2.14",
     "@omnivore/content-handler": "1.0.0",

--- a/packages/api/src/jobs/ai/create_digest.ts
+++ b/packages/api/src/jobs/ai/create_digest.ts
@@ -419,7 +419,9 @@ const generateSpeechFiles = (
 // basic checks to make sure the summaries are good.
 const filterSummaries = (summaries: RankedItem[]): RankedItem[] => {
   return summaries.filter(
-    (item) => item.summary.length < item.libraryItem.readableContent.length
+    (item) =>
+      item.summary.length > 200 ||
+      item.summary.length < item.libraryItem.readableContent.length
   )
 }
 

--- a/packages/api/src/jobs/ai/create_digest.ts
+++ b/packages/api/src/jobs/ai/create_digest.ts
@@ -113,18 +113,17 @@ const getPreferencesList = async (userId: string): Promise<LibraryItem[]> => {
   //   reason: "some older items that were interacted with"
 
   const preferences = await Promise.all(
-    digestDefinition.preferenceSelectors.map(async (selector) => {
-      // use the selector to fetch items
-      const results = await searchLibraryItems(
-        {
-          query: selector.query,
-          size: selector.count,
-        },
-        userId
-      )
-
-      return results.libraryItems
-    })
+    digestDefinition.preferenceSelectors.map(
+      async (selector) =>
+        // use the selector to fetch items
+        await searchLibraryItems(
+          {
+            query: selector.query,
+            size: selector.count,
+          },
+          userId
+        )
+    )
   )
 
   // deduplicate and flatten the items
@@ -160,21 +159,20 @@ const getCandidatesList = async (
   logger.info('existingCandidateIds: ', { existingCandidateIds })
 
   const candidates = await Promise.all(
-    digestDefinition.candidateSelectors.map(async (selector) => {
-      // use the selector to fetch items
-      const results = await searchLibraryItems(
-        {
-          includeContent: true,
-          query: existingCandidateIds
-            ? `(${selector.query}) -includes:${existingCandidateIds}` // exclude the existing candidates
-            : selector.query,
-          size: selector.count,
-        },
-        userId
-      )
-
-      return results.libraryItems
-    })
+    digestDefinition.candidateSelectors.map(
+      async (selector) =>
+        // use the selector to fetch items
+        await searchLibraryItems(
+          {
+            includeContent: true,
+            query: existingCandidateIds
+              ? `(${selector.query}) -includes:${existingCandidateIds}` // exclude the existing candidates
+              : selector.query,
+            size: selector.count,
+          },
+          userId
+        )
+    )
   )
 
   // deduplicate and flatten the items

--- a/packages/api/src/jobs/ai/create_digest.ts
+++ b/packages/api/src/jobs/ai/create_digest.ts
@@ -394,27 +394,24 @@ const summarizeItems = async (
   //   }))
   // )
 
-  const summaries = await Promise.all(
+  const prompts = await Promise.all(
     rankedCandidates.map(async (item) => {
       try {
-        const prompt = await contextualTemplate.format({
+        return await contextualTemplate.format({
           title: item.libraryItem.title,
           author: item.libraryItem.author ?? '',
           content: item.libraryItem.readableContent, // markdown content
         })
-
-        logger.info(`summarizeItems prompt: ${prompt}`)
-
-        const summary = await llm.invoke(prompt)
-        logger.info('summarizeItems summary: ', summary)
-
-        return summary
       } catch (error) {
         logger.error('summarizeItems error', error)
-        return { content: '' }
+        return ''
       }
     })
   )
+  logger.info('prompts: ', prompts)
+
+  const summaries = await llm.batch(prompts)
+  logger.info('summaries: ', summaries)
 
   summaries.forEach(
     (summary, index) =>
@@ -521,10 +518,6 @@ export const createDigest = async (jobData: CreateDigestData) => {
       summary: '',
     }))
     const summaries = await summarizeItems(selections)
-    logger.info(
-      'summaries: ',
-      summaries.map((item) => item.summary)
-    )
 
     const filteredSummaries = filterSummaries(summaries)
 

--- a/packages/api/src/jobs/ai/create_digest.ts
+++ b/packages/api/src/jobs/ai/create_digest.ts
@@ -24,7 +24,7 @@ import { sendMulticastPushNotifications } from '../../utils/sendNotification'
 
 export type CreateDigestJobSchedule = 'daily' | 'weekly'
 
-export interface CreateDigestJobData {
+export interface CreateDigestData {
   id: string
   userId: string
   voices?: string[]
@@ -434,7 +434,7 @@ const generateByline = (summaries: RankedItem[]): string =>
     .map((item) => item.libraryItem.author)
     .join(', ')
 
-export const createDigestJob = async (jobData: CreateDigestJobData) => {
+export const createDigest = async (jobData: CreateDigestData) => {
   try {
     digestDefinition = await fetchDigestDefinition()
 
@@ -451,12 +451,17 @@ export const createDigestJob = async (jobData: CreateDigestJobData) => {
       })
     }
 
-    const userProfile = await findOrCreateUserProfile(jobData.userId)
-    const rankedCandidates = await rankCandidates(candidates, userProfile)
-    const { finalSelections, rankedTopics } =
-      chooseRankedSelections(rankedCandidates)
+    // const userProfile = await findOrCreateUserProfile(jobData.userId)
+    // const rankedCandidates = await rankCandidates(candidates, userProfile)
+    // const { finalSelections, rankedTopics } =
+    //   chooseRankedSelections(rankedCandidates)
 
-    const summaries = await summarizeItems(finalSelections)
+    const selections = candidates.map((item) => ({
+      topic: '',
+      libraryItem: item,
+      summary: '',
+    }))
+    const summaries = await summarizeItems(selections)
 
     const filteredSummaries = filterSummaries(summaries)
 
@@ -480,7 +485,8 @@ export const createDigestJob = async (jobData: CreateDigestJobData) => {
         wordCount: speechFiles[index].wordCount,
       })),
       createdAt: new Date(),
-      description: generateDescription(summaries, rankedTopics),
+      description: '',
+      // description: generateDescription(summaries, rankedTopics),
       byline: generateByline(summaries),
       urlsToAudio: [],
     }

--- a/packages/api/src/jobs/ai/create_digest.ts
+++ b/packages/api/src/jobs/ai/create_digest.ts
@@ -192,6 +192,8 @@ const getCandidatesList = async (
       readableContent: htmlToMarkdown(item.readableContent),
     })) // convert the html content to markdown
 
+  console.timeEnd('getCandidatesList')
+
   if (dedupedCandidates.length === 0) {
     logger.info('No new candidates found')
 
@@ -210,8 +212,6 @@ const getCandidatesList = async (
   // store the ids in cache
   const candidateIds = selectedCandidates.map((item) => item.id).join(',')
   await redisDataSource.redisClient?.set(key, candidateIds)
-
-  console.timeEnd('getCandidatesList')
 
   return selectedCandidates
 }

--- a/packages/api/src/jobs/ai/create_digest.ts
+++ b/packages/api/src/jobs/ai/create_digest.ts
@@ -403,7 +403,7 @@ const summarizeItems = async (
           content: item.libraryItem.readableContent, // markdown content
         })
 
-        logger.info('summarizeItems prompt: ', prompt)
+        logger.info(`summarizeItems prompt: ${prompt}`)
 
         const summary = await llm.invoke(prompt)
         logger.info('summarizeItems summary: ', summary)

--- a/packages/api/src/jobs/trigger_rule.ts
+++ b/packages/api/src/jobs/trigger_rule.ts
@@ -243,14 +243,13 @@ const triggerActions = async (
     } catch (error) {
       if (error instanceof RequiresSearchQueryError) {
         logger.info('Failed to filter items by metadata, running search query')
-        const searchResult = await searchLibraryItems(
+        results = await searchLibraryItems(
           {
             query: `includes:${data.id} AND (${rule.filter})`,
             size: 1,
           },
           userId
         )
-        results = searchResult.libraryItems
       } else {
         logger.error('Error filtering item events', error)
         await markRuleAsFailed(rule.id, userId)

--- a/packages/api/src/queue-processor.ts
+++ b/packages/api/src/queue-processor.ts
@@ -16,7 +16,7 @@ import { appDataSource } from './data_source'
 import { env } from './env'
 import { TaskState } from './generated/graphql'
 import { aiSummarize, AI_SUMMARIZE_JOB_NAME } from './jobs/ai-summarize'
-import { createDigestJob, CREATE_DIGEST_JOB } from './jobs/ai/create_digest'
+import { createDigest, CREATE_DIGEST_JOB } from './jobs/ai/create_digest'
 import { bulkAction, BULK_ACTION_JOB_NAME } from './jobs/bulk_action'
 import { callWebhook, CALL_WEBHOOK_JOB_NAME } from './jobs/call_webhook'
 import {
@@ -181,7 +181,7 @@ export const createWorker = (connection: ConnectionOptions) =>
         case FORWARD_EMAIL_JOB:
           return forwardEmailJob(job.data)
         case CREATE_DIGEST_JOB:
-          return createDigestJob(job.data)
+          return createDigest(job.data)
         default:
           logger.warning(`[queue-processor] unhandled job: ${job.name}`)
       }

--- a/packages/api/src/resolvers/article/index.ts
+++ b/packages/api/src/resolvers/article/index.ts
@@ -74,7 +74,7 @@ import {
   countLibraryItems,
   createOrUpdateLibraryItem,
   findLibraryItemsByPrefix,
-  searchLibraryItems,
+  searchAndCountLibraryItems,
   softDeleteLibraryItem,
   sortParamsToSort,
   updateLibraryItem,
@@ -675,7 +675,7 @@ export const searchResolver = authorized<
     return { errorCodes: [SearchErrorCode.QueryTooLong] }
   }
 
-  const { libraryItems, count } = await searchLibraryItems(
+  const { libraryItems, count } = await searchAndCountLibraryItems(
     {
       from: Number(startCursor),
       size: first + 1, // fetch one more item to get next cursor
@@ -752,7 +752,7 @@ export const updatesSinceResolver = authorized<
     folder ? ' in:' + folder : ''
   } sort:${sort.by}-${sort.order}`
 
-  const { libraryItems, count } = await searchLibraryItems(
+  const { libraryItems, count } = await searchAndCountLibraryItems(
     {
       from: Number(startCursor),
       size: size + 1, // fetch one more item to get next cursor

--- a/packages/api/src/routers/digest_router.ts
+++ b/packages/api/src/routers/digest_router.ts
@@ -66,12 +66,6 @@ export function digestRouter() {
     }
 
     try {
-      const user = await findActiveUser(userId)
-      if (!user) {
-        logger.info(`User not found: ${userId}`)
-        return res.sendStatus(401)
-      }
-
       const feature = await findGrantedFeatureByName(
         FeatureName.AIDigest,
         userId
@@ -131,12 +125,6 @@ export function digestRouter() {
     }
 
     try {
-      const user = await findActiveUser(userId)
-      if (!user) {
-        logger.info(`User not found: ${userId}`)
-        return res.sendStatus(401)
-      }
-
       const feature = await findGrantedFeatureByName(
         FeatureName.AIDigest,
         userId

--- a/packages/api/src/routers/digest_router.ts
+++ b/packages/api/src/routers/digest_router.ts
@@ -1,6 +1,5 @@
 import cors from 'cors'
 import express from 'express'
-import { v4 as uuid } from 'uuid'
 import { env } from '../env'
 import { TaskState } from '../generated/graphql'
 import { CreateDigestJobSchedule } from '../jobs/ai/create_digest'
@@ -89,9 +88,11 @@ export function digestRouter() {
       // enqueue job and return job id
       const result = await enqueueCreateDigest(
         {
-          id: uuid(), // generate job id
           userId,
-          ...data,
+          voices: data.voices,
+          language: data.language,
+          rate: data.rate,
+          libraryItemIds: data.libraryItemIds,
         },
         data.schedule
       )

--- a/packages/api/src/utils/createTask.ts
+++ b/packages/api/src/utils/createTask.ts
@@ -18,7 +18,7 @@ import {
 } from '../generated/graphql'
 import { AISummarizeJobData, AI_SUMMARIZE_JOB_NAME } from '../jobs/ai-summarize'
 import {
-  CreateDigestJobData,
+  CreateDigestData,
   CreateDigestJobResponse,
   CreateDigestJobSchedule,
   CREATE_DIGEST_JOB,
@@ -856,7 +856,7 @@ export const enqueueSendEmail = async (jobData: SendEmailJobData) => {
 }
 
 export const enqueueCreateDigest = async (
-  data: CreateDigestJobData,
+  data: CreateDigestData,
   schedule?: CreateDigestJobSchedule
 ): Promise<CreateDigestJobResponse> => {
   const queue = await getBackendQueue()

--- a/packages/api/test/routers/auth.test.ts
+++ b/packages/api/test/routers/auth.test.ts
@@ -6,7 +6,7 @@ import { userRepository } from '../../src/repository/user'
 import { isValidSignupRequest } from '../../src/routers/auth/auth_router'
 import { AuthProvider } from '../../src/routers/auth/auth_types'
 import { createPendingUserToken } from '../../src/routers/auth/jwt_helpers'
-import { searchLibraryItems } from '../../src/services/library_item'
+import { searchAndCountLibraryItems } from '../../src/services/library_item'
 import { deleteUser, updateUser } from '../../src/services/user'
 import {
   comparePassword,
@@ -528,7 +528,7 @@ describe('auth router', () => {
           'web'
         ).expect(200)
         const user = await userRepository.findOneByOrFail({ name })
-        const { count } = await searchLibraryItems(
+        const { count } = await searchAndCountLibraryItems(
           { query: 'in:inbox sort:read-desc is:reading' },
           user.id
         )
@@ -552,7 +552,10 @@ describe('auth router', () => {
           'ios'
         ).expect(200)
         const user = await userRepository.findOneByOrFail({ name })
-        const { count } = await searchLibraryItems({ query: 'in:all' }, user.id)
+        const { count } = await searchAndCountLibraryItems(
+          { query: 'in:all' },
+          user.id
+        )
 
         expect(count).to.eql(4)
       })

--- a/packages/text-to-speech/mocha-config.json
+++ b/packages/text-to-speech/mocha-config.json
@@ -1,4 +1,5 @@
 {
     "extension": ["ts"],
-    "spec": "test/**/*.test.ts"
+    "spec": "test/**/*.test.ts",
+    "timeout": 10000
   }

--- a/packages/text-to-speech/test/htmlToSsml.test.ts
+++ b/packages/text-to-speech/test/htmlToSsml.test.ts
@@ -350,6 +350,41 @@ describe('convert HTML to Speech file', () => {
       options: TEST_OPTIONS,
     })
     expect(speechFile.utterances).to.have.lengthOf(2)
-    expect(speechFile.utterances[1].text).to.eql('McMeekin makes an extended case that Stalin was preparing to attack Nazi Germany when Hitler attacked him, that the two dictators were basically in a race to see who could mobilize to betray the other first — and that the initial Soviet debacle in 1941 happened in part because Stalin was also pushing his military toward an offensive alignment, and they were caught in a "mid-mobilization limbo."')
+    expect(speechFile.utterances[1].text).to.eql(
+      'McMeekin makes an extended case that Stalin was preparing to attack Nazi Germany when Hitler attacked him, that the two dictators were basically in a race to see who could mobilize to betray the other first — and that the initial Soviet debacle in 1941 happened in part because Stalin was also pushing his military toward an offensive alignment, and they were caught in a "mid-mobilization limbo."'
+    )
+  })
+
+  it('skip unwanted elements', () => {
+    const html = `<div class="page" id="readability-page-1" data-omnivore-anchor-idx="1">
+      <p data-omnivore-anchor-idx="2">This is a test.</p>
+      <script data-omnivore-anchor-idx="3">alert('hello');</script>
+      <style data-omnivore-anchor-idx="4">body { color: red; }</style>
+      <iframe data-omnivore-anchor-idx="6" src="https://example.com">test</iframe>
+      <figcaption data-omnivore-anchor-idx="7">test</figcaption>
+      </div>`
+
+    const speechFile = htmlToSpeechFile({
+      content: html,
+      options: TEST_OPTIONS,
+    })
+    expect(speechFile.utterances).to.have.lengthOf(1)
+    expect(speechFile.utterances[0].text).to.eql('This is a test.')
+  })
+
+  it('filters out utterances with only punctuation or whitespace', () => {
+    const html = `<div class="page" id="readability-page-1" data-omnivore-anchor-idx="1">
+      <p data-omnivore-anchor-idx="2">This is a test.</p>
+      <p data-omnivore-anchor-idx="3">.</p>
+      <p data-omnivore-anchor-idx="4"> </p>
+      </div>`
+
+    const speechFile = htmlToSpeechFile({
+      content: html,
+      options: TEST_OPTIONS,
+    })
+
+    expect(speechFile.utterances).to.have.lengthOf(1)
+    expect(speechFile.utterances[0].text).to.eql('This is a test.')
   })
 })

--- a/packages/text-to-speech/tsconfig.json
+++ b/packages/text-to-speech/tsconfig.json
@@ -6,5 +6,5 @@
     // Generate d.ts files
     "declaration": true
   },
-  "include": ["src"]
+  "include": ["src", "test"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -50,6 +50,20 @@
     lodash "^4.17.21"
     resize-observer-polyfill "^1.5.1"
 
+"@anthropic-ai/sdk@^0.20.1":
+  version "0.20.7"
+  resolved "https://registry.yarnpkg.com/@anthropic-ai/sdk/-/sdk-0.20.7.tgz#b19b0e66ba070f928bbf583c06d76e6efdd93d5e"
+  integrity sha512-uyc+3WGLpe8ur6mSIKSab7P9JdBerTdmqb7popc/yROYLLCW/Ykyw4ZfjmN/cLmxjnAKnv5YUngzbPM0BJuGjg==
+  dependencies:
+    "@types/node" "^18.11.18"
+    "@types/node-fetch" "^2.6.4"
+    abort-controller "^3.0.0"
+    agentkeepalive "^4.2.1"
+    form-data-encoder "1.7.2"
+    formdata-node "^4.3.2"
+    node-fetch "^2.6.7"
+    web-streams-polyfill "^3.2.1"
+
 "@anthropic-ai/sdk@^0.9.1":
   version "0.9.1"
   resolved "https://registry.yarnpkg.com/@anthropic-ai/sdk/-/sdk-0.9.1.tgz#b2d2b7bf05c90dce502c9a2e869066870f69ba88"
@@ -3774,6 +3788,17 @@
   dependencies:
     lodash "^4.17.21"
 
+"@langchain/anthropic@^0.1.16":
+  version "0.1.16"
+  resolved "https://registry.yarnpkg.com/@langchain/anthropic/-/anthropic-0.1.16.tgz#c2a9d3dd4e02df7118dd97cf2503c9bd1a4de5ad"
+  integrity sha512-vCbwkZ3pkMSKf67fBgNlslvuW9f3EZGBbO8Ic2etgX3xFl6L0WuMtfS26P1FCDpRwaKuC1BrCj2aLAeMzMq/Fg==
+  dependencies:
+    "@anthropic-ai/sdk" "^0.20.1"
+    "@langchain/core" "~0.1.56"
+    fast-xml-parser "^4.3.5"
+    zod "^3.22.4"
+    zod-to-json-schema "^3.22.4"
+
 "@langchain/community@~0.0.33":
   version "0.0.33"
   resolved "https://registry.yarnpkg.com/@langchain/community/-/community-0.0.33.tgz#5568fe36b1e2f8947d49414d47e14a27da5b65c9"
@@ -3797,6 +3822,24 @@
     js-tiktoken "^1.0.8"
     langsmith "~0.1.7"
     ml-distance "^4.0.0"
+    p-queue "^6.6.2"
+    p-retry "4"
+    uuid "^9.0.0"
+    zod "^3.22.4"
+    zod-to-json-schema "^3.22.3"
+
+"@langchain/core@~0.1.56":
+  version "0.1.61"
+  resolved "https://registry.yarnpkg.com/@langchain/core/-/core-0.1.61.tgz#9313363e04f1c6981a938b2909c44ce6fceb2736"
+  integrity sha512-C8OkAly+ugvXsL8TACCmFv9WTTcT4gvQaG6NbrXCOzibBCywfxxcTqEMOyg3zIKpxHEmR0DHqh0OiJRHocnsCg==
+  dependencies:
+    ansi-styles "^5.0.0"
+    camelcase "6"
+    decamelize "1.2.0"
+    js-tiktoken "^1.0.8"
+    langsmith "~0.1.7"
+    ml-distance "^4.0.0"
+    mustache "^4.2.0"
     p-queue "^6.6.2"
     p-retry "4"
     uuid "^9.0.0"
@@ -15694,7 +15737,7 @@ fast-xml-parser@^4.2.2, fast-xml-parser@^4.3.0:
   dependencies:
     strnum "^1.0.5"
 
-fast-xml-parser@^4.3.2:
+fast-xml-parser@^4.3.2, fast-xml-parser@^4.3.5:
   version "4.3.6"
   resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-4.3.6.tgz#190f9d99097f0c8f2d3a0e681a10404afca052ff"
   integrity sha512-M2SovcRxD4+vC493Uc2GZVcZaj66CCJhWurC4viynVSTvrpErCShNcDz1lAho6n9REQKvL/ll4A4/fw6Y9z8nw==
@@ -22821,6 +22864,11 @@ multimatch@5.0.0:
     array-union "^2.1.0"
     arrify "^2.0.1"
     minimatch "^3.0.4"
+
+mustache@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/mustache/-/mustache-4.2.0.tgz#e5892324d60a12ec9c2a73359edca52972bf6f64"
+  integrity sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==
 
 mute-stream@0.0.8, mute-stream@~0.0.4:
   version "0.0.8"
@@ -32216,6 +32264,11 @@ zod-to-json-schema@^3.22.3:
   version "3.22.4"
   resolved "https://registry.yarnpkg.com/zod-to-json-schema/-/zod-to-json-schema-3.22.4.tgz#f8cc691f6043e9084375e85fb1f76ebafe253d70"
   integrity sha512-2Ed5dJ+n/O3cU383xSY28cuVi0BCQhF8nYqWU5paEpl7fVdqdAmiLdqLyfblbNdfOFwFfi/mqU4O1pwc60iBhQ==
+
+zod-to-json-schema@^3.22.4:
+  version "3.23.0"
+  resolved "https://registry.yarnpkg.com/zod-to-json-schema/-/zod-to-json-schema-3.23.0.tgz#4fc60e88d3c709eedbfaae3f92f8a7bf786469f2"
+  integrity sha512-az0uJ243PxsRIa2x1WmNE/pnuA05gUq/JB8Lwe1EDCCL/Fz9MgjYQ0fPlyc2Tcv6aF2ZA7WM5TWaRZVEFaAIag==
 
 zod@^3.22.3, zod@^3.22.4:
   version "3.22.4"


### PR DESCRIPTION
- **fix: remove redundant user query**
- **do not create user profile and topics**
- **reduce number of db calls for search library items**
- **randomly select at most 25 candidates and time each step**
- **filter out summary if shorter than 200 words**
- **filter out summary if longer than 1000 words**
- **use claude API**
- **generate a unique id for each scheduled digest to avoid duplication**
- **fix: filter punctuation and whitespace only utterance out**
- **fix: skip unwanted nodes and update the index when converting html to utterances**
