### PR TITLE
Android bugfix: Make article title the subject when sharing original

### DIFF
--- a/android/Omnivore/app/src/main/java/app/omnivore/omnivore/feature/reader/WebReaderViewModel.kt
+++ b/android/Omnivore/app/src/main/java/app/omnivore/omnivore/feature/reader/WebReaderViewModel.kt
@@ -161,7 +161,7 @@ class WebReaderViewModel @Inject constructor(
 
             browserIntent.setType("text/plain")
             browserIntent.putExtra(Intent.EXTRA_TEXT, it.item.pageURLString)
-            browserIntent.putExtra(Intent.EXTRA_SUBJECT, it.item.pageURLString)
+            browserIntent.putExtra(Intent.EXTRA_SUBJECT, it.item.title)
             context.startActivity(browserIntent)
         }
     }


### PR DESCRIPTION
Currently when sharing an article via `Share original` in an article's menu, Omnivore shares using an intent with
```
browserIntent.putExtra(Intent.EXTRA_TEXT, it.item.pageURLString)
browserIntent.putExtra(Intent.EXTRA_SUBJECT, it.item.pageURLString)
```
This PR changes the EXTRA_SUBJECT to the article title.

This is very nitpicky (sorry) but it's fixing an issue I face when sharing via Telegram. When I try to share links via Telegram, it puts both the EXTRA_TEXT and the EXTRA_SUBJECT in the message body, which ends up very strange.

![photo_2024-05-01_21-33-39](https://github.com/omnivore-app/omnivore/assets/9449875/4a0afb3f-977f-4e9d-9c77-236871e608fe)

The originally intended use-case was probably email. Even then, putting the URL in the email subject is not standard. To respect that use-case, I'm changing the subject to the article title, although I'm happy to remove the EXTRA_SUBJECT from the intent altogether. Is there any context I'm missing?

