### PR TITLE
iOS Digest Chapters + audio issues

### DIFF
--- a/apple/OmnivoreKit/Sources/App/Views/Home/Components/LibraryItemFetcher.swift
+++ b/apple/OmnivoreKit/Sources/App/Views/Home/Components/LibraryItemFetcher.swift
@@ -114,6 +114,7 @@ import Views
     if let appliedFilter = filterState.appliedFilter {
       let shouldRemoteSearch = forceRemote || items.count < 1 || isRefresh && appliedFilter.shouldRemoteSearch
       if shouldRemoteSearch {
+        updateFetchController(dataService: dataService, filterState: filterState)
         await loadSearchQuery(dataService: dataService, filterState: filterState, isRefresh: isRefresh)
       } else {
         updateFetchController(dataService: dataService, filterState: filterState)

--- a/apple/OmnivoreKit/Sources/App/Views/Home/HomeFeedViewModel.swift
+++ b/apple/OmnivoreKit/Sources/App/Views/Home/HomeFeedViewModel.swift
@@ -38,7 +38,7 @@ enum LoadingBarStyle {
   @Published var selectedLabels = [LinkedItemLabel]()
   @Published var negatedLabels = [LinkedItemLabel]()
   @Published var appliedSort = LinkedItemSort.newest.rawValue
-  
+
   @Published var digestIsUnread = false
 
   @State var lastMoreFetched: Date?

--- a/apple/OmnivoreKit/Sources/App/Views/WebReader/WebReaderContainer.swift
+++ b/apple/OmnivoreKit/Sources/App/Views/WebReader/WebReaderContainer.swift
@@ -323,7 +323,7 @@ struct WebReaderContainerView: View {
         .padding(.trailing, 5)
         .popover(isPresented: $showPreferencesPopover) {
           webPreferencesPopoverView
-            .frame(maxWidth: 400, maxHeight: 475)
+            .frame(width: 400, height: 475)
         }
         .formSheet(isPresented: $showPreferencesFormsheet, modalSize: CGSize(width: 400, height: 475)) {
           webPreferencesPopoverView

--- a/apple/OmnivoreKit/Sources/Services/AudioSession/AudioController.swift
+++ b/apple/OmnivoreKit/Sources/Services/AudioSession/AudioController.swift
@@ -701,7 +701,6 @@ public struct DigestAudioItem: AudioItemProperties {
           player?.insert(playerItem, after: nil)
           if player?.items().count == 1, atOffset > 0.0 {
             playerItem.seek(to: CMTimeMakeWithSeconds(atOffset, preferredTimescale: 600)) { success in
-              print("success seeking to time: ", success)
               self.fireTimer()
             }
           }
@@ -1019,9 +1018,7 @@ public struct DigestAudioItem: AudioItemProperties {
         throw BasicError.message(messageText: "audioFetch failed. no data received.")
       }
       
-      let str = String(decoding: data, as: UTF8.self)
-      print("result speech file: ", str)
-      
+      let str = String(decoding: data, as: UTF8.self)      
       if let document = try? JSONDecoder().decode(SpeechDocument.self, from: data) {
         do {
           try? FileManager.default.createDirectory(at: document.audioDirectory, withIntermediateDirectories: true)

--- a/apple/OmnivoreKit/Sources/Services/AudioSession/AudioController.swift
+++ b/apple/OmnivoreKit/Sources/Services/AudioSession/AudioController.swift
@@ -814,15 +814,16 @@ public struct DigestAudioItem: AudioItemProperties {
         let percentProgress = timeElapsed / duration
         let speechIndex = (player?.currentItem as? SpeechPlayerItem)?.speechItem.audioIdx ?? 0
         let anchorIndex = Int((player?.currentItem as? SpeechPlayerItem)?.speechItem.htmlIdx ?? "") ?? 0
-        
+
         if let itemID = itemAudioProperties?.itemID {
           dataService.updateLinkReadingProgress(itemID: itemID, readingProgress: percentProgress, anchorIndex: anchorIndex, force: true)
         }
-        
-        if let itemID = itemAudioProperties?.itemID, let player = player, let currentItem = player.currentItem {
+
+        if let itemID = itemAudioProperties?.itemID,
+            let player = player,
+            let currentItem = player.currentItem,
+            itemAudioProperties?.audioItemType == .libraryItem {
           let currentOffset = CMTimeGetSeconds(currentItem.currentTime())
-          print("updating listening info: ", speechIndex, currentOffset, timeElapsed)
-          
           dataService.updateLinkListeningProgress(itemID: itemID,
                                                   listenIndex: speechIndex,
                                                   listenOffset: currentOffset,

--- a/apple/OmnivoreKit/Sources/Services/AudioSession/AudioController.swift
+++ b/apple/OmnivoreKit/Sources/Services/AudioSession/AudioController.swift
@@ -33,16 +33,20 @@ public struct DigestAudioItem: AudioItemProperties {
   public let digest: DigestResult
   public let itemID: String
   public let title: String
+  public let chapters: [DigestChapterData]
+
   public var byline: String?
   public var imageURL: URL?
   public var language: String?
   public var startIndex: Int = 0
   public var startOffset: Double = 0.0
 
-  public init(digest: DigestResult) {
+  public init(digest: DigestResult, chapters: [DigestChapterData]) {
     self.digest = digest
     self.itemID = digest.id
     self.title = digest.title
+    self.chapters = chapters
+ 
     self.startIndex = 0
     self.startOffset = 0
 
@@ -908,11 +912,30 @@ public struct DigestAudioItem: AudioItemProperties {
         return .commandFailed
       }
       
+      if let digest = self.itemAudioProperties as? DigestAudioItem {
+        commandCenter.nextTrackCommand.isEnabled = true
+        commandCenter.nextTrackCommand.addTarget { event -> MPRemoteCommandHandlerStatus in
+          let next = self.currentAudioIndex + 1
+          if next < (self.document?.utterances.count ?? 0) {
+            self.seek(toIdx: self.currentAudioIndex + 1)
+            return .success
+          }
+          return .commandFailed
+        }
+      }
+      
       Task {
         await downloadAndSetArtwork()
       }
     }
-    
+
+    func nextChapterIndex(digest: DigestResult, idx: Int) -> Int {
+//      for chapter in digest.chapters {
+//        if chapter.
+//      }
+      return 0
+    }
+
     func isoLangForCurrentVoice() -> String {
       // currentVoicePair should not ever be nil but if it is we return an empty string
       if let isoLang = currentVoicePair?.language {

--- a/apple/OmnivoreKit/Sources/Services/AudioSession/SpeechPlayerItem.swift
+++ b/apple/OmnivoreKit/Sources/Services/AudioSession/SpeechPlayerItem.swift
@@ -70,11 +70,9 @@ class SpeechPlayerItem: AVPlayerItem {
     DispatchQueue.main.async {
       if self.speechItem.audioIdx > self.session.currentAudioIndex + 5 {
         // prefetch has gotten too far ahead of the audio. Pause the prefetch queue
-        print("PAUSING PREFETCH QUEUE", self.speechItem.audioIdx, self.session.currentAudioIndex + 10, self.speechItem.text)
         prefetchQueue.isSuspended = true
       }
       if self.speechItem.audioIdx < self.session.currentAudioIndex + 5 {
-        print("RESUMING PREFETCH QUEUE", self.speechItem.audioIdx, self.session.currentAudioIndex + 5)
         prefetchQueue.isSuspended = false
       }
     }

--- a/apple/OmnivoreKit/Sources/Services/DataService/AI/AITasks.swift
+++ b/apple/OmnivoreKit/Sources/Services/DataService/AI/AITasks.swift
@@ -36,6 +36,18 @@ public struct DigestChapter: Codable {
   }
 }
 
+public struct DigestChapterData {
+  public let time: String
+  public let start: Int
+  public let end: Int
+
+  public init(time: String, start: Int, end: Int) {
+    self.time = time
+    self.start = start
+    self.end = end
+  }
+}
+
 public struct RefreshDigestResult: Codable {
   public let jobId: String
 }

--- a/apple/OmnivoreKit/Sources/Services/InternalModels/InternalFilter.swift
+++ b/apple/OmnivoreKit/Sources/Services/InternalModels/InternalFilter.swift
@@ -176,6 +176,15 @@ public struct InternalFilter: Encodable, Identifiable, Hashable, Equatable {
         defaultFilter: true
       ),
       InternalFilter(
+        id: "following_unread",
+        name: "Unread",
+        folder: "following",
+        filter: "in:following is:unread",
+        visible: true,
+        position: 11,
+        defaultFilter: true
+      ),
+      InternalFilter(
         id: "rss",
         name: "Feeds",
         folder: "following",

--- a/apple/OmnivoreKit/Sources/Views/FeedItem/LibraryItemCard.swift
+++ b/apple/OmnivoreKit/Sources/Views/FeedItem/LibraryItemCard.swift
@@ -284,10 +284,11 @@ public struct LibraryItemCard: View {
       let texts = [savedAtText, estimatedReadingTimeText, readingProgressText, highlightsText, notesText]
         .compactMap { $0 }
 
-      texts.dropLast().reduce(Text("")) { result, text in
+      if texts.count > 0 {
+        texts.dropLast().reduce(Text("")) { result, text in
           result + text + Text(" • ").font(.footnote).foregroundColor(Color.themeLibraryItemSubtle)
-      } + texts.last!
-        // .reduce(Text(""), +)
+        } + texts.last!
+      }
     }
     .frame(maxWidth: .infinity, alignment: .leading)
   }

--- a/apple/OmnivoreKit/Sources/Views/FeedItem/LibraryItemCard.swift
+++ b/apple/OmnivoreKit/Sources/Views/FeedItem/LibraryItemCard.swift
@@ -55,7 +55,7 @@ func savedDateString(_ savedAt: Date?) -> String {
       dateFormatter.dateFormat = "MMM dd"
     }
     dateFormatter.locale = locale
-    return dateFormatter.string(from: savedAt) + " • "
+    return dateFormatter.string(from: savedAt)
   }
   return ""
 }
@@ -160,12 +160,19 @@ public struct LibraryItemCard: View {
   var estimatedReadingTime: String {
     if item.wordsCount > 0 {
       let readLen = max(1, item.wordsCount / readingSpeed)
-      return "\(readLen) MIN READ • "
+      return "\(readLen) MIN READ"
     }
     return ""
   }
 
   var readingProgress: String {
+    if item.readingProgress < 2 {
+      return ""
+    }
+    var readingProgress = item.readingProgress
+    if readingProgress > 95 {
+      readingProgress = 100
+    }
     // If there is no wordsCount don't show progress because it will make no sense
     if item.wordsCount > 0 {
       return "\(String(format: "%d", Int(item.readingProgress)))%"
@@ -181,18 +188,15 @@ public struct LibraryItemCard: View {
     item.wordsCount > 0 || item.highlights?.first { ($0 as? Highlight)?.annotation != nil } != nil
   }
 
-  var highlightsText: String {
+  var highlightsStr: String {
     if let highlights = item.highlights, highlights.count > 0 {
       let fmted = LocalText.pluralizedText(key: "number_of_highlights", count: highlights.count)
-      if item.wordsCount > 0 || item.isPDF {
-        return " • \(fmted)"
-      }
       return fmted
     }
     return ""
   }
 
-  var notesText: String {
+  var notesStr: String {
     let notes = item.highlights?.filter { item in
       if let highlight = item as? Highlight {
         return !(highlight.annotation ?? "").isEmpty
@@ -202,9 +206,6 @@ public struct LibraryItemCard: View {
 
     if let notes = notes, notes.count > 0 {
       let fmted = LocalText.pluralizedText(key: "number_of_notes", count: notes.count)
-      if hasMultipleInfoItems {
-        return " • \(fmted)"
-      }
       return fmted
     }
     return ""
@@ -228,35 +229,65 @@ public struct LibraryItemCard: View {
     }
   }
 
+  var savedAtText: Text? {
+    if !savedAtStr.isEmpty {
+      return Text(savedAtStr)
+        .font(.footnote)
+        .foregroundColor(Color.themeLibraryItemSubtle)
+    }
+    return nil
+  }
+
+  var estimatedReadingTimeText: Text? {
+    if !estimatedReadingTime.isEmpty {
+      return Text("\(estimatedReadingTime)")
+        .font(.footnote)
+        .foregroundColor(Color.themeLibraryItemSubtle)
+
+    }
+    return nil
+  }
+
+  var readingProgressText: Text? {
+    if !readingProgress.isEmpty {
+      return Text("\(readingProgress)")
+      .font(.footnote)
+      .foregroundColor(isPartiallyRead ? Color.appGreenSuccess : Color.themeLibraryItemSubtle)
+    }
+    return nil
+  }
+
+  var highlightsText: Text? {
+    if !highlightsStr.isEmpty {
+      return Text("\(highlightsStr)")
+        .font(.footnote)
+        .foregroundColor(Color.themeLibraryItemSubtle)
+    }
+    return nil
+  }
+
+  var notesText: Text? {
+    if !notesStr.isEmpty {
+      return Text("\(notesStr)")
+        .font(.footnote)
+        .foregroundColor(Color.themeLibraryItemSubtle)
+    }
+    return nil
+  }
+
   var readInfo: some View {
     HStack(alignment: .center, spacing: 5.0) {
       ForEach(flairLabels, id: \.self) {
         $0.icon
       }
 
-      Text(savedAtStr)
-        .font(.footnote)
-        .foregroundColor(Color.themeLibraryItemSubtle)
+      let texts = [savedAtText, estimatedReadingTimeText, readingProgressText, highlightsText, notesText]
+        .compactMap { $0 }
 
-      +
-      Text("\(estimatedReadingTime)")
-        .font(.footnote)
-        .foregroundColor(Color.themeLibraryItemSubtle)
-
-        +
-        Text("\(readingProgress)")
-        .font(.footnote)
-        .foregroundColor(isPartiallyRead ? Color.appGreenSuccess : Color.themeLibraryItemSubtle)
-
-        +
-        Text("\(highlightsText)")
-        .font(.footnote)
-        .foregroundColor(Color.themeLibraryItemSubtle)
-
-        +
-        Text("\(notesText)")
-        .font(.footnote)
-        .foregroundColor(Color.themeLibraryItemSubtle)
+      texts.dropLast().reduce(Text("")) { result, text in
+          result + text + Text(" • ").font(.footnote).foregroundColor(Color.themeLibraryItemSubtle)
+      } + texts.last!
+        // .reduce(Text(""), +)
     }
     .frame(maxWidth: .infinity, alignment: .leading)
   }

--- a/apple/OmnivoreKit/Sources/Views/FontSizeAdjustmentPopoverView.swift
+++ b/apple/OmnivoreKit/Sources/Views/FontSizeAdjustmentPopoverView.swift
@@ -216,7 +216,9 @@ public enum WebFont: String, CaseIterable {
           updateReaderPreferences()
 
         }, label: { Image(systemName: "textformat.size.smaller") })
+          .buttonStyle(.plain)
           .frame(width: 25, height: 25, alignment: .center)
+          .foregroundColor(.appGrayTextContrast.opacity(0.4))
         CustomSlider(value: $storedFontSize, minValue: 10, maxValue: 48) { _ in
           if storedFontSize % 1 == 0 {
             updateReaderPreferences()
@@ -230,7 +232,9 @@ public enum WebFont: String, CaseIterable {
           updateReaderPreferences()
 
         }, label: { Image(systemName: "textformat.size.larger") })
+          .buttonStyle(.plain)
           .frame(width: 25, height: 25, alignment: .center)
+          .foregroundColor(.appGrayTextContrast.opacity(0.4))
       }
     }
 
@@ -244,7 +248,9 @@ public enum WebFont: String, CaseIterable {
           updateReaderPreferences()
 
         }, label: { Image("margin-smaller", bundle: .module) })
+          .buttonStyle(.plain)
           .frame(width: 25, height: 25, alignment: .center)
+          .foregroundColor(.appGrayTextContrast.opacity(0.4))
         CustomSlider(value: $storedMaxWidthPercentage, minValue: minValue, maxValue: 100) { _ in
           updateReaderPreferences()
         }
@@ -256,7 +262,9 @@ public enum WebFont: String, CaseIterable {
           updateReaderPreferences()
 
         }, label: { Image("margin-larger", bundle: .module) })
+          .buttonStyle(.plain)
           .frame(width: 25, height: 25, alignment: .center)
+          .foregroundColor(.appGrayTextContrast.opacity(0.4))
       }
     }
 
@@ -267,7 +275,9 @@ public enum WebFont: String, CaseIterable {
           updateReaderPreferences()
 
         }, label: { Image("lineheight-smaller", bundle: .module) })
+          .buttonStyle(.plain)
           .frame(width: 25, height: 25, alignment: .center)
+          .foregroundColor(.appGrayTextContrast.opacity(0.4))
         CustomSlider(value: $storedLineSpacing, minValue: 100, maxValue: 300) { _ in
           updateReaderPreferences()
         }
@@ -279,7 +289,9 @@ public enum WebFont: String, CaseIterable {
           updateReaderPreferences()
 
         }, label: { Image("lineheight-larger", bundle: .module) })
+          .buttonStyle(.plain)
           .frame(width: 25, height: 25, alignment: .center)
+          .foregroundColor(.appGrayTextContrast.opacity(0.4))
       }
     }
 
@@ -288,7 +300,9 @@ public enum WebFont: String, CaseIterable {
         Button(action: {
           storedFontSize = min(storedFontSize + 2, 28)
         }, label: { Image("brightness-lower", bundle: .module) })
+          .buttonStyle(.plain)
           .frame(width: 25, height: 25, alignment: .center)
+          .foregroundColor(.appGrayTextContrast.opacity(0.4))
         CustomSlider(value: $storedFontSize, minValue: 10, maxValue: 28) { _ in
           updateReaderPreferences()
         }
@@ -297,7 +311,9 @@ public enum WebFont: String, CaseIterable {
         Button(action: {
           storedFontSize = max(storedFontSize - 2, 10)
         }, label: { Image("brightness-higher", bundle: .module) })
+          .buttonStyle(.plain)
           .frame(width: 25, height: 25, alignment: .center)
+          .foregroundColor(.appGrayTextContrast.opacity(0.4))
       }
     }
 
@@ -371,6 +387,7 @@ public enum WebFont: String, CaseIterable {
           Text("Margin")
             .font(Font.system(size: 14))
             .frame(maxWidth: .infinity, alignment: .leading)
+            .foregroundColor(.appGrayTextContrast)
 
           marginSlider
             .padding(.top, 5)
@@ -379,6 +396,7 @@ public enum WebFont: String, CaseIterable {
           Text("Line Height")
             .font(Font.system(size: 14))
             .frame(maxWidth: .infinity, alignment: .leading)
+            .foregroundColor(.appGrayTextContrast)
 
           lineHeightSlider
           // .padding(.bottom, 20)
@@ -390,7 +408,7 @@ public enum WebFont: String, CaseIterable {
           //
           //            brightnessSlider
 
-        }.tint(Color(hex: "#6A6968"))
+        }.tint(.appGrayTextContrast)
           .padding(.horizontal, 30)
 
         Divider()
@@ -401,6 +419,7 @@ public enum WebFont: String, CaseIterable {
             Text("Theme")
               .font(Font.system(size: 14))
               .frame(maxWidth: .infinity, alignment: .leading)
+              .foregroundColor(.appGrayTextContrast)
             Spacer()
 
             systemThemeCheckbox


### PR DESCRIPTION
- Refactor chapter data to allow for click to skip to next chapter
- Add an Unread filter to Following
- Clean up metadata in list cards
- Forward and backward chapter skipping
- Long press to view full story
- Fix preferences popover on iOS 15 for iPad users
- Load cached items first
- Remove some debug
- Remove some debug
- Load digest from disk if available
- Fix crash with library items that have no info
- Return the deep link from save intent
