### PR TITLE
fix: add missing curly braces around props.children in ConditionalCaptchaProvider

### DIFF
--- a/packages/web/pages/_app.tsx
+++ b/packages/web/pages/_app.tsx
@@ -81,7 +81,7 @@ const ConditionalCaptchaProvider = (props: {
       </GoogleReCaptchaProvider>
     )
   }
-  return <>props.children</>
+  return <>{props.children}</>
 }
 
 export function OmnivoreApp({ Component, pageProps }: AppProps): JSX.Element {


### PR DESCRIPTION
**Description:**
There is a bug in the `ConditionalCaptchaProvider` component where `props.children` is not enclosed in curly braces {} in the return statement when the `NEXT_PUBLIC_RECAPTCHA_CHALLENGE_SITE_KEY` environment variable is not defined. This prevents the children from being rendered correctly in JSX.

**Steps to Reproduce:**
Ensure the `NEXT_PUBLIC_RECAPTCHA_CHALLENGE_SITE_KEY` environment variable is not set.
Observe that the children are not rendered correctly.
