### PR TITLE
fix support for themed icons (reverts to old monochrome until new monochrome is available)

### DIFF
--- a/android/Omnivore/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/android/Omnivore/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/ic_launcher_background"/>
     <foreground android:drawable="@mipmap/ic_launcher_foreground"/>
+    <monochrome android:drawable="@drawable/ic_launcher_monochrome"/>
 </adaptive-icon>

--- a/android/Omnivore/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/android/Omnivore/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/ic_launcher_background"/>
     <foreground android:drawable="@mipmap/ic_launcher_foreground"/>
+    <monochrome android:drawable="@drawable/ic_launcher_monochrome"/>
 </adaptive-icon>


### PR DESCRIPTION
Please test, 95% sure this should work but booting up android studio eats up a lot of resources so have not checked!

With the new icon, themed icons no longer work. This adds a quick fix to restore the functionality with the old icon. The alternative would be to add a monochrome for the new icon. It looks like there was a switch from svg to png, could try

```xml
<?xml version="1.0" encoding="utf-8"?>
<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
    <background android:drawable="@color/ic_launcher_background"/>
    <foreground android:drawable="@mipmap/ic_launcher_foreground"/>
    <monochrome android:drawable="@mipmap/ic_launcher_foreground"/>
</adaptive-icon>
```

but it looks like the new png has a *slight* gradient that may prevent that from working. Best solution would be to get a monochrome version of the png, or convert all to svg for easier management. Perhaps the original designer of the new icon would be the best source for getting a monochrome version if png is going to be used going forward?

Relevant commits and issues:
https://github.com/omnivore-app/omnivore/commit/f8f1bc9c4bfcc657940e968852f5d20876b9add4
https://github.com/omnivore-app/omnivore/commit/b62a26e38c7b47813e0e807bc3a53c0f3b5d031a