### PR TITLE
feat: mark home feed as seen

### DIFF
--- a/packages/web/lib/networking/mutations/bulkActionMutation.ts
+++ b/packages/web/lib/networking/mutations/bulkActionMutation.ts
@@ -6,6 +6,7 @@ export enum BulkAction {
   DELETE = 'DELETE',
   ADD_LABELS = 'ADD_LABELS',
   MARK_AS_READ = 'MARK_AS_READ',
+  MARK_AS_SEEN = 'MARK_AS_SEEN',
 }
 
 type BulkActionResponseData = {
@@ -20,7 +21,7 @@ type BulkActionResponse = {
 export async function bulkActionMutation(
   action: BulkAction,
   query: string,
-  expectedCount: number,
+  expectedCount?: number,
   labelIds?: string[]
 ): Promise<boolean> {
   const mutation = gql`

--- a/packages/web/pages/justread/index.tsx
+++ b/packages/web/pages/justread/index.tsx
@@ -55,6 +55,7 @@ export default function Home(): JSX.Element {
 
     if (homeData.sections) {
       const seenItemIds = homeData.sections
+        .filter((section) => section.layout !== 'hidden')
         .map((section) => section.items.map((item) => item.id))
         .flat()
 

--- a/packages/web/pages/justread/index.tsx
+++ b/packages/web/pages/justread/index.tsx
@@ -58,7 +58,9 @@ export default function Home(): JSX.Element {
         .map((section) => section.items.map((item) => item.id))
         .flat()
 
-      markItemsAsSeen(seenItemIds)
+      if (seenItemIds.length > 0) {
+        markItemsAsSeen(seenItemIds)
+      }
     }
   })
 

--- a/packages/web/pages/justread/index.tsx
+++ b/packages/web/pages/justread/index.tsx
@@ -1,7 +1,7 @@
 import * as HoverCard from '@radix-ui/react-hover-card'
 import { styled } from '@stitches/react'
 import { useRouter } from 'next/router'
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { Button } from '../../components/elements/Button'
 import { AddToLibraryActionIcon } from '../../components/elements/icons/home/AddToLibraryActionIcon'
 import { ArchiveActionIcon } from '../../components/elements/icons/home/ArchiveActionIcon'
@@ -12,6 +12,10 @@ import Pagination from '../../components/elements/Pagination'
 import { timeAgo } from '../../components/patterns/LibraryCards/LibraryCardStyles'
 import { theme } from '../../components/tokens/stitches.config'
 import { useApplyLocalTheme } from '../../lib/hooks/useApplyLocalTheme'
+import {
+  BulkAction,
+  bulkActionMutation,
+} from '../../lib/networking/mutations/bulkActionMutation'
 import { useGetHiddenHomeSection } from '../../lib/networking/queries/useGetHiddenHomeSection'
 import {
   HomeItem,
@@ -34,6 +38,29 @@ export default function Home(): JSX.Element {
   const homeData = useGetHomeItems()
   console.log('home sections: ', homeData.sections)
   useApplyLocalTheme()
+
+  useEffect(() => {
+    const markItemsAsSeen = async (seenItemIds: string[]) => {
+      try {
+        console.log('marking as seen', seenItemIds)
+        await bulkActionMutation(
+          BulkAction.MARK_AS_SEEN,
+          `includes:${seenItemIds.join(',')}`
+        )
+        console.log('marked as seen')
+      } catch (error) {
+        console.error('Error marking items as seen', error)
+      }
+    }
+
+    if (homeData.sections) {
+      const seenItemIds = homeData.sections
+        .map((section) => section.items.map((item) => item.id))
+        .flat()
+
+      markItemsAsSeen(seenItemIds)
+    }
+  })
 
   return (
     <VStack


### PR DESCRIPTION
This PR will create a feature on Web:

When the "home" feed is loaded, all the items will be marked as "seen" by calling `bulkAction` API.

Some questions:
1. Should we mark topic picks/quick links items that are on the pages which are not the current page?
2. Should we mark "hidden" items as seen?