### PR TITLE
Use shared UserDefaults instead of standard set

### DIFF
--- a/apple/OmnivoreKit/Sources/App/Views/SelfHostSettingsView.swift
+++ b/apple/OmnivoreKit/Sources/App/Views/SelfHostSettingsView.swift
@@ -10,9 +10,9 @@ class SelfHostSettingsViewModel: ObservableObject {
 }
 
 struct SelfHostSettingsView: View {
-  @State var apiServerAddress = UserDefaults.standard.string(forKey: AppEnvironmentUserDefaultKey.serverBaseURL.rawValue) ?? ""
-  @State var webServerAddress = UserDefaults.standard.string(forKey: AppEnvironmentUserDefaultKey.webAppBaseURL.rawValue) ?? ""
-  @State var ttsServerAddress = UserDefaults.standard.string(forKey: AppEnvironmentUserDefaultKey.ttsBaseURL.rawValue) ?? ""
+  @State var apiServerAddress = UserDefaults(suiteName: "group.app.omnivoreapp").string(forKey: AppEnvironmentUserDefaultKey.serverBaseURL.rawValue) ?? ""
+  @State var webServerAddress = UserDefaults(suiteName: "group.app.omnivoreapp").string(forKey: AppEnvironmentUserDefaultKey.webAppBaseURL.rawValue) ?? ""
+  @State var ttsServerAddress = UserDefaults(suiteName: "group.app.omnivoreapp").string(forKey: AppEnvironmentUserDefaultKey.ttsBaseURL.rawValue) ?? ""
 
   @State var showConfirmAlert = false
 

--- a/apple/OmnivoreKit/Sources/Models/AppEnvironment.swift
+++ b/apple/OmnivoreKit/Sources/Models/AppEnvironment.swift
@@ -40,15 +40,18 @@ public enum AppEnvironmentUserDefaultKey: String {
 
 public extension AppEnvironment {
   static func setCustom(serverBaseURL: String, webAppBaseURL: String, ttsBaseURL: String) {
-    UserDefaults.standard.set(
+    guard let sharedDefaults = UserDefaults(suiteName: "group.app.omnivoreapp") else {
+      fatalError("Could not create shared user defaults")
+    }
+    sharedDefaults.set(
       serverBaseURL.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines),
       forKey: AppEnvironmentUserDefaultKey.serverBaseURL.rawValue
     )
-    UserDefaults.standard.set(
+    sharedDefaults.set(
       webAppBaseURL.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines),
       forKey: AppEnvironmentUserDefaultKey.webAppBaseURL.rawValue
     )
-    UserDefaults.standard.set(
+    sharedDefaults.set(
       ttsBaseURL.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines),
       forKey: AppEnvironmentUserDefaultKey.ttsBaseURL.rawValue
     )
@@ -56,11 +59,14 @@ public extension AppEnvironment {
 
   var environmentConfigured: Bool {
     if self == .custom {
-      if let str = UserDefaults.standard.string(forKey: AppEnvironmentUserDefaultKey.webAppBaseURL.rawValue), let url = URL(string: str) {
-        return true
-      } else {
+      guard
+        let sharedDefaults = UserDefaults(suiteName: "group.app.omnnivoreapp"),
+        let str = sharedDefaults.string(forKey: AppEnvironmentUserDefaultKey.serverBaseURL.rawValue),
+        let url = URL(string: str) 
+      else {
         return false
       }
+      return true
     }
     return true
   }
@@ -94,7 +100,8 @@ public extension AppEnvironment {
       return URL(string: "http://localhost:4000")!
     case .custom:
       guard
-        let str = UserDefaults.standard.string(forKey: AppEnvironmentUserDefaultKey.serverBaseURL.rawValue),
+        let sharedDefaults = UserDefaults(suiteName: "group.app.omnnivoreapp"),
+        let str = sharedDefaults.string(forKey: AppEnvironmentUserDefaultKey.serverBaseURL.rawValue),
         let url = URL(string: str)
       else {
         fatalError("custom serverBaseURL not set")
@@ -113,7 +120,8 @@ public extension AppEnvironment {
       return URL(string: "http://localhost:3000")!
     case .custom:
       guard
-        let str = UserDefaults.standard.string(forKey: AppEnvironmentUserDefaultKey.webAppBaseURL.rawValue),
+        let sharedDefaults = UserDefaults(suiteName: "group.app.omnnivoreapp"),
+        let str = sharedDefaults.string(forKey: AppEnvironmentUserDefaultKey.webAppBaseURL.rawValue),
         let url = URL(string: str)
       else {
         fatalError("custom webAppBaseURL not set")
@@ -132,7 +140,8 @@ public extension AppEnvironment {
       return URL(string: "http://localhost:8080")!
     case .custom:
       guard
-        let str = UserDefaults.standard.string(forKey: AppEnvironmentUserDefaultKey.ttsBaseURL.rawValue),
+        let sharedDefaults = UserDefaults(suiteName: "group.app.omnnivoreapp"),
+        let str = sharedDefaults.string(forKey: AppEnvironmentUserDefaultKey.ttsBaseURL.rawValue),
         let url = URL(string: str)
       else {
         fatalError("custom ttsBaseURL not set")


### PR DESCRIPTION
This fixes a bug in the iOS application with self-hosted instances.

Due to using `UserDefaults.standard`, the environment configuration was not shared with the share sheet and background tasks. This lead the application to silently fallback to production URLs.

Using `UserDefaults(suiteName:)` fixes this and allows all Omnivore processes to access the configured URLs.