### PR TITLE
Fix highlights order in notebooks

### DIFF
--- a/packages/web/components/patterns/LibraryCards/LibraryHighlightGridCard.tsx
+++ b/packages/web/components/patterns/LibraryCards/LibraryHighlightGridCard.tsx
@@ -7,11 +7,11 @@ import { UserBasicData } from '../../../lib/networking/queries/useGetViewerQuery
 import { LibraryItemNode } from '../../../lib/networking/queries/useGetLibraryItemsQuery'
 import { Button } from '../../elements/Button'
 import { theme } from '../../tokens/stitches.config'
-import { getHighlightLocation } from '../../templates/article/NotebookModal'
 import { Highlight } from '../../../lib/networking/fragments/highlightFragment'
 import { HighlightView } from '../HighlightView'
 import { useRouter } from 'next/router'
 import { showErrorToast } from '../../../lib/toastHelpers'
+import { sortHighlights } from '../../../lib/highlights/sortHighlights'
 
 export const GridSeparator = styled(Box, {
   height: '1px',
@@ -57,37 +57,7 @@ export function LibraryHighlightGridCard(
   )
 
   const sortedHighlights = useMemo(() => {
-    const sorted = (a: number, b: number) => {
-      if (a < b) {
-        return -1
-      }
-      if (a > b) {
-        return 1
-      }
-      return 0
-    }
-
-    if (!props.item.highlights) {
-      return []
-    }
-
-    return props.item.highlights
-      .filter((h) => h.type === 'HIGHLIGHT')
-      .sort((a: Highlight, b: Highlight) => {
-        if (a.highlightPositionPercent && b.highlightPositionPercent) {
-          return sorted(a.highlightPositionPercent, b.highlightPositionPercent)
-        }
-        // We do this in a try/catch because it might be an invalid diff
-        // With PDF it will definitely be an invalid diff.
-        try {
-          const aPos = getHighlightLocation(a.patch)
-          const bPos = getHighlightLocation(b.patch)
-          if (aPos && bPos) {
-            return sorted(aPos, bPos)
-          }
-        } catch {}
-        return a.createdAt.localeCompare(b.createdAt)
-      })
+    return sortHighlights(props.item.highlights ?? [])
   }, [props.item.highlights])
 
   return (

--- a/packages/web/components/templates/article/NotebookModal.tsx
+++ b/packages/web/components/templates/article/NotebookModal.tsx
@@ -12,7 +12,6 @@ import { useCallback, useState } from 'react'
 import { X } from '@phosphor-icons/react'
 import { Dropdown, DropdownOption } from '../../elements/DropdownElements'
 import { showErrorToast, showSuccessToast } from '../../../lib/toastHelpers'
-import { diff_match_patch } from 'diff-match-patch'
 import { MenuTrigger } from '../../elements/MenuTrigger'
 import { highlightsAsMarkdown } from '../homeFeed/HighlightItem'
 import 'react-markdown-editor-lite/lib/index.css'
@@ -27,12 +26,6 @@ type NotebookModalProps = {
 
   viewHighlightInReader: (arg: string) => void
   onClose: (highlights: Highlight[], deletedHighlights: Highlight[]) => void
-}
-
-export const getHighlightLocation = (patch: string): number | undefined => {
-  const dmp = new diff_match_patch()
-  const patches = dmp.patch_fromText(patch)
-  return patches[0].start1 || undefined
 }
 
 export function NotebookModal(props: NotebookModalProps): JSX.Element {

--- a/packages/web/components/templates/homeFeed/HighlightItem.tsx
+++ b/packages/web/components/templates/homeFeed/HighlightItem.tsx
@@ -11,9 +11,8 @@ import {
   DropdownSeparator,
 } from '../../elements/DropdownElements'
 import { Box, VStack } from '../../elements/LayoutPrimitives'
-
 import { styled, theme } from '../../tokens/stitches.config'
-import { getHighlightLocation } from '../article/Notebook'
+import { sortHighlights } from '../../../lib/highlights/sortHighlights'
 
 type HighlightsMenuProps = {
   viewer: UserBasicData
@@ -133,36 +132,6 @@ export function HighlightsMenu(props: HighlightsMenuProps): JSX.Element {
   )
 }
 
-const sortHighlights = (highlights: Highlight[]) => {
-  const sorted = (a: number, b: number) => {
-    if (a < b) {
-      return -1
-    }
-    if (a > b) {
-      return 1
-    }
-    return 0
-  }
-
-  return (highlights ?? [])
-    .filter((h) => h.type === 'HIGHLIGHT')
-    .sort((a: Highlight, b: Highlight) => {
-      if (a.highlightPositionPercent && b.highlightPositionPercent) {
-        return sorted(a.highlightPositionPercent, b.highlightPositionPercent)
-      }
-      // We do this in a try/catch because it might be an invalid diff
-      // With PDF it will definitely be an invalid diff.
-      try {
-        const aPos = getHighlightLocation(a.patch)
-        const bPos = getHighlightLocation(b.patch)
-        if (aPos && bPos) {
-          return sorted(aPos, bPos)
-        }
-      } catch {}
-      return a.createdAt.localeCompare(b.createdAt)
-    })
-}
-
 export function highlightAsMarkdown(highlight: Highlight) {
   let buffer = `> ${highlight.quote}`
   if (highlight.annotation) {
@@ -175,8 +144,7 @@ export function highlightAsMarkdown(highlight: Highlight) {
 export function highlightsAsMarkdown(highlights: Highlight[]) {
   const noteMD = highlights.find((h) => h.type == 'NOTE')
 
-  const highlightMD = sortHighlights(highlights)
-    .filter((h) => h.type == 'HIGHLIGHT')
+  const highlightMD = sortHighlights(highlights ?? [])
     .map((highlight) => {
       return highlightAsMarkdown(highlight)
     })

--- a/packages/web/lib/highlights/sortHighlights.ts
+++ b/packages/web/lib/highlights/sortHighlights.ts
@@ -21,7 +21,11 @@ export function sortHighlights(highlights: Highlight[]) {
   return highlights
     .filter((h) => h.type === 'HIGHLIGHT')
     .sort((a: Highlight, b: Highlight) => {
-      if (a.highlightPositionPercent && b.highlightPositionPercent) {
+      if (
+        a.highlightPositionPercent &&
+        b.highlightPositionPercent &&
+        a.highlightPositionPercent !== b.highlightPositionPercent
+      ) {
         return sorted(a.highlightPositionPercent, b.highlightPositionPercent)
       }
       // We do this in a try/catch because it might be an invalid diff

--- a/packages/web/lib/highlights/sortHighlights.ts
+++ b/packages/web/lib/highlights/sortHighlights.ts
@@ -1,0 +1,38 @@
+import { diff_match_patch } from 'diff-match-patch'
+import type { Highlight } from '../networking/fragments/highlightFragment'
+
+export function sortHighlights(highlights: Highlight[]) {
+  const sorted = (a: number, b: number) => {
+    if (a < b) {
+      return -1
+    }
+    if (a > b) {
+      return 1
+    }
+    return 0
+  }
+
+  const getHighlightLocation = (patch: string): number | undefined => {
+    const dmp = new diff_match_patch()
+    const patches = dmp.patch_fromText(patch)
+    return patches[0].start1 || undefined
+  }
+
+  return highlights
+    .filter((h) => h.type === 'HIGHLIGHT')
+    .sort((a: Highlight, b: Highlight) => {
+      if (a.highlightPositionPercent && b.highlightPositionPercent) {
+        return sorted(a.highlightPositionPercent, b.highlightPositionPercent)
+      }
+      // We do this in a try/catch because it might be an invalid diff
+      // With PDF it will definitely be an invalid diff.
+      try {
+        const aPos = getHighlightLocation(a.patch)
+        const bPos = getHighlightLocation(b.patch)
+        if (aPos && bPos) {
+          return sorted(aPos, bPos)
+        }
+      } catch {}
+      return a.createdAt.localeCompare(b.createdAt)
+    })
+}


### PR DESCRIPTION
Fixes an issue with highlights display order in notebooks, as described in https://github.com/omnivore-app/omnivore/issues/3789:
- highlights with the same highlight position (i.e. in same line) are now sorted by their location within the line
- the same highlight sorting was performed in a few places - the sorting function been refactored to one common location

I also see that there's a new Highlights view in the works - I didn't want to increase the scope of this bug fix PR to include feature work, but let me know if any help is needed there!