### PR TITLE
Add Amplenote origins to cors config

### DIFF
--- a/packages/api/src/utils/corsConfig.ts
+++ b/packages/api/src/utils/corsConfig.ts
@@ -14,6 +14,8 @@ export const corsConfig = {
     env.client.url,
     'lsp://logseq.io',
     'app://obsidian.md',
+    'https://plugins.amplenote.com',
+    'amplenote-handler://bundle',
     'capacitor://localhost',
     'http://localhost',
   ],


### PR DESCRIPTION
Hello,

[Amplenote](https://amplenote.com/) is a note-taking app similar to Obsidian and Logseq. I'm currently working on developing a [plugin](https://github.com/debanjandhar12/my-amplenote-plugins-v2/tree/master/src-omnivore) for Amplenote that syncs with Omnivore.  However, I am facing issues due to CORS.

This change will fix that issue. Would it be possible to merge this PR?