### PR TITLE
Dont show left nav menu by default on smaller screens, reduce flicker on load

### DIFF
--- a/packages/web/components/templates/NavigationLayout.tsx
+++ b/packages/web/components/templates/NavigationLayout.tsx
@@ -143,6 +143,26 @@ export function NavigationLayout(props: NavigationLayoutProps): JSX.Element {
               },
             }}
           ></SpanBox>
+          <SpanBox
+            css={{
+              display: 'none',
+              position: 'fixed',
+              zIndex: '2',
+              backgroundColor: 'var(--colors-overlay)',
+              '@mdDown': {
+                display: 'flex',
+                top: '0px',
+                left: LIBRARY_LEFT_MENU_WIDTH,
+                width: '100vw',
+                height: '100vh',
+                pointerEvents: 'auto',
+              },
+            }}
+            onClick={(event) => {
+              props.setShowNavigationMenu(false)
+              event.stopPropagation()
+            }}
+          ></SpanBox>
         </>
       )}
       {props.children}

--- a/packages/web/lib/hooks/usePersistedState.tsx
+++ b/packages/web/lib/hooks/usePersistedState.tsx
@@ -4,10 +4,12 @@ export function usePersistedState<T>({
   key,
   initialValue,
   isSessionStorage,
+  defaultEvaluator,
 }: {
   key: string
   initialValue: T
   isSessionStorage?: boolean
+  defaultEvaluator?: () => T
 }): [T, (x: T | ((prev: T) => T)) => void, boolean] {
   // State to store our value
   // Pass initial state function to useState so logic is only executed once
@@ -27,6 +29,8 @@ export function usePersistedState<T>({
       // Parse stored json or if none return initialValue
       if (item) {
         setStoredValue(JSON.parse(item))
+      } else if (defaultEvaluator) {
+        setValue(defaultEvaluator())
       }
       setIsLoading(false)
     } catch (error) {

--- a/packages/web/pages/l/[section].tsx
+++ b/packages/web/pages/l/[section].tsx
@@ -9,6 +9,7 @@ import { LibraryContainer } from '../../components/templates/library/LibraryCont
 import { useMemo } from 'react'
 import { HighlightsContainer } from '../../components/nav-containers/HighlightsContainer'
 import { usePersistedState } from '../../lib/hooks/usePersistedState'
+import { isTouchScreenDevice } from '../../lib/deviceType'
 
 export default function Home(): JSX.Element {
   const router = useRouter()
@@ -19,6 +20,9 @@ export default function Home(): JSX.Element {
       key: 'nav-show-menu',
       isSessionStorage: false,
       initialValue: true,
+      defaultEvaluator: () => {
+        return !isTouchScreenDevice()
+      },
     })
 
   const section: NavigationSection | undefined = useMemo(() => {

--- a/packages/web/pages/l/[section].tsx
+++ b/packages/web/pages/l/[section].tsx
@@ -19,9 +19,9 @@ export default function Home(): JSX.Element {
     usePersistedState<boolean>({
       key: 'nav-show-menu',
       isSessionStorage: false,
-      initialValue: true,
+      initialValue: false,
       defaultEvaluator: () => {
-        return !isTouchScreenDevice()
+        return window.innerWidth > 1000
       },
     })
 


### PR DESCRIPTION
- On smaller screens we want the nav menu to be disabled by default
- Default to no show menu under 1000px
