### PR TITLE
fix: allow content-fetch to still process http requests

### DIFF
--- a/packages/api/src/queue-processor.ts
+++ b/packages/api/src/queue-processor.ts
@@ -111,10 +111,10 @@ export const getQueue = async (
         delay: 2000, // 2 seconds
       },
       removeOnComplete: {
-        age: 24 * 3600, // keep up to 24 hours
+        age: 3600, // keep up to 1 hour
       },
       removeOnFail: {
-        age: 7 * 24 * 3600, // keep up to 7 days
+        age: 24 * 3600, // keep up to 1 day
       },
     },
   })

--- a/packages/content-fetch/src/worker.ts
+++ b/packages/content-fetch/src/worker.ts
@@ -16,10 +16,10 @@ export const getQueue = async (
         delay: 2000, // 2 seconds
       },
       removeOnComplete: {
-        age: 24 * 3600, // keep up to 24 hours
+        age: 3600, // keep up to 1 hour
       },
       removeOnFail: {
-        age: 7 * 24 * 3600, // keep up to 7 days
+        age: 24 * 3600, // keep up to 1 day
       },
     },
   })


### PR DESCRIPTION
* [keep up to 1 hour complete tasks and up to 1 day failed tasks](https://github.com/omnivore-app/omnivore/pull/4309/commits/eec2734f5aff026d0ddb3816526aa8581697fd50)