### PR TITLE
Prevent fetching article before router params have been read

### DIFF
--- a/packages/web/lib/networking/library_items/useLibraryItems.tsx
+++ b/packages/web/lib/networking/library_items/useLibraryItems.tsx
@@ -677,10 +677,14 @@ export function useRefreshProcessingItems() {
   return mutation
 }
 
-export const useGetLibraryItemContent = (username: string, slug: string) => {
+export const useGetLibraryItemContent = (
+  username: string | undefined,
+  slug: string | undefined
+) => {
   const queryClient = useQueryClient()
   return useQuery({
     queryKey: ['libraryItem', slug],
+    enabled: !!username && !!slug,
     queryFn: async () => {
       const response = (await gqlFetcher(GQL_GET_LIBRARY_ITEM_CONTENT, {
         slug,


### PR DESCRIPTION
This prevents us from making an initial fetch with an undefined
slug and username that then returns a 400. This happens because
router isn't setup when we first make the call.
