### PR TITLE
fix: Quoted redis url in compose causing error

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -99,7 +99,7 @@ services:
       - CLIENT_URL=http://localhost:3000
       - GATEWAY_URL=http://localhost:8080/api
       - CONTENT_FETCH_URL=http://content-fetch:8080/?token=some_token
-      - REDIS_URL='redis://redis:6379'
+      - REDIS_URL=redis://redis:6379
     depends_on:
       migrate:
         condition: service_completed_successfully


### PR DESCRIPTION
When following the readme to run the app through docker compose the following error gets spammed in the logs:

```
omnivore-api            | [ioredis] Unhandled error event: Error: connect ENOENT %27redis://redis:6379%27
omnivore-api            |     at PipeConnectWrap.afterConnect [as oncomplete] (node:net:1494:16)
omnivore-api            |     at PipeConnectWrap.callbackTrampoline (node:internal/async_hooks:130:17)
```

This is most likely caused by the quotes being interpreted.