### PR TITLE
fix: Library Header layout shift

### DIFF
--- a/packages/web/components/elements/icons/HeaderToggleGridIcon.tsx
+++ b/packages/web/components/elements/icons/HeaderToggleGridIcon.tsx
@@ -21,8 +21,8 @@ export class HeaderToggleGridIcon extends React.Component<IconProps> {
         }}
       >
         <svg
-          width="40"
-          height="40"
+          width="38"
+          height="38"
           viewBox="0 0 40 40"
           fill="none"
           xmlns="http://www.w3.org/2000/svg"

--- a/packages/web/components/elements/icons/HeaderToggleListIcon.tsx
+++ b/packages/web/components/elements/icons/HeaderToggleListIcon.tsx
@@ -21,8 +21,8 @@ export class HeaderToggleListIcon extends React.Component<IconProps> {
         }}
       >
         <svg
-          width="40"
-          height="40"
+          width="38"
+          height="38"
           viewBox="0 0 40 40"
           fill="none"
           xmlns="http://www.w3.org/2000/svg"


### PR DESCRIPTION
| AS-IS | TO-BE |
|--------|--------|
| <video src='https://github.com/user-attachments/assets/30e656ad-b750-416c-b236-f6bc9718628f' /> | <video src='https://github.com/user-attachments/assets/32643136-5f86-423f-95e5-9089db2fd8c2'/> | 


When the checkbox is toggled, the GridIcon disappears, causing a layout shift. This occurs because while the entire container has a height of 38px, the icon itself has a height of 40px.