### PR TITLE
fix: resolve local redis and docker build errors

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -99,7 +99,7 @@ services:
       - CLIENT_URL=http://localhost:3000
       - GATEWAY_URL=http://localhost:8080/api
       - CONTENT_FETCH_URL=http://content-fetch:8080/?token=some_token
-      - REDIS_URL='redis://redis:6379'
+      - REDIS_URL=redis://redis:6379
     depends_on:
       migrate:
         condition: service_completed_successfully

--- a/packages/api/Dockerfile
+++ b/packages/api/Dockerfile
@@ -27,6 +27,8 @@ ADD /packages/content-handler ./packages/content-handler
 ADD /packages/liqe ./packages/liqe
 ADD /packages/utils ./packages/utils
 
+ENV NODE_OPTIONS=--max-old-space-size=4096
+
 RUN yarn workspace @omnivore/utils build
 RUN yarn workspace @omnivore/text-to-speech-handler build
 RUN yarn workspace @omnivore/content-handler build


### PR DESCRIPTION
I encountered a couple of issues when running the app locally, which this PR addresses:

1. **Fix for MacBook M1 build issue** (commit: 81dbccacca90818f9377e26609afb7e081179d5d, closes [#3315](https://github.com/omnivore-app/omnivore/issues/3315)):  
   - On a MacBook Air M1 8GB, I ran into the issue described in #3315. This commit resolves it.  
   - The change mirrors an existing step in the [`runner` stage](https://github.com/rbarbazz/omnivore/blob/81dbccacca90818f9377e26609afb7e081179d5d/packages/api/Dockerfile#L51), so it should not affect the current build pipeline.

2. **Fix for Redis connection error** (commit: f7ae2a44c7793774debe8cff1f676020de83308f):  
   - While running `docker compose up api content-fetch`, I encountered this error:
     ```console
     omnivore-api            | [ioredis] Unhandled error event: Error: connect ENOENT %27redis://redis:6379%27
     omnivore-api            |     at PipeConnectWrap.afterConnect [as oncomplete] (node:net:1494:16)
     ```
   - Removing the single quotes around the default `REDIS_URL` fixed the issue.
   **Edit:** I just noticed there's already another PR that implements this fix https://github.com/omnivore-app/omnivore/pull/4378, happy to revert.
