### PR TITLE
feat(Notebook): enable HTML mode toggle for article notes

### DIFF
--- a/packages/web/components/patterns/ArticleNotes.tsx
+++ b/packages/web/components/patterns/ArticleNotes.tsx
@@ -54,6 +54,7 @@ export function ArticleNotes(props: NoteSectionProps): JSX.Element {
       setText={props.setText}
       saveText={saveText}
       fillBackground={false}
+      isExpanded
     />
   )
 }
@@ -104,6 +105,7 @@ export function HighlightViewNote(props: HighlightViewNoteProps): JSX.Element {
       setText={props.setText}
       saveText={saveText}
       fillBackground={true}
+      isExpanded={false}
     />
   )
 }
@@ -116,6 +118,7 @@ type MarkdownNote = {
   text: string | undefined
   setText: (text: string) => void
   fillBackground: boolean | undefined
+  isExpanded: boolean
 
   saveText: (text: string) => void
 }
@@ -204,11 +207,12 @@ export function MarkdownNote(props: MarkdownNote): JSX.Element {
           'block-quote',
           'link',
           'auto-resize',
+          'mode-toggle',
           'save',
         ]}
         style={{
           width: '100%',
-          height: '180px',
+          height: props.isExpanded ? '360px' : '180px',
         }}
         renderHTML={(text: string) => mdParser.render(text)}
         onChange={handleEditorChange}

--- a/packages/web/components/patterns/MDEditorSavePlugin.tsx
+++ b/packages/web/components/patterns/MDEditorSavePlugin.tsx
@@ -17,7 +17,14 @@ export default class MDEditorSavePlugin extends PluginComponent {
     return (
       <Button
         style="plainIcon"
-        css={{ display: 'flex', pr: '5px' }}
+        css={{
+          alignItems: 'center',
+          display: 'flex',
+          height: '28px',
+          justifyContent: 'center',
+          lineHeight: '28px',
+          minWidth: '24px',
+        }}
         onClick={(event) => {
           document.dispatchEvent(new Event('saveMarkdownNote'))
           event.preventDefault()


### PR DESCRIPTION
## Context

I use [omnivore-ai-annotations](https://github.com/jancbeck/omnivore-ai-annotations) to generate article summaries in markdown. Reading summaries in Omnivore is sub-optimal as:
- The markdown displays in a small, non-resizable text-area.
- There is no option to toggle between markdown and HTML views.

## Solution

Enable the "mode-toggle" plugin in the markdown editor. This plugin allows users to toggle between writing and reading modes, similar to Obsidian. I also increased the editor's height for article notes for a better reading experience.

Feedback appreciated 🙏 

**Note:** I was unable to run the content fetching service locally (see https://github.com/omnivore-app/omnivore/issues/4269) and didn't test my changes with highlights.

## Screenshots

| Markdown | HTML |
|---|---|
| <img width="1552" alt="Screenshot 2024-10-25 at 3 30 44 AM" src="https://github.com/user-attachments/assets/450baa84-2152-4024-9dd8-7b7e82545606">  |  <img width="1552" alt="Screenshot 2024-10-25 at 3 30 49 AM" src="https://github.com/user-attachments/assets/0b91f615-8436-4aa4-92c6-c269ae08b752"> |
|  <img width="1552" alt="Screenshot 2024-10-25 at 3 31 28 AM" src="https://github.com/user-attachments/assets/e393577e-fb14-4eaa-84c8-e91a656452fe"> | <img width="1552" alt="Screenshot 2024-10-25 at 3 31 21 AM" src="https://github.com/user-attachments/assets/137b8a7f-0f8d-419e-b947-0facd1160d02">  |
|<img width="1552" alt="Screenshot 2024-10-25 at 3 32 24 AM" src="https://github.com/user-attachments/assets/0f5e30b8-eeb8-44f6-b209-6f59326b8c92">  | <img width="1552" alt="Screenshot 2024-10-25 at 3 32 30 AM" src="https://github.com/user-attachments/assets/70a8a005-dd89-48f0-88b0-a2b79c23f993"> |