### PR TITLE
Fix: incorrect group name when reading custom environment

### DIFF
--- a/apple/OmnivoreKit/Sources/Models/AppEnvironment.swift
+++ b/apple/OmnivoreKit/Sources/Models/AppEnvironment.swift
@@ -60,7 +60,7 @@ public extension AppEnvironment {
   var environmentConfigured: Bool {
     if self == .custom {
       guard
-        let sharedDefaults = UserDefaults(suiteName: "group.app.omnnivoreapp"),
+        let sharedDefaults = UserDefaults(suiteName: "group.app.omnivoreapp"),
         let str = sharedDefaults.string(forKey: AppEnvironmentUserDefaultKey.serverBaseURL.rawValue),
         let url = URL(string: str) 
       else {
@@ -100,7 +100,7 @@ public extension AppEnvironment {
       return URL(string: "http://localhost:4000")!
     case .custom:
       guard
-        let sharedDefaults = UserDefaults(suiteName: "group.app.omnnivoreapp"),
+        let sharedDefaults = UserDefaults(suiteName: "group.app.omnivoreapp"),
         let str = sharedDefaults.string(forKey: AppEnvironmentUserDefaultKey.serverBaseURL.rawValue),
         let url = URL(string: str)
       else {
@@ -120,7 +120,7 @@ public extension AppEnvironment {
       return URL(string: "http://localhost:3000")!
     case .custom:
       guard
-        let sharedDefaults = UserDefaults(suiteName: "group.app.omnnivoreapp"),
+        let sharedDefaults = UserDefaults(suiteName: "group.app.omnivoreapp"),
         let str = sharedDefaults.string(forKey: AppEnvironmentUserDefaultKey.webAppBaseURL.rawValue),
         let url = URL(string: str)
       else {
@@ -140,7 +140,7 @@ public extension AppEnvironment {
       return URL(string: "http://localhost:8080")!
     case .custom:
       guard
-        let sharedDefaults = UserDefaults(suiteName: "group.app.omnnivoreapp"),
+        let sharedDefaults = UserDefaults(suiteName: "group.app.omnivoreapp"),
         let str = sharedDefaults.string(forKey: AppEnvironmentUserDefaultKey.ttsBaseURL.rawValue),
         let url = URL(string: str)
       else {


### PR DESCRIPTION
This fixes the crash experienced after setting a custom environment.

This regression seems to have been introduced 8 months ago already in https://github.com/omnivore-app/omnivore/pull/4110.