### PR TITLE
change policy to anonymous for minio, as "mc: Please use 'mc anonymous'"

### DIFF
--- a/self-hosting/docker-compose/docker-compose.yml
+++ b/self-hosting/docker-compose/docker-compose.yml
@@ -132,7 +132,7 @@ services:
       sleep 5;
       until (/usr/bin/mc config host add myminio http://minio:9000 minio miniominio) do echo '...waiting...' && sleep 1; done;
       /usr/bin/mc mb myminio/omnivore;
-      /usr/bin/mc policy set public myminio/omnivore;
+      /usr/bin/mc anonymous set public myminio/omnivore;
       exit 0;
       "
   mail-watch-server:


### PR DESCRIPTION
Hi, I'm running the self-hosting omnivore and encounter "mc: Please use 'mc anonymous'" in the minio container, found that running `/usr/bin/mc anonymous set public myminio/omnivore` instead works.

Here's some log:
```
bash-5.1# /usr/bin/mc config host add myminio http://minio:9000 minio miniominio
Added `myminio` successfully.
bash-5.1# /usr/bin/mc mb myminio/omnivore
mc: <ERROR> Unable to make bucket `myminio/omnivore`. Your previous request to create the named bucket succeeded and you already own it.
bash-5.1# /usr/bin/mc ls myminio
[2025-03-08 03:40:01 UTC]     0B omnivore/
bash-5.1# /usr/bin/mc policy set public myminio/omnivore
mc: Please use 'mc anonymous'
bash-5.1# /usr/bin/mc policy set public myminio/omnivore
mc: Please use 'mc anonymous'
bash-5.1# /usr/bin/mc anonymous
```

Hopes it helps.