### PR TITLE
Fixing issue with mail content from SNS that is base64 encoded

### DIFF
--- a/packages/local-mail-watcher/src/lib/base64.js
+++ b/packages/local-mail-watcher/src/lib/base64.js
@@ -1,0 +1,19 @@
+/**
+ * Utility functions for handling base64 encoding/decoding
+ */
+
+/**
+ * Decodes a base64 string to UTF-8 text
+ * Uses Node.js Buffer but with type safety
+ */
+export function decodeBase64(base64String: string): string {
+    try {
+      // Use a type-safe approach without relying on global
+      // @ts-ignore - Ignore TypeScript error for Buffer
+      return Buffer.from(base64String, 'base64').toString('utf-8');
+    } catch (error) {
+      console.error('Error decoding base64 string:', error);
+      return base64String; // Return original string if decoding fails
+    }
+  }
+  


### PR DESCRIPTION
I was not seeing newsletters and other test emails come through successfully to omnivore. After a bunch of debug logging calls I finally figured out that I was getting base64'ed content and it failed to be parsed by the simpleParser. By detecting when the content is base64 based on a property in the SNS notification and then base64 decoding I was able to get these messages to be correctly processed and then consumed into my omnivore library.

I figured others may appreciate this fix as well.