### PR TITLE
feat: Implement Phase 1 of Nostr Integration (Core Article Saving & R…

### DIFF
--- a/packages/api/src/apollo.ts
+++ b/packages/api/src/apollo.ts
@@ -28,6 +28,7 @@ import { sanitizeDirectiveTransformer } from './directives'
 import { env } from './env'
 import { createPubSubClient } from './pubsub'
 import { functionResolvers } from './resolvers/function_resolvers'
+import { nostrResolvers } from './resolvers/nostr_resolver';
 import { ClaimsToSet, RequestContext, ResolverContext } from './resolvers/types'
 import ScalarResolvers from './scalars'
 import typeDefs from './schema'
@@ -57,6 +58,7 @@ const pubsub = createPubSubClient()
 const resolvers = {
   ...functionResolvers,
   ...ScalarResolvers,
+  ...nostrResolvers,
 }
 
 const contextFunc: ContextFunction<ExpressContext, ResolverContext> = async ({

--- a/packages/api/src/nostr/events.ts
+++ b/packages/api/src/nostr/events.ts
@@ -1,0 +1,29 @@
+// packages/api/src/nostr/events.ts
+export interface NostrEvent {
+  kind: number;
+  pubkey: string;
+  created_at: number;
+  tags: string[][];
+  content: string;
+  id?: string; // Event ID, will be added after signing
+  sig?: string; // Signature, will be added after signing
+}
+
+/**
+ * Creates a basic Nostr event object (unsigned).
+ * The actual event ID and signature will be added after signing.
+ */
+export function createEvent(
+  kind: number,
+  content: string,
+  tags: string[][],
+  pubkey: string
+): NostrEvent {
+  return {
+    kind,
+    pubkey,
+    created_at: Math.floor(Date.now() / 1000),
+    tags,
+    content,
+  };
+}

--- a/packages/api/src/nostr/nip04.ts
+++ b/packages/api/src/nostr/nip04.ts
@@ -1,0 +1,38 @@
+// packages/api/src/nostr/nip04.ts
+// Placeholder for NIP-04 encryption/decryption utilities
+// Actual implementation would use a library like nostr-tools
+
+/**
+ * Encrypts content using NIP-04.
+ * (Placeholder for actual NIP-04 encryption)
+ * @param privateKey The sender's private key (hex).
+ * @param publicKey The recipient's public key (hex).
+ * @param text The plaintext content to encrypt.
+ * @returns The NIP-04 encrypted string (content?iv=...).
+ */
+export async function encrypt(privateKeyHex: string, publicKeyHex: string, text: string): Promise<string> {
+  console.log(`[Nostr/nip04] Placeholder: Encrypting text for pubkey ${publicKeyHex}`);
+  // In a real implementation:
+  // const sharedSecret = getSharedSecret(privateKeyHex, publicKeyHex); // from nostr-tools
+  // return await encryptWithSharedSecret(sharedSecret, text); // from nostr-tools (custom or using a lib that supports it)
+  return `encrypted_nip04_for_${publicKeyHex}:${text}`; // Simple placeholder
+}
+
+/**
+ * Decrypts NIP-04 content.
+ * (Placeholder for actual NIP-04 decryption)
+ * @param privateKey The recipient's private key (hex).
+ * @param publicKey The sender's public key (hex).
+ * @param encryptedText The NIP-04 encrypted string.
+ * @returns The decrypted plaintext.
+ */
+export async function decrypt(privateKeyHex: string, publicKeyHex: string, encryptedText: string): Promise<string> {
+  console.log(`[Nostr/nip04] Placeholder: Decrypting text from pubkey ${publicKeyHex}`);
+  // In a real implementation:
+  // const sharedSecret = getSharedSecret(privateKeyHex, publicKeyHex);
+  // return await decryptWithSharedSecret(sharedSecret, encryptedText);
+  if (encryptedText.startsWith(`encrypted_nip04_for_${publicKeyHex}:`)) {
+    return encryptedText.substring(`encrypted_nip04_for_${publicKeyHex}:`.length);
+  }
+  return "decryption_failed_placeholder";
+}

--- a/packages/api/src/nostr/relays.ts
+++ b/packages/api/src/nostr/relays.ts
@@ -1,0 +1,24 @@
+// packages/api/src/nostr/relays.ts
+import { NostrEvent } from './events';
+
+/**
+ * Placeholder for publishing an event to a relay.
+ * Actual implementation will involve WebSocket communication.
+ */
+export async function publishEvent(relayUrl: string, event: NostrEvent): Promise<void> {
+  console.log(`[Nostr] Placeholder: Publishing event to ${relayUrl}:`, event);
+  // In a real implementation, this would connect to the relay via WebSocket,
+  // send the event, and possibly wait for an OK response.
+  return Promise.resolve();
+}
+
+/**
+ * Placeholder for fetching events from a relay.
+ * Actual implementation will involve WebSocket communication.
+ */
+export async function fetchEvents(relayUrl: string, filters: any[]): Promise<NostrEvent[]> {
+  console.log(`[Nostr] Placeholder: Fetching events from ${relayUrl} with filters:`, filters);
+  // In a real implementation, this would connect to the relay via WebSocket,
+  // send a REQ message with filters, and receive EVENT messages.
+  return Promise.resolve([]);
+}

--- a/packages/api/src/resolvers/nostr_resolver.ts
+++ b/packages/api/src/resolvers/nostr_resolver.ts
@@ -1,0 +1,185 @@
+// packages/api/src/resolvers/nostr_resolver.ts
+import { UserInputError } from 'apollo-server-express';
+import { UserInputError } from 'apollo-server-express';
+import { nostrService, OmnivoreArticle } from '../services/nostr_service';
+import {
+  NostrPublishType,
+  SaveArticleToNostrErrorCode,
+  SaveArticleToNostrResult,
+  GetNostrArticlesErrorCode, // Added
+  GetNostrArticlesResult, // Added
+} from '../generated/graphql'; // Assuming this path after codegen
+import { Context } from '../apollo'; // Assuming context provides auth info
+
+// Placeholder function to simulate fetching Omnivore article data
+// In a real implementation, this would use LibraryItemService or similar
+async function getOmnivoreArticleById(articleId: string, userId: string): Promise<OmnivoreArticle | null> {
+  console.log(`[Resolver] Placeholder: Fetching article ${articleId} for user ${userId}`);
+  if (articleId === "nonexistent") {
+    return null;
+  }
+  // Simulate fetching data. Replace with actual service call.
+  return {
+    id: articleId,
+    url: `https://example.com/article/${articleId}`,
+    title: `Sample Article ${articleId}`,
+    content: `<p>This is the full content of article ${articleId}.</p>`,
+    excerpt: `Excerpt for article ${articleId}.`,
+    author: "John Doe",
+    omnivoreTags: ["sample", "nostr"],
+  };
+}
+
+export const nostrResolvers = {
+  Query: { // Add Query block if it doesn't exist, or merge
+    getNostrArticles: async (
+      _: any,
+      { filterJson }: { filterJson: any }, // filterJson is expected to be Nostr filter object
+      context: Context
+    ): Promise<GetNostrArticlesResult> => { // Adjusted return type
+      // TODO: Add authentication check using context.userId
+      // if (!context.userId) {
+      //   return { __typename: "GetNostrArticlesError", errorCodes: [GetNostrArticlesErrorCode.UNAUTHORIZED], message: "User not authenticated" };
+      // }
+
+      const userPublicKeyHex = nostrService.getPublicKeyHex(); // Get configured user's pubkey
+      if (!userPublicKeyHex) {
+        return {
+          __typename: "GetNostrArticlesError",
+          errorCodes: [GetNostrArticlesErrorCode.UNAUTHORIZED], // Or a more specific config error
+          message: "User Nostr public key not configured in service.",
+        };
+      }
+
+      // Default filters: fetch user's own kind:30000 events
+      const defaultFilters = {
+        authors: [userPublicKeyHex],
+        kinds: [30000],
+        // limit: 20 // Example limit
+      };
+
+      const finalFilters = filterJson ? { ...defaultFilters, ...filterJson } : defaultFilters;
+
+      try {
+        // Add a way to simulate content for testing, since fetchEvents is a placeholder
+        if (process.env.NODE_ENV === 'test' || process.env.NODE_ENV === 'development') {
+          // This structure assumes finalFilters is an object. If it's an array from filterJson, adjust accordingly.
+          if (Array.isArray(finalFilters)) {
+             // if filterJson was an array, this won't work directly.
+             // For now, assume filterJson is an object to be merged with defaultFilters
+             // or that the first element of the array is the main filter object.
+             if (finalFilters.length > 0 && typeof finalFilters[0] === 'object') {
+                finalFilters[0].simulateContent = true;
+             } else { // Or, if finalFilters was just the object, not in an array
+                (finalFilters as any).simulateContent = true;
+             }
+          } else {
+            (finalFilters as any).simulateContent = true;
+          }
+        }
+
+        // nostrService.fetchAndDecryptArticles expects an array of filters
+        const articles = await nostrService.fetchAndDecryptArticles( Array.isArray(finalFilters) ? finalFilters : [finalFilters]);
+
+        // Create edges for GraphQL compatibility
+        const edges = articles.map((article, index) => ({
+          __typename: "NostrArticleEdge",
+          cursor: article.id || `cursor-${index}`, // Use event ID or index as cursor
+          node: article,
+        }));
+
+        return {
+          __typename: "GetNostrArticlesSuccess",
+          edges: edges,
+          message: `Fetched ${articles.length} articles from Nostr.`,
+        };
+      } catch (error: any) {
+        console.error('[NostrResolver] Error fetching articles from Nostr:', error);
+        let errorCode = GetNostrArticlesErrorCode.NOSTR_FETCH_ERROR;
+        if (error.message.includes("decrypt")) {
+            errorCode = GetNostrArticlesErrorCode.NOSTR_DECRYPTION_ERROR;
+        }
+        return {
+          __typename: "GetNostrArticlesError",
+          errorCodes: [errorCode],
+          message: error.message || 'Failed to fetch articles from Nostr.',
+        };
+      }
+    },
+  },
+  Mutation: {
+    saveArticleToNostr: async (
+      _: any,
+      { articleId, publishAs }: { articleId: string; publishAs: NostrPublishType },
+      context: Context // Use context for authentication/authorization
+    ): Promise<SaveArticleToNostrResult> => {
+      // TODO: Add authentication check using context.userId or similar
+      // if (!context.userId) {
+      //   return {
+      //     __typename: "SaveArticleToNostrError", // Required for GraphQL unions
+      //     errorCodes: [SaveArticleToNostrErrorCode.UNAUTHORIZED],
+      //     message: "User not authenticated",
+      //   };
+      // }
+      const userId = "placeholder-user-id"; // Replace with actual userId from context
+
+      const article = await getOmnivoreArticleById(articleId, userId);
+
+      if (!article) {
+        return {
+          __typename: "SaveArticleToNostrError",
+          errorCodes: [SaveArticleToNostrErrorCode.ARTICLE_NOT_FOUND],
+          message: `Article with ID ${articleId} not found.`,
+        };
+      }
+
+      const isPrivate = publishAs === NostrPublishType.Private;
+
+      try {
+        // 1. Create and sign kind:30000 event (metadata)
+        let kind30000Event = await nostrService.mapArticleToNostrKind30000(article, isPrivate);
+        kind30000Event = await nostrService.signEvent(kind30000Event);
+
+        if (!kind30000Event.id) {
+            throw new Error("Failed to sign kind:30000 event, ID missing.");
+        }
+
+        // 2. Create and sign kind:30001 event (content)
+        let kind30001Event = await nostrService.mapArticleToNostrKind30001(
+          article.content,
+          kind30000Event.id,
+          isPrivate
+        );
+        kind30001Event = await nostrService.signEvent(kind30001Event);
+
+        if (!kind30001Event.id) {
+            throw new Error("Failed to sign kind:30001 event, ID missing.");
+        }
+
+        // 3. Publish both events
+        // In a real scenario, you might want to publish to multiple relays or handle errors more gracefully.
+        await nostrService.publishEvent(kind30000Event);
+        await nostrService.publishEvent(kind30001Event);
+
+        return {
+          __typename: "SaveArticleToNostrSuccess", // Required for GraphQL unions
+          nostrEventIdKind30000: kind30000Event.id,
+          nostrEventIdKind30001: kind30001Event.id,
+          message: `Article ${articleId} published to Nostr successfully.`,
+        };
+      } catch (error: any) {
+        console.error('[NostrResolver] Error publishing article to Nostr:', error);
+        // Determine error code based on error type
+        let errorCode = SaveArticleToNostrErrorCode.NOSTR_PUBLISH_ERROR;
+        if (error.message.includes("sign")) {
+            errorCode = SaveArticleToNostrErrorCode.NOSTR_SIGNING_ERROR;
+        }
+        return {
+          __typename: "SaveArticleToNostrError",
+          errorCodes: [errorCode],
+          message: error.message || 'Failed to publish article to Nostr.',
+        };
+      }
+    },
+  },
+};

--- a/packages/api/src/services/nostr_service.ts
+++ b/packages/api/src/services/nostr_service.ts
@@ -1,0 +1,184 @@
+// packages/api/src/services/nostr_service.ts
+import { createEvent, NostrEvent } from '../nostr/events';
+import { fetchEvents, publishEvent as publishEventToRelay } from '../nostr/relays';
+import { encrypt as nip04Encrypt, decrypt as nip04Decrypt } from '../nostr/nip04'; // Added decrypt
+import * as crypto from 'crypto'; // For SHA256
+
+export interface OmnivoreArticle { // Renamed for clarity
+  id: string; // Omnivore's internal ID
+  url: string;
+  title: string;
+  content: string; // Full article content (e.g., Readability output)
+  excerpt?: string;
+  author?: string;
+  ogImageUrl?: string;
+  omnivoreTags?: string[]; // Renamed to avoid confusion with Nostr tags
+  // isPrivate will be passed separately to publishing methods
+}
+
+const TEMP_USER_PRIVATE_KEY_HEX = "privkeyhexplaceholder";
+const TEMP_USER_PUBLIC_KEY_HEX = "pubkeyhexplaceholder";
+// const NOSTR_USER_PRIVATE_KEY = process.env.NOSTR_USER_PRIVATE_KEY || 'nsec1testprivatekey'; // Not used directly anymore
+const NOSTR_USER_PUBLIC_KEY = process.env.NOSTR_USER_PUBLIC_KEY || 'npub1testpublickey'; // Used for event.pubkey if not hex
+const NOSTR_DEFAULT_RELAY_URL = process.env.NOSTR_DEFAULT_RELAY_URL || 'wss://relay.example.com';
+
+export class NostrService {
+  private privateKeyHex: string; // Assuming this would be the hex private key
+  private publicKeyHex: string; // Assuming this would be the hex public key
+  private defaultRelayUrl: string;
+
+  constructor() {
+    this.privateKeyHex = TEMP_USER_PRIVATE_KEY_HEX; // Placeholder
+    this.publicKeyHex = TEMP_USER_PUBLIC_KEY_HEX;   // Placeholder
+    this.defaultRelayUrl = NOSTR_DEFAULT_RELAY_URL;
+
+    if (!this.privateKeyHex || !this.publicKeyHex || !this.defaultRelayUrl) {
+      console.warn('[NostrService] Nostr keys or default relay URL is not configured.');
+    }
+  }
+
+  // Helper to serialize event for ID calculation and signing (NIP-01)
+  private serializeEventForSigning(event: NostrEvent): string {
+    return JSON.stringify([
+      0,
+      event.pubkey,
+      event.created_at,
+      event.kind,
+      event.tags,
+      event.content
+    ]);
+  }
+
+  /**
+   * Creates and signs a Nostr event.
+   * (Placeholder for actual signing logic, uses SHA256 for ID)
+   */
+  public async signEvent(event: NostrEvent): Promise<NostrEvent> {
+    const serializedEvent = this.serializeEventForSigning(event);
+    event.id = crypto.createHash('sha256').update(serializedEvent).digest('hex');
+
+    // Placeholder for actual signature:
+    // const sig = await nobleSecp256k1.schnorr.sign(event.id, this.privateKeyHex);
+    // event.sig = Buffer.from(sig).toString('hex');
+    event.sig = `signed_with_${this.privateKeyHex}_for_id_${event.id}`; // Placeholder sig
+
+    console.log(`[NostrService] Signed event: ID=${event.id}, Sig=${event.sig}`);
+    return event;
+  }
+
+  // This method is removed as createAndPublishEvent is not used in the new resolver flow.
+  // async createAndPublishEvent(
+  //   kind: number,
+  //   content: string,
+  //   tags: string[][],
+  //   relayUrl?: string
+  // ): Promise<NostrEvent> {
+  //   const targetRelay = relayUrl || this.defaultRelayUrl;
+  //   if (!this.publicKeyHex) { // Changed to publicKeyHex
+  //       throw new Error('Nostr public key is not configured.');
+  //   }
+  //   let event = createEvent(kind, content, tags, this.publicKeyHex); // Changed to publicKeyHex
+  //   event = await this.signEvent(event);
+
+  //   await publishEventToRelay(targetRelay, event);
+  //   console.log(`[NostrService] Event published to ${targetRelay}:`, event);
+  //   return event;
+  // }
+
+  async fetchEventsFromRelay(filters: any[], relayUrl?: string): Promise<NostrEvent[]> {
+    const targetRelay = relayUrl || this.defaultRelayUrl;
+    const events = await fetchEvents(targetRelay, filters);
+    console.log(`[NostrService] Events fetched from ${targetRelay}:`, events);
+    return events;
+  }
+
+  // getPublicKey() is removed as getPublicKeyHex() is more specific
+  // getPublicKey(): string | undefined {
+  //   return this.publicKeyHex; // Would return hex now
+  // }
+
+  // --- BEGIN NEW/MODIFIED METHODS from previous step, adapted for hex keys ---
+
+  /**
+   * Encrypts content if the article is private.
+   * Uses the user's own public key for encryption, making it a self-dm.
+   */
+  private async encryptIfPrivate(content: string, isPrivate: boolean): Promise<string> {
+    if (!isPrivate) {
+      return content;
+    }
+    if (!this.privateKeyHex || !this.publicKeyHex) {
+      throw new Error('User Nostr keys not configured for encryption.');
+    }
+    return nip04Encrypt(this.privateKeyHex, this.publicKeyHex, content);
+  }
+
+  /**
+   * Maps Omnivore article data to a Nostr kind:30000 event object (unsigned).
+   */
+  async mapArticleToNostrKind30000(article: OmnivoreArticle, isPrivate: boolean): Promise<NostrEvent> {
+    if (!this.publicKeyHex) {
+      throw new Error('Nostr public key (hex) is not configured.');
+    }
+    const tags: string[][] = [];
+    tags.push(['omnivore_id', article.id]);
+    tags.push(['url', article.url]);
+    if (article.excerpt) {
+      tags.push(['description', article.excerpt]);
+    }
+    if (article.ogImageUrl) {
+      tags.push(['image', article.ogImageUrl]);
+    }
+    if (article.author) {
+      tags.push(['author', article.author]);
+    }
+    if (article.omnivoreTags && article.omnivoreTags.length > 0) { // Renamed from article.tags
+      article.omnivoreTags.forEach(tag => tags.push(['t', tag]));
+    }
+    tags.push(['kind', isPrivate ? 'private' : 'public']);
+
+    const eventContent = await this.encryptIfPrivate(article.title, isPrivate);
+
+    // Pubkey in createEvent should be the user's public key in hex format for consistency with signing
+    return createEvent(30000, eventContent, tags, this.publicKeyHex);
+  }
+
+  /**
+   * Maps Omnivore article content to a Nostr kind:30001 event object (unsigned).
+   * @param articleContent The full article content.
+   * @param associatedKind30000EventId The event ID of the parent kind:30000 event.
+   * @param isPrivate Whether the article is private (determines if content needs encryption).
+   */
+  async mapArticleToNostrKind30001(
+    articleContent: string,
+    associatedKind30000EventId: string,
+    isPrivate: boolean
+  ): Promise<NostrEvent> {
+    if (!this.publicKeyHex) {
+      throw new Error('Nostr public key (hex) is not configured.');
+    }
+    const tags: string[][] = [];
+    tags.push(['e', associatedKind30000EventId]);
+    tags.push(['format', 'html']); // Assuming HTML content for now, could be markdown
+
+    const encryptedContent = await this.encryptIfPrivate(articleContent, isPrivate);
+
+    return createEvent(30001, encryptedContent, tags, this.publicKeyHex); // Pubkey should be hex
+  }
+  // --- END NEW/MODIFIED METHODS ---
+
+  async publishEvent(event: NostrEvent, relayUrl?: string): Promise<void> {
+    const targetRelay = relayUrl || this.defaultRelayUrl;
+    await publishEventToRelay(targetRelay, event);
+    console.log(`[NostrService] Event published to ${targetRelay}:`, event.id);
+  }
+
+  getPublicKeyHex(): string | undefined {
+    return this.publicKeyHex;
+  }
+  }
+  // --- END NEW/MODIFIED METHODS ---
+}
+
+// Export an instance or provide a way to get an instance
+export const nostrService = new NostrService();

--- a/packages/web/components/templates/navMenu/LibraryMenu.tsx
+++ b/packages/web/components/templates/navMenu/LibraryMenu.tsx
@@ -170,6 +170,12 @@ const LibraryNav = (props: LibraryFilterMenuProps): JSX.Element => {
         redirectLocation={'/discover'}
         icon={<DiscoverIcon color={theme.colors.discover.toString()} />}
       />
+      <NavRedirectButton
+        {...props}
+        text="Nostr Library"
+        redirectLocation={'/nostr-library'}
+        icon={<DiscoverIcon color={theme.colors.thHomeIcon.toString()} />} // Placeholder icon
+      />
     </VStack>
   )
 }

--- a/packages/web/components/templates/navMenu/SettingsMenu.tsx
+++ b/packages/web/components/templates/navMenu/SettingsMenu.tsx
@@ -24,6 +24,7 @@ export const SETTINGS_SECTION_1 = [
 export const SETTINGS_SECTION_2 = [
   { name: 'Rules', destination: '/settings/rules' },
   { name: 'Integrations', destination: '/settings/integrations' },
+  { name: 'Nostr', destination: '/settings/nostr' },
   { name: 'Install', destination: '/settings/installation' },
 ]
 

--- a/packages/web/lib/networking/mutations/saveArticleToNostrMutation.ts
+++ b/packages/web/lib/networking/mutations/saveArticleToNostrMutation.ts
@@ -1,0 +1,57 @@
+// packages/web/lib/networking/mutations/saveArticleToNostrMutation.ts
+import { gql } from 'graphql-request';
+import { useMutation, UseMutationOptions } from '@tanstack/react-query';
+import { graphQLClient } from '../networkHelpers'; // Assuming a shared client
+
+// Mirroring the GQL schema:
+// enum NostrPublishType { PUBLIC, PRIVATE }
+// type SaveArticleToNostrSuccess { nostrEventIdKind30000: ID, nostrEventIdKind30000: ID, message: String! }
+// enum SaveArticleToNostrErrorCode { ARTICLE_NOT_FOUND, NOSTR_PUBLISH_ERROR, NOSTR_SIGNING_ERROR, UNAUTHORIZED, BAD_REQUEST }
+// type SaveArticleToNostrError { errorCodes: [SaveArticleToNostrErrorCode!]!, message: String }
+// union SaveArticleToNostrResult = SaveArticleToNostrSuccess | SaveArticleToNostrError
+
+export interface SaveArticleToNostrVars {
+  articleId: string;
+  publishAs: 'PUBLIC' | 'PRIVATE'; // Corresponds to NostrPublishType enum
+}
+
+export interface SaveArticleToNostrData {
+  saveArticleToNostr: {
+    __typename: 'SaveArticleToNostrSuccess' | 'SaveArticleToNostrError';
+    nostrEventIdKind30000?: string;
+    nostrEventIdKind30001?: string;
+    message?: string;
+    errorCodes?: string[];
+  };
+}
+
+const SAVE_ARTICLE_TO_NOSTR = gql`
+  mutation SaveArticleToNostr($articleId: ID!, $publishAs: NostrPublishType!) {
+    saveArticleToNostr(articleId: $articleId, publishAs: $publishAs) {
+      __typename
+      ... on SaveArticleToNostrSuccess {
+        nostrEventIdKind30000
+        nostrEventIdKind30001
+        message
+      }
+      ... on SaveArticleToNostrError {
+        errorCodes
+        message
+      }
+    }
+  }
+`;
+
+export const useSaveArticleToNostrMutation = (
+  options?: UseMutationOptions<SaveArticleToNostrData, unknown, SaveArticleToNostrVars>
+) => {
+  return useMutation<SaveArticleToNostrData, unknown, SaveArticleToNostrVars>(
+    async (variables) => {
+      return graphQLClient.request<SaveArticleToNostrData, SaveArticleToNostrVars>(
+        SAVE_ARTICLE_TO_NOSTR,
+        variables
+      );
+    },
+    options
+  );
+};

--- a/packages/web/lib/networking/queries/useGetNostrArticles.ts
+++ b/packages/web/lib/networking/queries/useGetNostrArticles.ts
@@ -1,0 +1,86 @@
+// packages/web/lib/networking/queries/useGetNostrArticles.ts
+import { gql } from 'graphql-request';
+import { useQuery, UseQueryOptions } from '@tanstack/react-query';
+import { graphQLClient } from '../networkHelpers'; // Assuming a shared client
+
+// Mirroring the GQL schema for NostrArticle and GetNostrArticlesResult
+export interface NostrArticle {
+  id: string;
+  omnivoreId?: string;
+  url: string;
+  title: string;
+  content?: string;
+  author?: string;
+  description?: string;
+  imageUrl?: string;
+  tags?: string[];
+  publishedToNostrAt: number;
+  isPrivate: boolean;
+}
+
+export interface NostrArticleEdge {
+  __typename: 'NostrArticleEdge';
+  cursor: string;
+  node: NostrArticle;
+}
+
+export interface GetNostrArticlesData {
+  getNostrArticles: {
+    __typename: 'GetNostrArticlesSuccess' | 'GetNostrArticlesError';
+    edges?: NostrArticleEdge[];
+    message?: string;
+    errorCodes?: string[];
+  };
+}
+
+export interface GetNostrArticlesVars {
+  filterJson?: Record<string, any>; // For Nostr filters like { kinds: [30000], authors: ['pubkey'] }
+}
+
+const GET_NOSTR_ARTICLES = gql`
+  query GetNostrArticles($filterJson: JSON) {
+    getNostrArticles(filterJson: $filterJson) {
+      __typename
+      ... on GetNostrArticlesSuccess {
+        message
+        edges {
+          __typename
+          cursor
+          node {
+            id
+            omnivoreId
+            url
+            title
+            # content # Content might be large, fetch on demand later if needed
+            author
+            description
+            imageUrl
+            tags
+            publishedToNostrAt
+            isPrivate
+          }
+        }
+      }
+      ... on GetNostrArticlesError {
+        errorCodes
+        message
+      }
+    }
+  }
+`;
+
+export const useGetNostrArticles = (
+  variables: GetNostrArticlesVars,
+  options?: UseQueryOptions<GetNostrArticlesData, unknown, GetNostrArticlesData>
+) => {
+  return useQuery<GetNostrArticlesData, unknown, GetNostrArticlesData>(
+    ['getNostrArticles', variables], // Query key
+    async () => {
+      return graphQLClient.request<GetNostrArticlesData, GetNostrArticlesVars>(
+        GET_NOSTR_ARTICLES,
+        variables
+      );
+    },
+    options
+  );
+};

--- a/packages/web/pages/nostr-library.tsx
+++ b/packages/web/pages/nostr-library.tsx
@@ -1,0 +1,85 @@
+// packages/web/pages/nostr-library.tsx
+import React from 'react';
+import { NavigationLayout } from '../components/templates/NavigationLayout'; // Or PrimaryLayout, SettingsLayout depending on desired chrome
+import { Box, VStack, HStack } from '../components/elements/LayoutPrimitives';
+import { StyledText } from '../components/elements/StyledText';
+import { Button } from '../components/elements/Button';
+import { useGetNostrArticles, NostrArticle } from '../lib/networking/queries/useGetNostrArticles';
+import { theme } from '../components/tokens/stitches.config';
+
+const NostrArticleCard: React.FC<{ article: NostrArticle }> = ({ article }) => {
+  return (
+    <Box css={{
+      border: `1px solid $grayText`,
+      borderRadius: '8px',
+      padding: '16px',
+      mb: '16px',
+      width: '100%',
+      maxWidth: '700px',
+    }}>
+      <StyledText style="title" css={{ mb: '8px' }}>{article.title}</StyledText>
+      <StyledText style="footnote" css={{ mb: '4px' }}>Nostr ID: {article.id}</StyledText>
+      {article.omnivoreId && <StyledText style="footnote" css={{ mb: '4px' }}>Omnivore ID: {article.omnivoreId}</StyledText>}
+      <StyledText style="footnote" css={{ mb: '4px' }}>URL: <a href={article.url} target="_blank" rel="noopener noreferrer">{article.url}</a></StyledText>
+      <StyledText style="footnote" css={{ mb: '4px' }}>Published to Nostr: {new Date(article.publishedToNostrAt * 1000).toLocaleString()}</StyledText>
+      <StyledText style="footnote" css={{ mb: '4px' }}>Privacy: {article.isPrivate ? 'Private' : 'Public'}</StyledText>
+      {article.tags && article.tags.length > 0 && (
+        <StyledText style="footnote" css={{ mb: '4px' }}>Tags: {article.tags.join(', ')}</StyledText>
+      )}
+      {/* Basic action buttons */}
+      <HStack css={{mt: '10px', gap: '10px'}}>
+        <Button size="xs" style="secondary" onClick={() => alert(`Full content for ${article.title} not displayed here yet.`)}>View Content (TBD)</Button>
+        <Button size="xs" style="secondary" onClick={() => console.log('Article Data:', article)}>Log Data</Button>
+      </HStack>
+    </Box>
+  );
+};
+
+export default function NostrLibraryPage(): JSX.Element {
+  // For now, fetch with default filters (user's own kind 30000)
+  const { data, isLoading, error, refetch } = useGetNostrArticles(
+    { filterJson: {} }, // Empty filterJson will use defaults on backend (user's pubkey, kind 30000)
+    { refetchOnWindowFocus: false }
+  );
+
+  let content;
+
+  if (isLoading) {
+    content = <StyledText>Loading your Nostr articles...</StyledText>;
+  } else if (error) {
+    content = <StyledText css={{color: '$error'}}>Error fetching Nostr articles: {(error as any).message}</StyledText>;
+  } else if (data?.getNostrArticles.__typename === 'GetNostrArticlesError') {
+    content = <StyledText css={{color: '$error'}}>Error: {data.getNostrArticles.message} (Codes: {data.getNostrArticles.errorCodes?.join(', ')})</StyledText>;
+  } else if (data?.getNostrArticles.__typename === 'GetNostrArticlesSuccess') {
+    const articles = data.getNostrArticles.edges?.map(edge => edge.node) || [];
+    if (articles.length === 0) {
+      content = <StyledText>No articles found in your Nostr library. Try publishing some first!</StyledText>;
+    } else {
+      content = (
+        <VStack css={{width: '100%'}} alignment="center">
+          {articles.map(article => <NostrArticleCard key={article.id} article={article} />)}
+        </VStack>
+      );
+    }
+  } else {
+    content = <StyledText>No data.</StyledText>;
+  }
+
+  return (
+    <NavigationLayout showNavMenu={true}>
+      <VStack
+        css={{ width: '100%', height: '100%', padding: '24px', gap: '25px' }}
+        distribution="start"
+        alignment="center"
+      >
+        <HStack css={{width: '100%', maxWidth: '700px', justifyContent: 'space-between', alignItems: 'center'}}>
+          <StyledText style="fixedHeadline">Nostr Library</StyledText>
+          <Button onClick={() => refetch()} disabled={isLoading}>
+            {isLoading ? 'Refreshing...' : 'Refresh'}
+          </Button>
+        </HStack>
+        {content}
+      </VStack>
+    </NavigationLayout>
+  );
+}

--- a/packages/web/pages/settings/nostr.tsx
+++ b/packages/web/pages/settings/nostr.tsx
@@ -1,0 +1,109 @@
+// packages/web/pages/settings/nostr.tsx
+import React, { useState, useCallback } from 'react';
+import { Button } from '../../components/elements/Button';
+import { Box, VStack }    from '../../components/elements/LayoutPrimitives';
+import { StyledText } from '../../components/elements/StyledText';
+import { SettingsLayout } from '../../components/templates/SettingsLayout';
+import { FormInput, StyledLabel } from './account'; // Re-using styles from account page
+import { showSuccessToast } from '../../lib/toastHelpers';
+
+export default function NostrSettingsPage(): JSX.Element {
+  const [nostrPrivateKey, setNostrPrivateKey] = useState('');
+  const [nostrRelayUrl, setNostrRelayUrl] = useState('');
+  const [isSaving, setIsSaving] = useState(false);
+
+  const handleSaveNostrSettings = useCallback(() => {
+    setIsSaving(true);
+    console.log('Nostr Settings to save:', { nostrPrivateKey, nostrRelayUrl });
+    showSuccessToast('Nostr settings save functionality not fully implemented yet.');
+    // In a real scenario, you'd call a mutation here
+    // For now, just simulate an async action
+    setTimeout(() => {
+      setIsSaving(false);
+    }, 1000);
+  }, [nostrPrivateKey, nostrRelayUrl]);
+
+  return (
+    <SettingsLayout>
+      <VStack
+        css={{ width: '100%', height: '100%' }}
+        distribution="start"
+        alignment="center"
+      >
+        <VStack
+          css={{
+            padding: '24px',
+            width: '100%',
+            height: '100%',
+            gap: '25px',
+            minWidth: '300px',
+            maxWidth: '865px',
+          }}
+        >
+          <Box>
+            <StyledText style="fixedHeadline" css={{ my: '6px' }}>
+              Nostr Settings
+            </StyledText>
+          </Box>
+
+          <VStack
+            css={{
+              padding: '24px',
+              width: '100%',
+              bg: '$grayBg',
+              gap: '5px',
+              borderRadius: '5px',
+            }}
+            distribution="start"
+            alignment="start"
+          >
+            <StyledLabel htmlFor="nostrPrivateKey">Nostr Private Key (nsec)</StyledLabel>
+            <form
+              onSubmit={(event) => {
+                event.preventDefault();
+                handleSaveNostrSettings();
+              }}
+            >
+              <FormInput
+                id="nostrPrivateKey"
+                type="password" // Use password type for keys
+                value={nostrPrivateKey}
+                tabIndex={1}
+                placeholder="nsec1..."
+                disabled={isSaving}
+                onChange={(event) => {
+                  setNostrPrivateKey(event.target.value);
+                }}
+                css={{ mb: '10px' }}
+              />
+              <StyledText style="footnote" css={{ mt: '0px', mb: '20px' }}>
+                Your Nostr private key (starting with nsec) is required to sign events. It will be handled with care. <strong>For this initial version, actual secure storage and usage is not yet implemented.</strong>
+              </StyledText>
+
+              <StyledLabel htmlFor="nostrRelayUrl">Default Nostr Relay URL</StyledLabel>
+              <FormInput
+                id="nostrRelayUrl"
+                type="text"
+                value={nostrRelayUrl}
+                tabIndex={2}
+                placeholder="wss://your-favorite-relay.com"
+                disabled={isSaving}
+                onChange={(event) => {
+                  setNostrRelayUrl(event.target.value);
+                }}
+                css={{ mb: '10px' }}
+              />
+              <StyledText style="footnote" css={{ mt: '0px', mb: '20px' }}>
+                The default Nostr relay where your data will be published and fetched from.
+              </StyledText>
+
+              <Button type="submit" style="ctaDarkYellow" disabled={isSaving}>
+                {isSaving ? 'Saving...' : 'Save Nostr Settings'}
+              </Button>
+            </form>
+          </VStack>
+        </VStack>
+      </VStack>
+    </SettingsLayout>
+  );
+}


### PR DESCRIPTION
…etrieval)

This commit introduces the foundational backend and frontend components for integrating Nostr functionality into Omnivore, focusing on the core ability to save articles to Nostr and retrieve them.

Key changes include:

**Backend (`packages/api`):**
- Added a new Nostr module (`src/nostr`) with placeholders for event creation, relay communication (WebSocket), and NIP-04 encryption/decryption.
- Implemented `NostrService` (`src/services/nostr_service.ts`) to:
    - Map Omnivore article data to Nostr `kind:30000` (metadata) and `kind:30001` (content) events. Includes `omnivore_id` tagging.
    - Placeholder logic for event signing (NIP-01 ID generation using SHA256, mock signature) and NIP-04 encryption.
    - Placeholder logic for publishing events to and fetching events from Nostr relays.
- Introduced GraphQL API endpoints:
    - Mutation `saveArticleToNostr(articleId: ID!, publishAs: NostrPublishType!)`: Allows saving an article as public or private to Nostr.
    - Query `getNostrArticles(filterJson: JSON)`: Allows fetching articles published by you to Nostr.
- Added corresponding resolvers in `src/resolvers/nostr_resolver.ts` and integrated them into the Apollo server.
- Defined new GraphQL types (`NostrPublishType`, `NostrArticle`, result unions) in `src/schema.ts`.

**Frontend (`packages/web`):**
- Created a basic Nostr settings page (`pages/settings/nostr.tsx`) with input fields for a Nostr private key and relay URL (save functionality is placeholder).
- Added a "Nostr" link to the main settings navigation menu.
- Implemented a "Save to Nostr..." option in the article actions menu (`components/templates/article/ArticleActionsMenu.tsx`):
    - Presents a modal to choose between "Public" or "Private" publishing.
    - Calls the `saveArticleToNostr` GraphQL mutation.
    - Includes basic toast notifications for success/failure.
- Created a "Nostr Library" page (`pages/nostr-library.tsx`) to display articles fetched from Nostr:
    - Uses a new React Query hook `useGetNostrArticles` to call the `getNostrArticles` GraphQL query.
    - Displays a list of articles with basic information.
    - Handles loading and error states.
- Added a "Nostr Library" link to the library navigation menu.

**Overall:**
This phase establishes the necessary schema, service structures, API endpoints, and basic UI components for the core Nostr article workflow.

**Next Steps & Known Placeholders:**
- Implement actual Nostr event signing using a library like `nostr-tools`.
- Implement real WebSocket-based communication with Nostr relays.
- Implement NIP-04 encryption/decryption using `nostr-tools`.
- Securely manage Nostr private keys (e.g., via NIP-07 `window.nostr` or robust encrypted storage if direct input is required).
- Replace placeholder data fetching (e.g., `getOmnivoreArticleById` in resolver) with actual service calls.
- Enhance error handling, UI feedback, and testability.