### PR TITLE
Update imap-mail-watcher to use sender name as from field

### DIFF
--- a/packages/imap-mail-watcher/src/lib/emailApi.ts
+++ b/packages/imap-mail-watcher/src/lib/emailApi.ts
@@ -16,7 +16,7 @@ export const sendToEmailApi = (data: EmailContents) => {
 
 export const convertToMailObject = (it: ParsedMail): EmailContents => {
   return {
-    from: it.from?.value[0]?.address || '',
+    from: it.from?.value[0]?.name || it.from?.value[0]?.address || '',
     to: env.omnivoreEmail,
     subject: it.subject || '',
     html: it.html || '',


### PR DESCRIPTION
1 line change to address the issue I raised in [4583](https://github.com/omnivore-app/omnivore/issues/4583)

Changes the default value for 'from' from the sender email address to the sender name. Email address is used as a fallback.