### PR TITLE
feat: Add Podman Integration 

### DIFF
--- a/self-hosting/podman-compose/.env.example
+++ b/self-hosting/podman-compose/.env.example
@@ -1,0 +1,68 @@
+# Postgres & Migrate
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=postgres
+POSTGRES_DB=omnivore
+PGPASSWORD=postgres
+PG_REPLICATION=false
+PG_HOST=postgres
+PG_PASSWORD=app_pass
+PG_DB=omnivore
+PG_USER=app_user
+PG_PORT=5432
+PG_POOL_MAX=20
+
+# API
+API_ENV=local
+IMAGE_PROXY_SECRET=some-secret
+JWT_SECRET=some_secret
+SSO_JWT_SECRET=some_sso_secret
+GATEWAY_URL=http://api:8080/api
+CONTENT_FETCH_URL=http://content-fetch:8080/?token=some_token
+GCS_USE_LOCAL_HOST=true
+GCS_UPLOAD_BUCKET=omnivore
+AUTO_VERIFY=true
+AWS_ACCESS_KEY_ID=minio
+AWS_SECRET_ACCESS_KEY=miniominio
+AWS_REGION=us-east-1
+CONTENT_FETCH_QUEUE_ENABLED=true
+
+# IMPORTANT: These URLs must be adapted to your domain
+IMAGE_PROXY_URL=http://localhost:7070  # Change to https://your-domain.com:7070 for NGINX
+CLIENT_URL=http://localhost:3000       # Change to https://your-domain.com for NGINX
+LOCAL_MINIO_URL=http://minio:9000      # Internal URL for MinIO
+
+# Redis
+REDIS_URL=redis://redis:6379/0
+
+# MAIL
+WATCHER_API_KEY=mail-api-key
+LOCAL_EMAIL_DOMAIN=domain.tld
+SNS_ARN=arn_of_sns  # For use with SES and SNS
+
+# Web
+APP_ENV=prod
+BASE_URL=http://localhost:3000         # Frontend - Change to https://your-domain.com for NGINX
+SERVER_BASE_URL=http://localhost:4000  # API Server - Change to https://your-domain.com for NGINX
+HIGHLIGHTS_BASE_URL=http://localhost:3000  # Frontend - Change to https://your-domain.com for NGINX
+
+# Content Fetch
+VERIFICATION_TOKEN=some_token
+REST_BACKEND_ENDPOINT=http://api:8080/api
+SKIP_UPLOAD_ORIGINAL=true
+
+# Minio
+MINIO_ROOT_USER=minio
+MINIO_ROOT_PASSWORD=miniominio
+AWS_S3_ENDPOINT_URL=http://minio:9000
+
+# Export
+EXPORT_QUEUE_NAME=omnivore-backend-queue
+
+# Youtube
+YOUTUBE_TRANSCRIPT_PROMPT=Reformat the supplied transcript data adding formatting, punctuation, and paragraphs, but do not summarize or change the content. Format the output as markdown.
+YOUTUBE_MAXIMUM_VIDEO_DURATION_TRANSCRIPT=1801
+
+# CORS Configuration
+CORS_ALLOWED_ORIGINS=http://localhost:3000,moz-extension://*  # Adapt according to your domain
+API_URL=http://localhost:4000/api  # Adapt according to your domain
+QUEUE_CONCURRENCY=2

--- a/self-hosting/podman-compose/podman-compose.yml
+++ b/self-hosting/podman-compose/podman-compose.yml
@@ -1,0 +1,179 @@
+version: '3'
+x-postgres:
+  &postgres-common
+  image: "docker.io/pgvector/pgvector:pg15"
+  user: postgres
+  healthcheck:
+    test: "exit 0"
+    interval: 2s
+    timeout: 12s
+    retries: 3
+services:
+  postgres:
+    <<: *postgres-common
+    container_name: "omnivore-postgres"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    env_file:
+      - .env
+
+    networks:
+      - omnivore-network
+      
+  migrate:
+    image: "ghcr.io/omnivore-app/sh-migrate:latest"
+    container_name: "omnivore-migrate"
+    command: '/bin/sh ./packages/db/setup.sh'
+    env_file:
+      - .env
+    depends_on:
+      postgres:
+        condition: service_healthy
+    networks:
+      - omnivore-network
+      
+  api:
+    image: "ghcr.io/omnivore-app/sh-backend:latest"
+    container_name: "omnivore-api"
+    ports:
+      - "4000:8080"
+    healthcheck:
+      test: ["CMD-SHELL", "nc -z 0.0.0.0 8080 || exit 1"]
+      interval: 15s
+      timeout: 90s
+      retries: 6
+    env_file:
+      - .env
+    depends_on:
+      migrate:
+        condition: service_completed_successfully
+    networks:
+      - omnivore-network
+      
+  queue-processor:
+    image: "ghcr.io/omnivore-app/sh-queue-processor:latest"
+    container_name: "omnivore-queue-processor"
+    env_file:
+      - .env
+    depends_on:
+      api:
+        condition: service_started
+    networks:
+      - omnivore-network
+      
+  web:
+    image: "ghcr.io/omnivore-app/sh-web:latest"
+    container_name: "omnivore-web"
+    ports:
+      - "3000:8080"
+    env_file:
+      - .env
+    depends_on:
+      api:
+        condition: service_healthy
+    networks:
+      - omnivore-network
+      
+  image-proxy:
+    image: "ghcr.io/omnivore-app/sh-image-proxy:latest"
+    container_name: "omnivore-image-proxy"
+    ports:
+      - "7070:8080"
+    env_file:
+      - .env
+    networks:
+      - omnivore-network
+      
+  content-fetch:
+    image: "ghcr.io/omnivore-app/sh-content-fetch:latest"
+    container_name: "omnivore-content-fetch"
+    ports:
+      - "9090:8080"
+    environment:
+      - USE_FIREFOX=true
+    env_file:
+      - .env
+    depends_on:
+      redis:
+        condition: service_healthy
+      api:
+        condition: service_healthy
+    networks:
+      - omnivore-network
+      
+  redis:
+    image: "docker.io/library/redis:latest"
+    container_name: "omnivore-redis"
+    expose:
+      - 6379
+    ports:
+      - "6379:6379"
+    healthcheck:
+      test: [ "CMD", "redis-cli", "--raw", "incr", "ping" ]
+    volumes:
+      - redis_data:/data
+    networks:
+      - omnivore-network
+      
+  minio:
+    image: "docker.io/minio/minio:latest"
+    container_name: "omnivore-minio"
+    expose:
+      - 9000
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    healthcheck:
+      test: [ "CMD", "mc", "ready", "local" ]
+      interval: 5s
+      timeout: 1s
+    environment:
+      - "MINIO_ACCESS_KEY=minio"
+      - "MINIO_SECRET_KEY=miniominio"
+    command: server /data --console-address ":9001"
+    volumes:
+      - minio_data:/data
+    networks:
+      - omnivore-network
+      
+  createbuckets:
+    image: docker.io/minio/mc:latest
+    environment:
+      - MINIO_ACCESS_KEY=minio
+      - MINIO_SECRET_KEY=miniominio
+      - BUCKET_NAME=omnivore
+      - ENDPOINT=http://minio:9000
+    depends_on:
+      - minio
+    entrypoint: >
+      /bin/bash -c "
+      sleep 5;
+      until (/usr/bin/mc alias set myminio http://minio:9000 minio miniominio) do echo '...waiting...' && sleep 1; done;
+      /usr/bin/mc mb myminio/omnivore;
+      /usr/bin/mc anonymous set public myminio/omnivore;
+      exit 0;
+      "
+    networks:
+      - omnivore-network
+      
+  mail-watch-server:
+    image: "ghcr.io/omnivore-app/sh-local-mail-watcher:latest"
+    container_name: "omnivore-mail-watch-server"
+    ports:
+      - "4398:8080"
+    env_file:
+      - .env
+    depends_on:
+      redis:
+        condition: service_healthy
+    networks:
+      - omnivore-network
+
+networks:
+  omnivore-network:
+    driver: bridge
+
+volumes:
+  pgdata:
+  redis_data:
+  minio_data:


### PR DESCRIPTION
As an alternative for docker, this PR integrates a podman-compose.yml (slightly different from docker one, in the network settings and images links) and its own .env.example file.

