### PR TITLE
Remove port exposing for Redis service

### DIFF
--- a/self-hosting/docker-compose/docker-compose.yml
+++ b/self-hosting/docker-compose/docker-compose.yml
@@ -92,8 +92,6 @@ services:
     container_name: "omnivore-redis"
     expose:
       - 6379
-    ports:
-      - "6379:6379"
     healthcheck:
       test: [ "CMD", "redis-cli", "--raw", "incr", "ping" ]
     volumes:


### PR DESCRIPTION
There is no need to expose redis to public network, this could cause security issues