### PR TITLE
Adding option to disable email signup

### DIFF
--- a/packages/api/.env.example
+++ b/packages/api/.env.example
@@ -27,3 +27,4 @@ SENDER_MESSAGE=msgs@sender.domain
 SENDER_FEEDBACK=feedback@sender.domain
 SENDER_GENERAL=no-reply@sender.domain
 CONTENT_FETCH_URL=http://localhost:9090/
+ENABLE_EMAIL_SIGNUP=TRUE

--- a/packages/api/src/routers/auth/auth_router.ts
+++ b/packages/api/src/routers/auth/auth_router.ts
@@ -514,6 +514,11 @@ export function authRouter() {
     hourlyLimiter,
     cors<express.Request>(corsConfig),
     async (req: express.Request, res: express.Response) => {
+      if (process.env.ENABLE_EMAIL_SIGNUP === 'false') {
+        return res.redirect(
+          `${env.client.url}/auth/email-signup?errorCodes=EMAIL_SIGNUP_DISABLED`
+        )
+      }        
       if (!isValidSignupRequest(req.body)) {
         return res.redirect(
           `${env.client.url}/auth/email-signup?errorCodes=INVALID_CREDENTIALS`

--- a/packages/web/locales/en/messages.ts
+++ b/packages/web/locales/en/messages.ts
@@ -1,6 +1,7 @@
 const errorMessages: Record<string, string> = {
   'error.AUTH_FAILED': 'Something went wrong, please try again in a moment',
   'error.USER_ALREADY_EXISTS': 'User with this email exists already',
+  'error.EMAIL_SIGNUP_DISABLED': 'Email signup is currently disabled',
   'error.INVALID_CREDENTIALS': 'Invalid email or password',
   'error.USER_NOT_FOUND': 'There is no user with this email yet',
   'error.WRONG_SOURCE': 'This email currently used by another source',

--- a/self-hosting/docker-compose/.env.example
+++ b/self-hosting/docker-compose/.env.example
@@ -29,6 +29,7 @@ AWS_ACCESS_KEY_ID=minio   # Used for Minio S3 Client
 AWS_SECRET_ACCESS_KEY=miniominio
 AWS_REGION=us-east-1
 CONTENT_FETCH_QUEUE_ENABLED=true
+ENABLE_EMAIL_SIGNUP=true
 
 IMAGE_PROXY_URL=http://localhost:7070 # Need to change this for NGINX
 CLIENT_URL=http://localhost:3000 # Need to change this when using NGINX


### PR DESCRIPTION
Adding an environment variable, ENABLE_EMAIL_SIGNUP, which allows the email-signup API endpoint to be disabled. Also added an error code to the frontend to display an error message for the signup form when email signup is disabled.