### PR TITLE
adding android compatibility to manifest for firefox extension

### DIFF
--- a/pkg/extension-v3/extension/manifest.json
+++ b/pkg/extension-v3/extension/manifest.json
@@ -38,5 +38,8 @@
     "16": "icons/icon-16.png",
     "48": "icons/icon-48.png",
     "128": "icons/icon-128.png"
+  },
+  "browser_specific_settings": {
+    "gecko_android": {}
   }
 }

--- a/pkg/extension-v3/src/manifest.json
+++ b/pkg/extension-v3/src/manifest.json
@@ -38,5 +38,8 @@
     "16": "icons/icon-16.png",
     "48": "icons/icon-48.png",
     "128": "icons/icon-128.png"
+  },
+  "browser_specific_settings": {
+    "gecko_android": {}
   }
 }


### PR DESCRIPTION
The current Firefox extension does not show up in the extensions for Android, despite the fact that it does work (tested on Nightly). This is due to the extension not being specified as compatible.[1](https://discourse.mozilla.org/t/our-android-compatible-extension-does-not-show-up-in-search-on-ff-for-android-why/126069/3)[2](https://extensionworkshop.com/documentation/publish/version-compatibility/#browser-specific-settings)