### PR TITLE
fix(api): treat S3 NoSuchKey as file-not-found in isFileExists

### DIFF
--- a/packages/api/src/utils/uploads.ts
+++ b/packages/api/src/utils/uploads.ts
@@ -134,9 +134,15 @@ export const uploadToSignedUrl = async (
 }
 
 export const isFileExists = async (filePath: string): Promise<boolean> => {
-  const file = await storage.downloadFile(bucketName, filePath)
-  const exists = await file.exists()
-  return exists
+  try {
+    const file = await storage.downloadFile(bucketName, filePath)
+    return await file.exists()
+  } catch (error) {
+    if ((error as { name?: string })?.name === 'NoSuchKey') {
+      return false
+    }
+    throw error
+  }
 }
 
 export const downloadFromBucket = async (filePath: string): Promise<Buffer> => {


### PR DESCRIPTION
## Summary

`isFileExists()` in `packages/api/src/utils/uploads.ts` breaks content downloads for every new library item on self-hosted deployments that use the S3/MinIO storage backend (`GCS_USE_LOCAL_HOST=true`).

## Root cause

```ts
export const isFileExists = async (filePath: string): Promise<boolean> => {
  const file = await storage.downloadFile(bucketName, filePath)
  const exists = await file.exists()
  return exists
}
```

`storage.downloadFile()` behaves differently across the two storage backends:

- **GCS** (`GcsStorageClient`) returns a lazy file reference. Calling `.exists()` on it issues the existence check and returns `false` cleanly if the object is missing.
- **S3/MinIO** (`S3StorageClient.downloadFile()`, `packages/api/src/repository/storage/S3StorageClient.ts`) eagerly issues a `GetObjectCommand` and throws a `NoSuchKey` exception if the object doesn't exist.

Since `isFileExists()` doesn't catch that exception, it propagates to every caller. For a brand-new library item, the content file *always* doesn't exist yet, so this throws every time. Callers affected:

- `packages/api/src/routers/content_router.ts` (`/api/content` route) — the request handler's catch block logs `"Error while generating signed url"` and returns `{"error": "Failed to generate download url"}` to every client, for every item that hasn't had its content file generated yet.
- `packages/api/src/jobs/upload_content.ts`, `packages/api/src/jobs/save_page.ts`, `packages/api/src/jobs/process-youtube-video.ts` — the queue-processor jobs that are actually supposed to *create* that content file also call `isFileExists()` first and throw before ever uploading.

Net effect: content sync is fully blocked for all self-hosted deployments on S3/MinIO.

## Fix

Catch `NoSuchKey` specifically and treat it as "file does not exist" (matching the GCS behavior), re-throwing any other error:

```ts
export const isFileExists = async (filePath: string): Promise<boolean> => {
  try {
    const file = await storage.downloadFile(bucketName, filePath)
    return await file.exists()
  } catch (error) {
    if ((error as { name?: string })?.name === 'NoSuchKey') {
      return false
    }
    throw error
  }
}
```

## Testing

Verified against a self-hosted instance running MinIO as the S3-compatible backend:

- Before the fix: `POST /api/content` for any newly-saved library item returned `{"error":"Failed to generate download url"}`, and the queue-processor's upload job threw before logging `"Uploading content to bucket"`.
- Rebuilt both the `api` and `queue-processor` images from this patch (both bundle `packages/api`, and both call `isFileExists()`).
- After the fix: `POST /api/content` returns a valid signed download URL; queue-processor logs show `"Uploading content to bucket"` completing successfully; fetching the returned `downloadUrl` returns the real uploaded content (HTTP 200) instead of a 404/error.

## Changelog

- **Fixed**: `isFileExists()` no longer throws on S3/MinIO when the target object doesn't exist yet, restoring content sync (`/api/content`, save-page/upload jobs, YouTube video processing) for self-hosted deployments using the S3-compatible storage backend.
- **No behavior change** for the GCS backend — `GcsStorageClient`'s lazy file reference already returned `false` from `.exists()` for missing objects, so this path is unaffected.