### PR TITLE
fix: replace permanent auth token in SSO redirect URL with one-time exchange

### DIFF
--- a/packages/api/src/routers/auth/auth_router.ts
+++ b/packages/api/src/routers/auth/auth_router.ts
@@ -39,7 +39,7 @@ import { logger } from '../../utils/logger'
 import { ARCHIVE_ACCOUNT_PATH, DEFAULT_HOME_PATH } from '../../utils/navigation'
 import { hourlyLimiter } from '../../utils/rate_limit'
 import { verifyChallengeRecaptcha } from '../../utils/recaptcha'
-import { createSsoToken, ssoRedirectURL } from '../../utils/sso'
+import { createSsoToken, exchangeSsoToken, ssoRedirectURL } from '../../utils/sso'
 import { handleAppleWebAuth } from './apple_auth'
 import type { AuthProvider } from './auth_types'
 import {
@@ -409,6 +409,21 @@ export function authRouter() {
       return res.redirect(`${env.client.url}/login?errorCodes=AUTH_FAILED`)
     }
   }
+
+  router.post(
+    '/exchange',
+    async (req: express.Request, res: express.Response) => {
+      const token = (req.body?.ssoToken ?? '') as string
+      if (!token) {
+        return res.status(400).json({ errorCode: 'SSO_EXCHANGE_NOT_FOUND' })
+      }
+      const authToken = await exchangeSsoToken(token)
+      if (!authToken) {
+        return res.status(400).json({ errorCode: 'SSO_EXCHANGE_NOT_FOUND' })
+      }
+      return res.status(200).json({ authToken })
+    }
+  )
 
   router.options(
     '/email-login',

--- a/packages/api/src/utils/sso.ts
+++ b/packages/api/src/utils/sso.ts
@@ -1,18 +1,57 @@
 import { env, homePageURL } from '../env'
+import { redisDataSource } from '../redis_data_source'
 import * as jwt from 'jsonwebtoken'
+import { v4 as uuidv4 } from 'uuid'
+
+const SSO_EXPIRY_SECONDS = 300
+const SSO_EXCHANGE_KEY_PREFIX = 'sso:exchange:'
 
 export const createSsoToken = (
   authToken: string,
   redirectTo: string
 ): string => {
+  const exchangeId = uuidv4()
+  // The permanent auth token never leaves the server: it is stored under a
+  // random one-time exchange id instead of being embedded in the redirect
+  // URL. JWT payloads are signed, not encrypted, so any credential carried in
+  // the tok parameter is recoverable by anyone who observes the URL (access
+  // logs, browser history, HAR exports). The URL now carries only an
+  // exchange id that is single-use and short-lived.
+  void redisDataSource.redisClient?.setex(
+    `${SSO_EXCHANGE_KEY_PREFIX}${exchangeId}`,
+    SSO_EXPIRY_SECONDS,
+    authToken
+  )
+
   const ssoToken = jwt.sign(
-    { authToken, redirectTo },
+    { exchangeId, redirectTo },
     env.server.ssoJwtSecret,
     {
-      expiresIn: '1d',
+      expiresIn: `${SSO_EXPIRY_SECONDS}s`,
     }
   )
   return ssoToken
+}
+
+export const exchangeSsoToken = async (
+  ssoToken: string
+): Promise<string | undefined> => {
+  let payload: { exchangeId: string; redirectTo: string } | undefined
+  try {
+    payload = jwt.verify(ssoToken, env.server.ssoJwtSecret) as typeof payload
+  } catch {
+    return undefined
+  }
+  if (!payload?.exchangeId) return undefined
+
+  // getdel gives single-use semantics: replaying the same tok from a log or
+  // shared link fails on the second attempt even inside the 5 minute window.
+  const client = redisDataSource.redisClient
+  if (!client) return undefined
+  const authToken = await client.getdel(
+    `${SSO_EXCHANGE_KEY_PREFIX}${payload.exchangeId}`
+  )
+  return authToken === null ? undefined : authToken
 }
 
 export const ssoRedirectURL = (ssoToken: string): string => {

--- a/packages/api/test/routers/auth.test.ts
+++ b/packages/api/test/routers/auth.test.ts
@@ -169,6 +169,38 @@ describe('auth router', () => {
         expect(res.header.location).to.contain('/api/client/auth?tok')
       })
 
+      it('exchanges a valid sso token for an auth token', async () => {
+        const res = await loginRequest(email, password).expect(302)
+        const location = res.header.location as string
+        const tok = new URL(location).searchParams.get('tok')
+        expect(tok).to.not.be.null
+
+        const exchange = await request
+          .post('/api/auth/exchange')
+          .send({ ssoToken: tok })
+          .expect(200)
+        expect(exchange.body.authToken).to.be.a('string')
+      })
+
+      it('refuses to exchange an sso token twice (single use)', async () => {
+        const res = await loginRequest(email, password).expect(302)
+        const location = res.header.location as string
+        const tok = new URL(location).searchParams.get('tok')
+
+        await request.post('/api/auth/exchange').send({ ssoToken: tok }).expect(200)
+        await request
+          .post('/api/auth/exchange')
+          .send({ ssoToken: tok })
+          .expect(400)
+      })
+
+      it('refuses a garbage sso token', async () => {
+        await request
+          .post('/api/auth/exchange')
+          .send({ ssoToken: 'not-a-real-token' })
+          .expect(400)
+      })
+
       it('set auth token in cookie', async () => {
         const res = await loginRequest(email, password).expect(302)
         expect(res.header['set-cookie']).to.be.an('array')

--- a/packages/web/pages/api/client/auth.ts
+++ b/packages/web/pages/api/client/auth.ts
@@ -1,15 +1,18 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
 import { serialize } from 'cookie'
 import * as jwt from 'jsonwebtoken'
-import { ssoJwtSecret } from '../../../lib/appConfig'
+import { fetchEndpoint, ssoJwtSecret } from '../../../lib/appConfig'
 import { DEFAULT_HOME_PATH } from '../../../lib/navigations'
 
 type AuthPayload = {
-  authToken: string
+  exchangeId: string
   redirectTo: string
 }
 
-const requestHandler = (req: NextApiRequest, res: NextApiResponse): void => {
+const requestHandler = async (
+  req: NextApiRequest,
+  res: NextApiResponse
+): Promise<void> => {
   const cookieOptions = {
     httpOnly: true,
     secure: true,
@@ -19,20 +22,46 @@ const requestHandler = (req: NextApiRequest, res: NextApiResponse): void => {
 
   const tok = req.query.tok
   if (ssoJwtSecret && tok && !Array.isArray(tok)) {
-    const payload = jwt.verify(tok, ssoJwtSecret) as AuthPayload
-    res.setHeader(
-      'Set-Cookie',
-      serialize('auth', payload.authToken, cookieOptions)
-    )
-    res.writeHead(302, {
-      Location: payload.redirectTo,
-    })
-  } else {
-    res.writeHead(302, {
-      Location: DEFAULT_HOME_PATH,
-    })
+    let payload: AuthPayload | undefined
+    try {
+      payload = jwt.verify(tok, ssoJwtSecret) as AuthPayload
+    } catch {
+      payload = undefined
+    }
+
+    if (payload?.exchangeId) {
+      // The tok parameter carries only a one-time exchange id. The permanent
+      // auth token is minted server-side by the API and never appears in the
+      // URL, so a captured redirect (log, history, HAR) cannot be decoded
+      // into a working credential.
+      const exchangeUrl = new URL(`${fetchEndpoint}/auth/exchange`)
+      try {
+        const response = await fetch(exchangeUrl.toString(), {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ ssoToken: tok }),
+        })
+        const body = (await response.json()) as { authToken?: string }
+        if (response.ok && body.authToken) {
+          res.setHeader(
+            'Set-Cookie',
+            serialize('auth', body.authToken, cookieOptions)
+          )
+          res.writeHead(302, {
+            Location: payload.redirectTo,
+          })
+          res.end()
+          return
+        }
+      } catch {
+        // fall through to the default redirect below
+      }
+    }
   }
 
+  res.writeHead(302, {
+    Location: DEFAULT_HOME_PATH,
+  })
   res.end()
 }
 


### PR DESCRIPTION
Closes #4676

## The vulnerability

In the default prod (Vercel) Google sign-in flow, the API embedded the permanent web auth JWT (the `auth` cookie value) inside the SSO JWT that gets carried in the redirect URL as `/api/client/auth?tok=<ssoToken>`. JWT payloads are signed, not encrypted, so anyone who observed the URL (access logs, CDN/Vercel logs, browser history, HAR exports, shared links) could decode `tok` and recover a credential that never expires and has no session binding or revocation. That is persistent account takeover.

## The fix

The `tok` parameter now carries only a random, one-time exchange id:

- API (`packages/api/src/utils/sso.ts`): `createSsoToken` stores the real auth token in redis under `sso:exchange:<uuid>` with a 5 minute TTL and never puts it in the JWT. `exchangeSsoToken` redeems it with GETDEL, so replaying the same tok from a log or a shared link fails on the second attempt even inside the expiry window.
- API (`packages/api/src/routers/auth/auth_router.ts`): new `POST /api/auth/exchange` endpoint validates the sso token and returns the stored auth token; 400 on missing, expired, or already-redeemed tokens.
- Web (`packages/web/pages/api/client/auth.ts`): verifies the sso JWT, exchanges it server-side against the API, then sets the `auth` cookie. The permanent credential never appears in a URL. Login/confirm-email redirect flows are unchanged, so existing sessions and mobile flows are untouched.

The API-domain cookie path (`setAuthInCookie`) is unchanged.

## Tests

Three new cases in `packages/api/test/routers/auth.test.ts`:
1. a valid sso token exchanges for an auth token
2. the same token refuses a second exchange (single use)
3. a garbage token is refused

## Verification

- `tsc --noEmit` clean in both packages (typescript via root node_modules)
- The DB-backed suite needs a running Postgres; none is available in this environment, so the auth test suite itself was not executed locally. CI runs it.

## Notes

redisDataSource is initialized in server startup (server.ts) before routes are served, so redisClient is always available. ioredis 6 maps getdel to redis GETDEL (redis >= 6.2).